### PR TITLE
Error path deletion of assigned identity, raise events (#79)

### DIFF
--- a/pkg/cloudprovider/cloudprovidertest/cloudprovider_test_util.go
+++ b/pkg/cloudprovider/cloudprovidertest/cloudprovider_test_util.go
@@ -17,6 +17,15 @@ type TestCloudClient struct {
 type TestVMClient struct {
 	*cloudprovider.VMClient
 	nodeMap map[string]*compute.VirtualMachine
+	err     *error
+}
+
+func (c *TestVMClient) SetError(err error) {
+	c.err = &err
+}
+
+func (c *TestVMClient) UnSetError() {
+	c.err = nil
 }
 
 func (c *TestVMClient) Get(rgName string, nodeName string) (ret compute.VirtualMachine, err error) {
@@ -30,6 +39,9 @@ func (c *TestVMClient) Get(rgName string, nodeName string) (ret compute.VirtualM
 }
 
 func (c *TestVMClient) CreateOrUpdate(rg string, nodeName string, vm compute.VirtualMachine) error {
+	if c.err != nil {
+		return *c.err
+	}
 	c.nodeMap[nodeName] = &vm
 	return nil
 }
@@ -78,6 +90,14 @@ func (c *TestCloudClient) PrintMSI() {
 	}
 }
 
+func (c *TestCloudClient) SetError(err error) {
+	c.testVMClient.SetError(err)
+}
+
+func (c *TestCloudClient) UnSetError() {
+	c.testVMClient.UnSetError()
+}
+
 func NewTestVMClient() *TestVMClient {
 	nodeMap := make(map[string]*compute.VirtualMachine, 0)
 	vmClient := &cloudprovider.VMClient{}
@@ -85,6 +105,7 @@ func NewTestVMClient() *TestVMClient {
 	return &TestVMClient{
 		vmClient,
 		nodeMap,
+		nil,
 	}
 }
 

--- a/pkg/mic/mictest/mic_test.go
+++ b/pkg/mic/mictest/mic_test.go
@@ -1,6 +1,7 @@
 package mictest
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -62,8 +63,10 @@ func TestSimpleMICClient(t *testing.T) {
 	cloudClient := cp.NewTestCloudClient()
 	crdClient := crd.NewTestCrdClient(nil)
 	podClient := pod.NewTestPodClient()
+	var evtRecorder TestEventRecorder
+	evtRecorder.lastEvent = new(LastEvent)
 
-	micClient := NewMICClient(eventCh, cloudClient, crdClient, podClient)
+	micClient := NewMICClient(eventCh, cloudClient, crdClient, podClient, &evtRecorder)
 
 	crdClient.CreateId("test-id", aadpodid.UserAssignedMSI, "test-user-msi-resourceid", "test-user-msi-clientid", nil, "", "", "")
 	crdClient.CreateBinding("testbinding", "test-id", "test-select")
@@ -84,13 +87,72 @@ func TestSimpleMICClient(t *testing.T) {
 		for _, assignedID := range *listAssignedIDs {
 			if assignedID.Spec.Pod == "test-pod" && assignedID.Spec.PodNamespace == "default" && assignedID.Spec.NodeName == "test-node" &&
 				assignedID.Spec.AzureBindingRef.Name == "testbinding" && assignedID.Spec.AzureIdentityRef.Name == "test-id" {
-				testPass = true
+				testPass = evtRecorder.Validate(&LastEvent{Type: "Normal", Reason: "binding applied",
+					Message: "Binding testbinding applied on node test-node for pod test-pod-default-test-id"})
+				if !testPass {
+					panic("event mismatch")
+				}
 				break
 			}
 		}
-
 	}
+
 	if !testPass {
 		panic("assigned id mismatch")
+	}
+
+	//Test2: Remove assigned id event test
+	podClient.DeletePod("test-pod", "default")
+
+	eventCh <- aadpodid.PodDeleted
+	time.Sleep(5 * time.Second)
+	testPass = false
+	listAssignedIDs, err = crdClient.ListAssignedIDs()
+	if err != nil {
+		glog.Error(err)
+		panic("list assigned failed")
+	}
+	testPass = evtRecorder.Validate(&LastEvent{Type: "Normal", Reason: "binding removed",
+		Message: "Binding testbinding removed from node test-node for pod test-pod"})
+
+	if !testPass {
+		panic("event mismatch")
+	}
+
+	// Test3: Error from cloud provider event test
+	err = errors.New("error returned from cloud provider")
+	cloudClient.SetError(err)
+
+	podClient.AddPod("test-pod", "default", "test-node", "test-select")
+	eventCh <- aadpodid.PodCreated
+	time.Sleep(2 * time.Second)
+
+	testPass = evtRecorder.Validate(&LastEvent{Type: "Warning", Reason: "binding apply error",
+		Message: "Applying binding testbinding node test-node for pod test-pod-default-test-id resulted in error error returned from cloud provider"})
+
+	if !testPass {
+		panic("event mismatch")
+	}
+
+	// Test4: Removal error event test
+	//Reset the state to add the id.
+	cloudClient.UnSetError()
+
+	//podClient.AddPod("test-pod", "default", "test-node", "test-select")
+	eventCh <- aadpodid.PodCreated
+	time.Sleep(5 * time.Second)
+
+	err = errors.New("remove error returned from cloud provider")
+	cloudClient.SetError(err)
+
+	podClient.DeletePod("test-pod", "default")
+	eventCh <- aadpodid.PodDeleted
+	time.Sleep(5 * time.Second)
+
+	testPass = evtRecorder.Validate(&LastEvent{Type: "Warning", Reason: "binding remove error",
+		Message: "Binding testbinding removal from node test-node for pod test-pod resulted in error remove error returned from cloud provider"})
+
+	if !testPass {
+		panic("event mismatch")
 	}
 }

--- a/pkg/mic/mictest/mic_test_util.go
+++ b/pkg/mic/mictest/mic_test_util.go
@@ -5,17 +5,39 @@ import (
 	cp "github.com/Azure/aad-pod-identity/pkg/cloudprovider/cloudprovidertest"
 	crd "github.com/Azure/aad-pod-identity/pkg/crd/crdtest"
 	pod "github.com/Azure/aad-pod-identity/pkg/pod/podtest"
+	"github.com/golang/glog"
 
 	"github.com/Azure/aad-pod-identity/pkg/mic"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+type LastEvent struct {
+	Type    string
+	Reason  string
+	Message string
+}
+
 type TestEventRecorder struct {
+	lastEvent *LastEvent
 }
 
 func (c TestEventRecorder) Event(object runtime.Object, t string, r string, message string) {
+	c.lastEvent.Type = t
+	c.lastEvent.Reason = r
+	c.lastEvent.Message = message
+}
 
+func (c TestEventRecorder) Validate(e *LastEvent) bool {
+	t := c.lastEvent.Type
+	r := c.lastEvent.Reason
+	m := c.lastEvent.Message
+
+	if t != e.Type || r != e.Reason || m != e.Message {
+		glog.Errorf("event mismatch. expected - (t:%s, r:%s, m:%s). got - (t:%s, r:%s, m:%s)", e.Type, e.Reason, e.Message, t, r, m)
+		return false
+	}
+	return true
 }
 
 func (c TestEventRecorder) Eventf(object runtime.Object, t string, r string, messageFmt string, args ...interface{}) {
@@ -30,8 +52,7 @@ func (c TestEventRecorder) AnnotatedEventf(object runtime.Object, annotations ma
 
 }
 
-func NewMICClient(eventCh chan aadpodid.EventType, cpClient *cp.TestCloudClient, crdClient *crd.TestCrdClient, podClient *pod.TestPodClient) *TestMICClient {
-	var eventRecorder TestEventRecorder
+func NewMICClient(eventCh chan aadpodid.EventType, cpClient *cp.TestCloudClient, crdClient *crd.TestCrdClient, podClient *pod.TestPodClient, eventRecorder *TestEventRecorder) *TestMICClient {
 
 	realMICClient := &mic.Client{
 		CloudClient:   cpClient,

--- a/pkg/pod/podtest/pod_test_util.go
+++ b/pkg/pod/podtest/pod_test_util.go
@@ -43,3 +43,19 @@ func (c *TestPodClient) AddPod(podName string, podNs string, nodeName string, bi
 	}
 	c.pods = append(c.pods, pod)
 }
+
+func (c *TestPodClient) DeletePod(podName string, podNs string) {
+	var newPods []*corev1.Pod
+	changed := false
+	for _, pod := range c.pods {
+		if pod.Name == podName && pod.Namespace == podNs {
+			changed = true
+			continue
+		} else {
+			newPods = append(newPods, pod)
+		}
+	}
+	if changed {
+		c.pods = newPods
+	}
+}


### PR DESCRIPTION
- Delete the assigned identity in case the vm id binding errors out.
- Raise events on failure to add or remove (#79).
- More UTs.