### PR TITLE
Apply least privilege concept on NMI ClusterRole.

### DIFF
--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -46,8 +46,17 @@ kind: ClusterRole
 metadata:
   name: aad-pod-id-nmi-role
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
   verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
The current ClusterRole for RBAC-enabled clusters defines an extremely loose access privileges for the NMI service account. That service account has get and list verb across all api groups and resource types - including secrets from kube-system and user defined namespaces.

This PR restricts the access privileges to get/list of CustomResourceTypes defined by this service, plus pods.