### PR TITLE
Json parse fixes and improve debuggability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.10
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	micClient, err := mic.NewMICClient(cloudconfig, config)
 	if err != nil {
-		glog.Fatalf("Could not get the crd client: %+v", err)
+		glog.Fatalf("Could not get the MIC client: %+v", err)
 	}
 
 	exit := make(chan struct{})

--- a/pkg/config/azureconfig.go
+++ b/pkg/config/azureconfig.go
@@ -2,11 +2,11 @@ package config
 
 // AzureConfig is representing /etc/kubernetes/azure.json
 type AzureConfig struct {
-	Cloud             string `json:"cloud"`
-	TenantID          string `json:"tenantId"`
-	ClientID          string `json:"aadClientId"`
-	ClientSecret      string `json:"aadClientSecret"`
-	SubscriptionID    string `json:"subscriptionId"`
-	ResourceGroupName string `json:"resourceGroup"`
-	SecurityGroupName string `json:"securityGroupName"`
+	Cloud             string `json:"cloud" yaml:"cloud"`
+	TenantID          string `json:"tenantId" yaml:"tenantId"`
+	ClientID          string `json:"aadClientId" yaml:"aadClientId"`
+	ClientSecret      string `json:"aadClientSecret" yaml:"aadClientSecret"`
+	SubscriptionID    string `json:"subscriptionId" yaml:"subscriptionId"`
+	ResourceGroupName string `json:"resourceGroup" yaml:"resourceGroup"`
+	SecurityGroupName string `json:"securityGroupName" yaml:"securityGroupName"`
 }

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Azure/aad-pod-identity/pkg/stats"
+	"github.com/Azure/aad-pod-identity/version"
 
 	aadpodid "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 
@@ -49,27 +50,28 @@ type ClientInt interface {
 }
 
 func NewMICClient(cloudconfig string, config *rest.Config) (*Client, error) {
-	glog.Infof("Starting to create the pod identity client")
+	glog.Infof("Starting to create the pod identity client. Version: %v. Build date: %v", version.Version, version.BuildDate)
+
 	clientSet := kubernetes.NewForConfigOrDie(config)
 
 	cloudClient, err := cloudprovider.NewCloudProvider(cloudconfig)
 	if err != nil {
 		return nil, err
 	}
-	glog.V(6).Infof("Cloud provider initialized")
+	glog.V(1).Infof("Cloud provider initialized")
 
 	eventCh := make(chan aadpodid.EventType, 100)
 	crdClient, err := crd.NewCRDClient(config, eventCh)
 	if err != nil {
 		return nil, err
 	}
-	glog.V(6).Infof("CRD client initialized")
+	glog.V(1).Infof("CRD client initialized")
 
 	podClient, err := pod.NewPodClient(clientSet, eventCh)
 	if err != nil {
 		return nil, err
 	}
-	glog.V(6).Infof("Pod Client initialized")
+	glog.V(1).Infof("Pod Client initialized")
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)


### PR DESCRIPTION
- Rename mic.go in cmd to main.go for better debuggability.

- Add more logging for error paths.

- Move to yaml.unmarshal instead of json.unmarshal to circumvent the json parsing
issues caused by values such as 'True' (with caps T instead of all small true)
in the value fields of azure.json. This is similar to the azure.go in upstream k8s
code (parseConfig function).