### PR TITLE
Added a sample Helm chart

### DIFF
--- a/charts/aad-pod-identity/.helmignore
+++ b/charts/aad-pod-identity/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/aad-pod-identity/Chart.yaml
+++ b/charts/aad-pod-identity/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A chart to deploy the components needed for AAD pod identity
+name: aad-pod-identity
+version: 0.1.0

--- a/charts/aad-pod-identity/README.md
+++ b/charts/aad-pod-identity/README.md
@@ -1,0 +1,97 @@
+# Helm chart for Azure Active Directory Pod Identity
+A simple [helm](https://helm.sh/) chart for setting up the components needed to use [Azure Active Directory Pod Identity](https://github.com/Azure/aad-pod-identity) in Kubernetes.
+
+## Chart resources
+This helm chart will deploy the following resources:
+* AzureIdentity `CustomResourceDefinition`
+* AzureIdentityBinding `CustomResourceDefinition`
+* AzureAssignedIdentity `CustomResourceDefinition`
+* AzureIdentity instance
+* AzureIdentityBinding instance
+* Managed Identity Controller (MIC) `Deployment`
+* Node Managed Identity (NMI) `DaemonSet`
+
+## Getting Started
+The following steps will help you create a new Azure identity ([Managed Service Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) or [Service Principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals)) and assign it to pods running in your Kubernetes cluster.
+
+### Prerequisites
+* [Azure Subscription](https://azure.microsoft.com/)
+* [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/services/kubernetes-service/) or [ACS-Engine](https://github.com/Azure/acs-engine) deployment
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (authenticated to your Kubernetes cluster)
+* [Helm v1.10+](https://github.com/helm/helm)
+* [Azure CLI 2.0](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+* [git](https://git-scm.com/downloads)
+
+### Steps
+
+1. Create a new [Azure User Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) using the Azure CLI:
+> __NOTE:__ It's simpler to use the same resource group as your Kubernetes nodes are deployed in. For AKS this is the MC_* resource group. If you can't use the same resource group, you'll need to grant the Kubernetes cluster's service principal the "Managed Identity Operator" role.
+```shell
+az identity create -g <resource-group> -n <id-name>
+```
+
+2. Assign your newly created identity the role of _Reader_ for the resource group:
+```shell
+az role assignment create --role Reader --assignee <principal-id> --scope /subscriptions/<subscription-id>/resourcegroups/<resource-group>
+```
+
+3. Clone this repository and navigate to the helm chart's directory.
+```shell
+git clone git@github.com:Azure/aad-pod-identity.git && cd aad-pod-identity/charts/aad-pod-identity
+```
+
+4. Open the `values.yaml` file in a text editor.
+
+5. Update the `azureIdentity` values with your Azure identity's resource ID and client ID (retrievable from the CLI or portal).
+
+6. Update the `azureIdentityBinding` selector value with a value that will match the label applied to the pods you wish to assign the identity to i.e. `selector: demo`.
+
+7. Ensure you have helm initialized correctly to work with your cluster. If not, follow this [guide](https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller). If your cluster has rbac-enabled, you'll need to initialize tiller with a suitable `service-account`.
+
+8. Install the helm chart into your Kubernetes cluster using your updated `values.yaml`.
+```shell
+helm install --values values.yaml .
+```
+
+9. Deploy your application to Kubernetes. The application should use [ADAL](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-authentication-libraries) to request a token from the MSI endpoint as usual. If you do not currently have such an application, a demo application is available [here](https://github.com/Azure/aad-pod-identity#demo-app). If you do use the demo application, please update the `deployment.yaml` with the appropriate subscription ID, client ID and resource group name. Also make sure the selector you defined in your `AzureIdentityBinding` matches the `aadpodidbinding` label on the deployment i.e. `aadpodidbinding: demo`.
+
+10. Once you have successfully deployed your application, validate the MIC has detected your `AzureIdentityBinding` by viewing its logs.
+```shell
+kubectl logs mic-768489d94-pjxqf
+...
+I0919 13:12:34.222107       1 event.go:218] Event(v1.ObjectReference{Kind:"AzureIdentityBinding", Namespace:"default", Name:"msi-binding", UID:"UID", APIVersion:"aadpodidentity.k8s.io/v1", ResourceVersion:"231329", FieldPath:""}): type: 'Normal' reason: 'binding applied' Binding msi-binding applied on node aks-agentpool-12603492-1 for pod demo-77d858d9f9-62d4r-default-msi
+```
+
+11. Check the MIC has created a new `AzureAssignedIdentity` for your deployment.
+```shell
+kubectl get AzureAssignedIdentity
+...
+NAME                                CREATED AT
+demo-77d858d9f9-62d4r-default-msi   1m
+```
+
+12. Check the NMI successfully retrieved a token for your app by viewing its logs
+```shell
+kubectl logs nmi-cn4cc
+...
+time="2018-09-19T13:56:20Z" level=info msg="Status (200) took 37041685 ns" req.method=GET req.path=/metadata/identity/oauth2/token req.remote=10.244.0.12
+```
+
+13. Finally, validate your application is behaving and logging as expected. The demo application will log details about the MSI acquisition
+```
+kubectl logs demo-77d858d9f9-62d4r
+...
+time="2018-09-19T13:14:28Z" level=info msg="succesfully acquired a token using the MSI, msiEndpoint(http://169.254.169.254/metadata/identity/oauth2/token)" podip=10.244.0.12 podname=demo-77d858d9f9-62d4r podnamespace=demo-77d858d9f9-62d4r
+```
+
+## Known Issues
+
+__Error Redeploying Chart__
+
+If you have previously installed the helm chart, you may come across the following error message:
+```shell
+Error: object is being deleted: customresourcedefinitions.apiextensions.k8s.io ? "azureassignedidentities.aadpodidentity.k8s.io" already exists
+```
+This is because helm doesn't actively manage the `CustomResourceDefinition` resources that the chart created. The full discussion concerning this issue is available [here](https://github.com/helm/helm/issues/2994). We are using helm's [crd-install hooks](https://docs.helm.sh/developing_charts#defining-a-crd-with-the-crd-install-hook) to provision the `CustomResourceDefintion` resources before the rest of the chart is verified and deployed. We also use `hook-delete-policy` to try and clean down the resources before the next helm release is applied. Unfortunately, as CRD deletion is slow it doesn't appear to resolve the issue. This issue is tracked [here](https://github.com/helm/helm/issues/4440). The easiest solution is to manually delete the `CustomerResourceDefintion` resources or setup a job to do so.
+
+

--- a/charts/aad-pod-identity/README.md
+++ b/charts/aad-pod-identity/README.md
@@ -6,8 +6,8 @@ This helm chart will deploy the following resources:
 * AzureIdentity `CustomResourceDefinition`
 * AzureIdentityBinding `CustomResourceDefinition`
 * AzureAssignedIdentity `CustomResourceDefinition`
-* AzureIdentity instance
-* AzureIdentityBinding instance
+* AzureIdentity instance (optional)
+* AzureIdentityBinding instance (optional)
 * Managed Identity Controller (MIC) `Deployment`
 * Node Managed Identity (NMI) `DaemonSet`
 

--- a/charts/aad-pod-identity/templates/crds.yaml
+++ b/charts/aad-pod-identity/templates/crds.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureassignedidentities.aadpodidentity.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureAssignedIdentity
+    plural: azureassignedidentities
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentitybindings.aadpodidentity.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentityBinding
+    plural: azureidentitybindings
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentities.aadpodidentity.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentity
+    singular: azureidentity
+    plural: azureidentities
+  scope: Namespaced

--- a/charts/aad-pod-identity/templates/identities.yaml
+++ b/charts/aad-pod-identity/templates/identities.yaml
@@ -1,11 +1,12 @@
+{{- if .Values.azureIdentity.enabled }}
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentity
 metadata:
  name: {{ .Values.azureIdentity.name }}
 spec:
  type: {{ .Values.azureIdentity.type }}
- ResourceID: {{required .Values.azureIdentity.resourceID }}
- ClientID: {{required .Values.azureIdentity.clientID }}
+ ResourceID: {{required ".Values.azureIdentity.resourceID is required!" .Values.azureIdentity.resourceID }}
+ ClientID: {{required ".Values.azureIdentity.clientID is required!" .Values.azureIdentity.clientID }}
 ---
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentityBinding
@@ -13,4 +14,5 @@ metadata:
  name: {{ .Values.azureIdentityBinding.name }}
 spec:
  AzureIdentity: {{ .Values.azureIdentity.name }}
- Selector: {{required .Values.azureIdentityBinding.selector }}
+ Selector: {{required ".Values.azureIdentityBinding.selector is required!" .Values.azureIdentityBinding.selector }}
+{{- end }}

--- a/charts/aad-pod-identity/templates/identities.yaml
+++ b/charts/aad-pod-identity/templates/identities.yaml
@@ -1,0 +1,16 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+ name: {{ .Values.azureIdentity.name }}
+spec:
+ type: {{ .Values.azureIdentity.type }}
+ ResourceID: {{required .Values.azureIdentity.resourceID }}
+ ClientID: {{required .Values.azureIdentity.clientID }}
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+ name: {{ .Values.azureIdentityBinding.name }}
+spec:
+ AzureIdentity: {{ .Values.azureIdentity.name }}
+ Selector: {{required .Values.azureIdentityBinding.selector }}

--- a/charts/aad-pod-identity/templates/infra.yaml
+++ b/charts/aad-pod-identity/templates/infra.yaml
@@ -1,0 +1,166 @@
+{{- if .Values.rbac.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-id-nmi-service-account
+  namespace: default
+{{- end}}
+---
+{{- if .Values.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-id-nmi-role
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-id-nmi-binding
+  labels:
+    k8s-app: aad-pod-id-nmi-binding
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-id-nmi-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-id-nmi-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    component: nmi
+    tier: node
+  name: nmi
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        component: nmi
+        tier: node
+    spec:
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: aad-pod-id-nmi-service-account
+      {{- end }}
+      hostNetwork: true
+      containers:
+      - name: nmi
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.3"
+        imagePullPolicy: Always
+        args:
+          - "--host-ip=$(HOST_IP)"
+          - "--node=$(NODE_NAME)"
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+---
+{{- if .Values.rbac.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-id-mic-service-account
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-id-mic-role
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: [ "list", "watch" ]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list", "watch", "post"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-id-mic-binding
+  labels:
+    k8s-app: aad-pod-id-mic-binding
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-id-mic-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-id-mic-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: mic
+  name: mic
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        component: mic
+    spec:
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: aad-pod-id-mic-service-account
+      {{- end }}
+      containers:
+      - name: mic
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.2"
+        imagePullPolicy: Always
+        args:
+          - "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
+          - "--cloudconfig=/etc/kubernetes/azure.json"
+          - "--logtostderr"
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /etc/kubernetes/kubeconfig
+            readOnly: true
+          - name: certificates
+            mountPath: /etc/kubernetes/certs
+            readOnly: true
+          - name: k8s-azure-file
+            mountPath: /etc/kubernetes/azure.json
+            readOnly: true
+      volumes:
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kubelet
+      - name: certificates
+        hostPath:
+          path: /etc/kubernetes/certs
+      - name: k8s-azure-file
+        hostPath:
+          path: /etc/kubernetes/azure.json

--- a/charts/aad-pod-identity/templates/infra.yaml
+++ b/charts/aad-pod-identity/templates/infra.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: aad-pod-id-nmi-service-account
   namespace: default
-{{- end}}
+{{- end }}
 ---
 {{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/aad-pod-identity/values.yaml
+++ b/charts/aad-pod-identity/values.yaml
@@ -6,6 +6,7 @@ rbac:
   enabled: true
 
 azureIdentity:
+  enabled: true # enabled/disable deployment of azure identity and binding
   name: "azure-identity"
   type: 0 # type 0: MSI, type 1: Service Principal
   resourceID: "" # /subscriptions/subscription-id/resourcegroups/resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name

--- a/charts/aad-pod-identity/values.yaml
+++ b/charts/aad-pod-identity/values.yaml
@@ -1,0 +1,34 @@
+# Default values for pod-aad-identity-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+rbac:
+  enabled: true
+
+azureIdentity:
+  name: "azure-identity"
+  type: 0 # type 0: MSI, type 1: Service Principal
+  resourceID: "" # /subscriptions/subscription-id/resourcegroups/resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name
+  clientID: ""
+
+azureIdentityBinding:
+  name: "azure-identity-binding"
+  selector: "" # demo
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
I've added a Helm chart that can help users bootstrap their Kubernetes cluster with the required resources. Details are included in the `README.md` - primarily meant to work with provided demo application as a way of demonstrating the functionality but can be used with custom apps. Supports both RBAC and non RBAC enabled clusters.