### PR TITLE
Add support for vmss

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -640,6 +640,7 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/selection",
     "k8s.io/client-go/informers",
+    "k8s.io/client-go/informers/core/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",

--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -132,7 +132,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["*"]
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "nodes"]
   verbs: [ "list", "watch" ]
 - apiGroups: [""]
   resources: ["events"]

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
+	"path"
+	"regexp"
 	"time"
-	"unicode"
 
 	config "github.com/Azure/aad-pod-identity/pkg/config"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/glog"
 	yaml "gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Client is a cloud provider client
@@ -27,8 +28,8 @@ type Client struct {
 }
 
 type ClientInt interface {
-	RemoveUserMSI(userAssignedMSIID string, nodeName string) error
-	AssignUserMSI(userAssignedMSIID string, nodeName string) error
+	RemoveUserMSI(userAssignedMSIID string, node *corev1.Node) error
+	AssignUserMSI(userAssignedMSIID string, node *corev1.Node) error
 }
 
 // NewCloudProvider returns a azure cloud provider client
@@ -75,19 +76,15 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 		ExtClient:         extClient,
 	}
 
-	switch azureConfig.VMType {
-	case "vmss":
-		client.VMSSClient, err = NewVMSSClient(azureConfig, spt)
-		if err != nil {
-			glog.Errorf("Create VM Client error: %+v", err)
-			return nil, err
-		}
-	default:
-		client.VMClient, err = NewVirtualMachinesClient(azureConfig, spt)
-		if err != nil {
-			glog.Errorf("Create VM Client error: %+v", err)
-			return nil, err
-		}
+	client.VMSSClient, err = NewVMSSClient(azureConfig, spt)
+	if err != nil {
+		glog.Errorf("Create VMSS Client error: %+v", err)
+		return nil, err
+	}
+	client.VMClient, err = NewVirtualMachinesClient(azureConfig, spt)
+	if err != nil {
+		glog.Errorf("Create VM Client error: %+v", err)
+		return nil, err
 	}
 
 	return client, nil
@@ -104,20 +101,20 @@ func withInspection() autorest.PrepareDecorator {
 }
 
 //RemoveUserMSI - Use the underlying cloud api calls and remove the given user assigned MSI from the vm.
-func (c *Client) RemoveUserMSI(userAssignedMSIID string, nodeName string) error {
-	idH, updateFunc, err := c.getIdentityResource(nodeName)
+func (c *Client) RemoveUserMSI(userAssignedMSIID string, node *corev1.Node) error {
+	idH, updateFunc, err := c.getIdentityResource(node)
 	if err != nil {
 		return err
 	}
 
 	info := idH.IdentityInfo()
 	if info == nil {
-		glog.Errorf("Identity null for vm: %s ", nodeName)
-		return fmt.Errorf("identity null for vm: %s ", nodeName)
+		glog.Errorf("Identity null for vm: %s ", node.Name)
+		return fmt.Errorf("identity null for vm: %s ", node.Name)
 	}
 
 	if err := info.RemoveUserIdentity(userAssignedMSIID); err != nil {
-		return fmt.Errorf("could not remove identity from node %s: %v", nodeName, err)
+		return fmt.Errorf("could not remove identity from node %s: %v", node.Name, err)
 	}
 
 	if err := updateFunc(); err != nil {
@@ -128,18 +125,18 @@ func (c *Client) RemoveUserMSI(userAssignedMSIID string, nodeName string) error 
 	return nil
 }
 
-func (c *Client) AssignUserMSI(userAssignedMSIID string, nodeName string) error {
+func (c *Client) AssignUserMSI(userAssignedMSIID string, node *corev1.Node) error {
 	// Get the vm using the VmClient
 	// Update the assigned identity into the VM using the CreateOrUpdate
 
-	glog.Infof("Find %s in resource group: %s", nodeName, c.Config.ResourceGroupName)
+	glog.Infof("Find %s in resource group: %s", node.Name, c.Config.ResourceGroupName)
 	timeStarted := time.Now()
 
-	idH, updateFunc, err := c.getIdentityResource(nodeName)
+	idH, updateFunc, err := c.getIdentityResource(node)
 	if err != nil {
 		return err
 	}
-	glog.V(6).Infof("Get of %s completed in %s", nodeName, time.Since(timeStarted))
+	glog.V(6).Infof("Get of %s completed in %s", node.Name, time.Since(timeStarted))
 
 	info := idH.IdentityInfo()
 	if info == nil {
@@ -153,37 +150,74 @@ func (c *Client) AssignUserMSI(userAssignedMSIID string, nodeName string) error 
 		return err
 	}
 
-	glog.V(6).Infof("CreateOrUpdate of %s completed in %s", nodeName, time.Since(timeStarted))
+	glog.V(6).Infof("CreateOrUpdate of %s completed in %s", node.Name, time.Since(timeStarted))
 	return nil
 }
 
-func (c *Client) getIdentityResource(name string) (idH IdentityHolder, update func() error, retErr error) {
-	switch c.Config.VMType {
+func (c *Client) getIdentityResource(node *corev1.Node) (idH IdentityHolder, update func() error, retErr error) {
+	name := node.Name // fallback in case parsing the provider spec fails
+	rg := c.Config.ResourceGroupName
+	rt := c.Config.VMType
+	if r, err := ParseResourceID(node.Spec.ProviderID); err == nil {
+		name = r.ResourceName
+		rg = r.ResourceGroup
+		if r.ResourceType == "virtualMachineScaleSets" {
+			rt = "vmss"
+		}
+	}
+
+	switch rt {
 	case "vmss":
-		// TODO(@cpuguy83): We are getting a *node* name as an argument to this function, but need the vmss name.
-		// For now, assume the name of the node follows <vmssname><nodenumber>, so trimming the node number should give us the vmss name.
-		name = strings.TrimRightFunc(name, func(r rune) bool {
-			return unicode.IsNumber(r)
-		})
-		vmss, err := c.VMSSClient.Get(c.Config.ResourceGroupName, name)
+		vmss, err := c.VMSSClient.Get(rg, name)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		update = func() error {
-			return c.VMSSClient.CreateOrUpdate(c.Config.ResourceGroupName, name, vmss)
+			return c.VMSSClient.CreateOrUpdate(rg, name, vmss)
 		}
 		idH = &vmssIdentityHolder{&vmss}
 	default:
-		vm, err := c.VMClient.Get(c.Config.ResourceGroupName, name)
+		vm, err := c.VMClient.Get(rg, name)
 		if err != nil {
 			return nil, nil, err
 		}
 		update = func() error {
-			return c.VMClient.CreateOrUpdate(c.Config.ResourceGroupName, name, vm)
+			return c.VMClient.CreateOrUpdate(rg, name, vm)
 		}
 		idH = &vmIdentityHolder{&vm}
 	}
 
 	return idH, update, nil
+}
+
+const nestedResourceIDPatternText = `(?i)subscriptions/(.+)/resourceGroups/(.+)/providers/(.+?)/(.+?)/(.+?)/(.+)`
+const resourceIDPatternText = `(?i)subscriptions/(.+)/resourceGroups/(.+)/providers/(.+?)/(.+?)/(.+)`
+
+var (
+	nestedResourceIDPattern = regexp.MustCompile(nestedResourceIDPatternText)
+	resourceIDPattern       = regexp.MustCompile(resourceIDPatternText)
+)
+
+// ParseResourceID is a slightly modified version of https://github.com/Azure/go-autorest/blob/528b76fd0ebec0682f3e3da7c808cd472b999615/autorest/azure/azure.go#L175
+// The modification here is to support a nested resource such as is the case for a node resource in a vmss.
+func ParseResourceID(resourceID string) (azure.Resource, error) {
+	match := nestedResourceIDPattern.FindStringSubmatch(resourceID)
+	if len(match) == 0 {
+		match = resourceIDPattern.FindStringSubmatch(resourceID)
+	}
+
+	if len(match) < 6 {
+		return azure.Resource{}, fmt.Errorf("parsing failed for %s: invalid resource id format", resourceID)
+	}
+
+	result := azure.Resource{
+		SubscriptionID: match[1],
+		ResourceGroup:  match[2],
+		Provider:       match[3],
+		ResourceType:   match[4],
+		ResourceName:   path.Base(match[5]),
+	}
+
+	return result, nil
 }

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -148,8 +148,6 @@ func (c *Client) AssignUserMSI(userAssignedMSIID string, nodeName string) error 
 
 	info.AppendUserIdentity(userAssignedMSIID)
 
-	glog.Infof("ID: %s already found in vm identities", userAssignedMSIID)
-
 	timeStarted = time.Now()
 	if err := updateFunc(); err != nil {
 		return err

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -1,0 +1,50 @@
+package cloudprovider
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func TestParseResourceID(t *testing.T) {
+	type testCase struct {
+		desc   string
+		testID string
+		expect azure.Resource
+		xErr   bool
+	}
+
+	notNested := "/subscriptions/asdf/resourceGroups/qwerty/providers/testCompute/myComputeObjectType/testComputeResource"
+	nested := "/subscriptions/asdf/resourceGroups/qwerty/providers/testCompute/myComputeObjectType/testComputeResource/someNestedResource/myNestedResource"
+
+	for _, c := range []testCase{
+		{"empty string", "", azure.Resource{}, true},
+		{"just a string", "asdf", azure.Resource{}, true},
+		{"partial match", "/subscriptions/asdf/resourceGroups/qwery", azure.Resource{}, true},
+		{"nested", nested, azure.Resource{
+			SubscriptionID: "asdf",
+			ResourceGroup:  "qwerty",
+			Provider:       "testCompute",
+			ResourceName:   "testComputeResource",
+			ResourceType:   "myComputeObjectType",
+		}, false},
+		{"not nested", notNested, azure.Resource{
+			SubscriptionID: "asdf",
+			ResourceGroup:  "qwerty",
+			Provider:       "testCompute",
+			ResourceName:   "testComputeResource",
+			ResourceType:   "myComputeObjectType",
+		}, false},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			r, err := ParseResourceID(c.testID)
+			if (err != nil) != c.xErr {
+				t.Fatalf("expected err==%v, got: %v", c.xErr, err)
+			}
+			if !reflect.DeepEqual(r, c.expect) {
+				t.Fatalf("resource does not match expected:\nexpected:\n\t%+v\ngot:\n\t%+v", c.expect, r)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/cloudprovidertest/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovidertest/cloudprovider_test.go
@@ -7,38 +7,30 @@ import (
 
 func TestSimple(t *testing.T) {
 	flag.Set("logtostderr", "true")
-	//flag.Set("log_dir", ".")
 	flag.Set("v", "3")
 	flag.Parse()
 
-	//	flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
-	//	flag.Parse()
 	cloudClient := NewTestCloudClient()
-	//glog.Infof("Test starting")
-	//glog.Infof("Empty MSI")
-	//cloudClient.PrintMSI()
 
 	cloudClient.AssignUserMSI("ID0", "node0")
 	cloudClient.AssignUserMSI("ID0", "node0")
 	cloudClient.AssignUserMSI("ID0again", "node0")
 	cloudClient.AssignUserMSI("ID1", "node1")
 	cloudClient.AssignUserMSI("ID2", "node2")
-	//glog.Infof("Add more MSI")
-	//cloudClient.PrintMSI()
+
 	testMSI := []string{"ID0", "ID0again"}
 	if !cloudClient.CompareMSI("node0", testMSI) {
-		panic("MSI mismatch")
+		t.Fatal("MSI mismatch")
 	}
 
 	cloudClient.RemoveUserMSI("ID0", "node0")
 	cloudClient.RemoveUserMSI("ID2", "node2")
 	testMSI = []string{"ID0again"}
 	if !cloudClient.CompareMSI("node0", testMSI) {
-		panic("MSI mismatch")
+		t.Fatal("MSI mismatch")
 	}
 	testMSI = []string{}
 	if !cloudClient.CompareMSI("node2", testMSI) {
-		panic("MSI mismatch")
+		t.Fatal("MSI mismatch")
 	}
-	//cloudClient.PrintMSI()
 }

--- a/pkg/cloudprovider/cloudprovidertest/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovidertest/cloudprovider_test.go
@@ -3,6 +3,8 @@ package cloudprovidertest
 import (
 	"flag"
 	"testing"
+
+	"github.com/Azure/aad-pod-identity/pkg/config"
 )
 
 func TestSimple(t *testing.T) {
@@ -10,27 +12,38 @@ func TestSimple(t *testing.T) {
 	flag.Set("v", "3")
 	flag.Parse()
 
-	cloudClient := NewTestCloudClient()
+	for _, cfg := range []config.AzureConfig{
+		config.AzureConfig{},
+		config.AzureConfig{VMType: "vmss"},
+	} {
+		desc := cfg.VMType
+		if desc == "" {
+			desc = "default"
+		}
+		t.Run(desc, func(t *testing.T) {
+			cloudClient := NewTestCloudClient(cfg)
 
-	cloudClient.AssignUserMSI("ID0", "node0")
-	cloudClient.AssignUserMSI("ID0", "node0")
-	cloudClient.AssignUserMSI("ID0again", "node0")
-	cloudClient.AssignUserMSI("ID1", "node1")
-	cloudClient.AssignUserMSI("ID2", "node2")
+			cloudClient.AssignUserMSI("ID0", "node0")
+			cloudClient.AssignUserMSI("ID0", "node0")
+			cloudClient.AssignUserMSI("ID0again", "node0")
+			cloudClient.AssignUserMSI("ID1", "node1")
+			cloudClient.AssignUserMSI("ID2", "node2")
 
-	testMSI := []string{"ID0", "ID0again"}
-	if !cloudClient.CompareMSI("node0", testMSI) {
-		t.Fatal("MSI mismatch")
-	}
+			testMSI := []string{"ID0", "ID0again"}
+			if !cloudClient.CompareMSI("node0", testMSI) {
+				t.Fatal("MSI mismatch")
+			}
 
-	cloudClient.RemoveUserMSI("ID0", "node0")
-	cloudClient.RemoveUserMSI("ID2", "node2")
-	testMSI = []string{"ID0again"}
-	if !cloudClient.CompareMSI("node0", testMSI) {
-		t.Fatal("MSI mismatch")
-	}
-	testMSI = []string{}
-	if !cloudClient.CompareMSI("node2", testMSI) {
-		t.Fatal("MSI mismatch")
+			cloudClient.RemoveUserMSI("ID0", "node0")
+			cloudClient.RemoveUserMSI("ID2", "node2")
+			testMSI = []string{"ID0again"}
+			if !cloudClient.CompareMSI("node0", testMSI) {
+				t.Fatal("MSI mismatch")
+			}
+			testMSI = []string{}
+			if !cloudClient.CompareMSI("node2", testMSI) {
+				t.Fatal("MSI mismatch")
+			}
+		})
 	}
 }

--- a/pkg/cloudprovider/cloudprovidertest/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovidertest/cloudprovider_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/Azure/aad-pod-identity/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSimple(t *testing.T) {
@@ -23,25 +25,29 @@ func TestSimple(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			cloudClient := NewTestCloudClient(cfg)
 
-			cloudClient.AssignUserMSI("ID0", "node0")
-			cloudClient.AssignUserMSI("ID0", "node0")
-			cloudClient.AssignUserMSI("ID0again", "node0")
-			cloudClient.AssignUserMSI("ID1", "node1")
-			cloudClient.AssignUserMSI("ID2", "node2")
+			node0 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"}}
+			node1 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+			node2 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+
+			cloudClient.AssignUserMSI("ID0", node0)
+			cloudClient.AssignUserMSI("ID0", node0)
+			cloudClient.AssignUserMSI("ID0again", node0)
+			cloudClient.AssignUserMSI("ID1", node1)
+			cloudClient.AssignUserMSI("ID2", node2)
 
 			testMSI := []string{"ID0", "ID0again"}
 			if !cloudClient.CompareMSI("node0", testMSI) {
 				t.Fatal("MSI mismatch")
 			}
 
-			cloudClient.RemoveUserMSI("ID0", "node0")
-			cloudClient.RemoveUserMSI("ID2", "node2")
+			cloudClient.RemoveUserMSI("ID0", node0)
+			cloudClient.RemoveUserMSI("ID2", node2)
 			testMSI = []string{"ID0again"}
-			if !cloudClient.CompareMSI("node0", testMSI) {
+			if !cloudClient.CompareMSI(node0.Name, testMSI) {
 				t.Fatal("MSI mismatch")
 			}
 			testMSI = []string{}
-			if !cloudClient.CompareMSI("node2", testMSI) {
+			if !cloudClient.CompareMSI(node2.Name, testMSI) {
 				t.Fatal("MSI mismatch")
 			}
 		})

--- a/pkg/cloudprovider/cloudprovidertest/cloudprovider_test_util.go
+++ b/pkg/cloudprovider/cloudprovidertest/cloudprovider_test_util.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/Azure/aad-pod-identity/pkg/cloudprovider"
+	"github.com/Azure/aad-pod-identity/pkg/config"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/golang/glog"
 )
@@ -11,7 +12,8 @@ import (
 type TestCloudClient struct {
 	*cloudprovider.Client
 	// testVMClient is test validation purpose.
-	testVMClient *TestVMClient
+	testVMClient   *TestVMClient
+	testVMSSClient *TestVMSSClient
 }
 
 type TestVMClient struct {
@@ -71,11 +73,74 @@ func (c *TestVMClient) CompareMSI(nodeName string, userIDs []string) bool {
 	return reflect.DeepEqual(*ids, userIDs)
 }
 
+type TestVMSSClient struct {
+	*cloudprovider.VMSSClient
+	nodeMap map[string]*compute.VirtualMachineScaleSet
+	err     *error
+}
+
+func (c *TestVMSSClient) SetError(err error) {
+	c.err = &err
+}
+
+func (c *TestVMSSClient) UnSetError() {
+	c.err = nil
+}
+
+func (c *TestVMSSClient) Get(rgName string, nodeName string) (ret compute.VirtualMachineScaleSet, err error) {
+	stored := c.nodeMap[nodeName]
+	if stored == nil {
+		vm := new(compute.VirtualMachineScaleSet)
+		c.nodeMap[nodeName] = vm
+		return *vm, nil
+	}
+	return *stored, nil
+}
+
+func (c *TestVMSSClient) CreateOrUpdate(rg string, nodeName string, vm compute.VirtualMachineScaleSet) error {
+	if c.err != nil {
+		return *c.err
+	}
+	c.nodeMap[nodeName] = &vm
+	return nil
+}
+
+func (c *TestVMSSClient) ListMSI() (ret map[string]*[]string) {
+	ret = make(map[string]*[]string)
+
+	for key, val := range c.nodeMap {
+		ret[key] = val.Identity.IdentityIds
+	}
+	return ret
+}
+
+func (c *TestVMSSClient) CompareMSI(nodeName string, userIDs []string) bool {
+	stored := c.nodeMap[nodeName]
+	if stored == nil || stored.Identity == nil {
+		return false
+	}
+
+	ids := stored.Identity.IdentityIds
+	if ids == nil {
+		if len(userIDs) == 0 && stored.Identity.Type == compute.ResourceIdentityTypeNone { // Validate that we have reset the resource type as none.
+			return true
+		}
+		return false
+	}
+	return reflect.DeepEqual(*ids, userIDs)
+}
+
 func (c *TestCloudClient) ListMSI() (ret map[string]*[]string) {
+	if c.Client.Config.VMType == "vmss" {
+		return c.testVMSSClient.ListMSI()
+	}
 	return c.testVMClient.ListMSI()
 }
 
 func (c *TestCloudClient) CompareMSI(nodeName string, userIDs []string) bool {
+	if c.Client.Config.VMType == "vmss" {
+		return c.testVMSSClient.CompareMSI(nodeName, userIDs)
+	}
 	return c.testVMClient.CompareMSI(nodeName, userIDs)
 }
 
@@ -109,14 +174,29 @@ func NewTestVMClient() *TestVMClient {
 	}
 }
 
-func NewTestCloudClient() *TestCloudClient {
+func NewTestVMSSClient() *TestVMSSClient {
+	nodeMap := make(map[string]*compute.VirtualMachineScaleSet, 0)
+	vmssClient := &cloudprovider.VMSSClient{}
+
+	return &TestVMSSClient{
+		vmssClient,
+		nodeMap,
+		nil,
+	}
+}
+
+func NewTestCloudClient(cfg config.AzureConfig) *TestCloudClient {
 	vmClient := NewTestVMClient()
+	vmssClient := NewTestVMSSClient()
 	cloudClient := &cloudprovider.Client{
-		VMClient: vmClient,
+		Config:     cfg,
+		VMClient:   vmClient,
+		VMSSClient: vmssClient,
 	}
 
 	return &TestCloudClient{
 		cloudClient,
 		vmClient,
+		vmssClient,
 	}
 }

--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -1,0 +1,93 @@
+package cloudprovider
+
+import (
+	"errors"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
+)
+
+// IdentityHolder represents a resource that contains an Identity object
+// This is used to be able to generically intract with multiple resource types (e.g. VirtualMachine and VittualMachineScaleSet)
+// which each contain an identity.
+type IdentityHolder interface {
+	IdentityInfo() IdentityInfo
+	ResetIdentity() IdentityInfo
+}
+
+// IdentityInfo is used to interact with different implementations of Azure compute identities.
+// This is needed because different Azure resource types (e.g. VirtualMachine and VirtualMachineScaleSet)
+// have different identity types.
+// This abstracts those differences.
+type IdentityInfo interface {
+	AppendUserIdentity(id string)
+	RemoveUserIdentity(id string) error
+}
+
+var (
+	errNotAssigned = errors.New("identity is not assigned to the resource")
+	errNotFound    = errors.New("user assigned identity not found")
+)
+
+// filterUserIdentity provides a common implementation for removing an identity
+// from an identity list.
+func filterUserIdentity(idType *compute.ResourceIdentityType, idList *[]string, id string) error {
+	switch *idType {
+	case compute.ResourceIdentityTypeUserAssigned,
+		compute.ResourceIdentityTypeSystemAssignedUserAssigned:
+	default:
+		return errNotFound
+	}
+
+	origLen := len(*idList)
+	filter(idList, id)
+
+	if len(*idList) >= origLen {
+		return errNotAssigned
+	}
+
+	if len(*idList) != 0 {
+		return nil
+	}
+
+	if *idType == compute.ResourceIdentityTypeSystemAssignedUserAssigned {
+		*idType = compute.ResourceIdentityTypeSystemAssigned
+	} else {
+		*idType = compute.ResourceIdentityTypeNone
+	}
+
+	return nil
+}
+
+func filter(ls *[]string, filter string) {
+	if ls == nil {
+		return
+	}
+
+	for i, v := range *ls {
+		if v == filter {
+			copy((*ls)[i:], (*ls)[i+1:])
+			*ls = (*ls)[:len(*ls)-1]
+			return
+		}
+	}
+}
+
+// appendUserIdentity provides a common implementation for adding a new identity
+// to an identity object.
+func appendUserIdentity(idType *compute.ResourceIdentityType, idList *[]string, newID string) {
+	switch *idType {
+	case compute.ResourceIdentityTypeUserAssigned, compute.ResourceIdentityTypeSystemAssignedUserAssigned:
+		// check if this ID is already in the list
+		for _, id := range *idList {
+			if id == newID {
+				return
+			}
+		}
+	case compute.ResourceIdentityTypeSystemAssigned:
+		*idType = compute.ResourceIdentityTypeSystemAssignedUserAssigned
+	default:
+		*idType = compute.ResourceIdentityTypeUserAssigned
+	}
+
+	*idList = append(*idList, newID)
+}

--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -7,7 +7,7 @@ import (
 )
 
 // IdentityHolder represents a resource that contains an Identity object
-// This is used to be able to generically intract with multiple resource types (e.g. VirtualMachine and VittualMachineScaleSet)
+// This is used to be able to generically intract with multiple resource types (e.g. VirtualMachine and VirtualMachineScaleSet)
 // which each contain an identity.
 type IdentityHolder interface {
 	IdentityInfo() IdentityInfo

--- a/pkg/cloudprovider/identity_test.go
+++ b/pkg/cloudprovider/identity_test.go
@@ -1,0 +1,120 @@
+package cloudprovider
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
+)
+
+func TestFilterIdentity(t *testing.T) {
+	idList := []string{}
+	idType := compute.ResourceIdentityTypeNone
+	if err := filterUserIdentity(&idType, &idList, "A"); err == nil || err != errNotFound {
+		t.Fatalf("expected error %q, got: %v", errNotFound, err)
+	}
+
+	idType = compute.ResourceIdentityTypeUserAssigned
+	if err := filterUserIdentity(&idType, &idList, "A"); err == nil || err != errNotAssigned {
+		t.Fatalf("expected error %q, got: %v", errNotAssigned, err)
+	}
+
+	idList = []string{"A"}
+	if err := filterUserIdentity(&idType, &idList, "A"); err != nil {
+		t.Fatal(err)
+	}
+	expect := []string{}
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeNone {
+		t.Fatalf("expected id type to be %q, got: %s", compute.ResourceIdentityTypeNone, idType)
+	}
+
+	idList = []string{"A", "B"}
+	idType = compute.ResourceIdentityTypeUserAssigned
+	if err := filterUserIdentity(&idType, &idList, "A"); err != nil {
+		t.Fatal(err)
+	}
+	expect = []string{"B"}
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("expected id type to be %q, got: %s", compute.ResourceIdentityTypeNone, idType)
+	}
+
+	idList = []string{"A", "B"}
+	idType = compute.ResourceIdentityTypeSystemAssignedUserAssigned
+	if err := filterUserIdentity(&idType, &idList, "A"); err != nil {
+		t.Fatal(err)
+	}
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeSystemAssignedUserAssigned {
+		t.Fatalf("expected id type to be %q, got: %s", compute.ResourceIdentityTypeSystemAssignedUserAssigned, idType)
+	}
+
+	idList = []string{"A"}
+	idType = compute.ResourceIdentityTypeSystemAssignedUserAssigned
+	if err := filterUserIdentity(&idType, &idList, "A"); err != nil {
+		t.Fatal(err)
+	}
+	expect = []string{}
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeSystemAssigned {
+		t.Fatalf("expected id type to be %q, got: %s", compute.ResourceIdentityTypeSystemAssigned, idType)
+	}
+}
+
+func TestAppendUserIdentity(t *testing.T) {
+	var (
+		idList []string
+		idType compute.ResourceIdentityType
+	)
+
+	appendUserIdentity(&idType, &idList, "A")
+	expect := []string{"A"}
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("expected type %s, got: %s", compute.ResourceIdentityTypeUserAssigned, idType)
+	}
+
+	// Append the same value again, should not change anything
+	appendUserIdentity(&idType, &idList, "A")
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("expected type %s, got: %s", compute.ResourceIdentityTypeUserAssigned, idType)
+	}
+
+	appendUserIdentity(&idType, &idList, "B")
+	expect = []string{"A", "B"}
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("expected type %s, got: %s", compute.ResourceIdentityTypeUserAssigned, idType)
+	}
+
+	idType = compute.ResourceIdentityTypeSystemAssigned
+	idList = []string{"A"}
+	expect = []string{"A", "B"}
+	appendUserIdentity(&idType, &idList, "B")
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeSystemAssignedUserAssigned {
+		t.Fatalf("expected type %s, got: %s", compute.ResourceIdentityTypeSystemAssignedUserAssigned, idType)
+	}
+
+	idType = compute.ResourceIdentityTypeNone
+	idList = []string{}
+	expect = []string{"A"}
+	appendUserIdentity(&idType, &idList, "A")
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("expected type %s, got: %s", compute.ResourceIdentityTypeUserAssigned, idType)
+	}
+}
+
+func checkIDList(t *testing.T, expect, actual []string) {
+	t.Helper()
+	if len(actual) != len(expect) {
+		t.Fatalf("expected %v, got: %v", expect, actual)
+	}
+	for i, v := range expect {
+		if actual[i] != v {
+			t.Fatalf("expected entry %d to be %q, got: %s", i, v, actual[i])
+		}
+	}
+}

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -1,0 +1,117 @@
+package cloudprovider
+
+import (
+	"context"
+	"time"
+
+	"github.com/Azure/aad-pod-identity/pkg/config"
+	"github.com/Azure/aad-pod-identity/pkg/stats"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/golang/glog"
+)
+
+// VMSSClient is used to interact with Azure virtual machine scale sets.
+type VMSSClient struct {
+	client compute.VirtualMachineScaleSetsClient
+}
+
+// VMSSClientInt is the interface used by "cloudprovider" for interacting with Azure vmss
+type VMSSClientInt interface {
+	CreateOrUpdate(rg, name string, vm compute.VirtualMachineScaleSet) error
+	Get(rgName, name string) (compute.VirtualMachineScaleSet, error)
+}
+
+// NewVMSSClient creates a new vmss client.
+func NewVMSSClient(config config.AzureConfig, spt *adal.ServicePrincipalToken) (c *VMSSClient, e error) {
+	client := compute.NewVirtualMachineScaleSetsClient(config.SubscriptionID)
+	client.BaseURI = azure.PublicCloud.ResourceManagerEndpoint
+	client.Authorizer = autorest.NewBearerAuthorizer(spt)
+	client.PollingDelay = 5 * time.Second
+	return &VMSSClient{
+		client: client,
+	}, nil
+}
+
+// CreateOrUpdate creates a new vmss, or if the vmss already exists it updates the existing one.
+// This is used by "cloudprovider" to *update* add/remove identities from an already existing vmss.
+func (c *VMSSClient) CreateOrUpdate(rg string, vmssName string, vm compute.VirtualMachineScaleSet) error {
+	// Set the read-only property of extension to null.
+	//vm.Resources = nil
+
+	ctx := context.Background()
+	begin := time.Now()
+	future, err := c.client.CreateOrUpdate(ctx, rg, vmssName, vm)
+	if err != nil {
+		glog.Error(err)
+		return err
+	}
+
+	err = future.WaitForCompletion(ctx, c.client.Client)
+	if err != nil {
+		glog.Error(err)
+		return err
+	}
+
+	vm, err = future.Result(c.client)
+	if err != nil {
+		glog.Error(err)
+		return err
+	}
+	stats.Update(stats.CloudPut, time.Since(begin))
+	return nil
+}
+
+// Get gets the passed in vmss.
+func (c *VMSSClient) Get(rgName string, vmssName string) (ret compute.VirtualMachineScaleSet, err error) {
+	ctx := context.Background()
+	beginGetTime := time.Now()
+	vm, err := c.client.Get(ctx, rgName, vmssName)
+	if err != nil {
+		glog.Error(err)
+		return vm, err
+	}
+	stats.Update(stats.CloudGet, time.Since(beginGetTime))
+	return vm, nil
+}
+
+// vmssIdentityHolder implements `IdentityHolder` for vmss resources.
+type vmssIdentityHolder struct {
+	vm *compute.VirtualMachineScaleSet
+}
+
+func (h *vmssIdentityHolder) IdentityInfo() IdentityInfo {
+	if h.vm.Identity == nil {
+		return nil
+	}
+	return &vmssIdentityInfo{h.vm.Identity}
+}
+
+func (h *vmssIdentityHolder) ResetIdentity() IdentityInfo {
+	h.vm.Identity = &compute.VirtualMachineScaleSetIdentity{}
+	return h.IdentityInfo()
+}
+
+type vmssIdentityInfo struct {
+	info *compute.VirtualMachineScaleSetIdentity
+}
+
+func (i *vmssIdentityInfo) RemoveUserIdentity(id string) error {
+	if err := filterUserIdentity(&i.info.Type, i.info.IdentityIds, id); err != nil {
+		return err
+	}
+	if i.info.Type == compute.ResourceIdentityTypeNone {
+		i.info.IdentityIds = nil
+	}
+	return nil
+}
+
+func (i *vmssIdentityInfo) AppendUserIdentity(id string) {
+	if i.info.IdentityIds == nil {
+		var ids []string
+		i.info.IdentityIds = &ids
+	}
+	appendUserIdentity(&i.info.Type, i.info.IdentityIds, id)
+}

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -79,18 +79,18 @@ func (c *VMSSClient) Get(rgName string, vmssName string) (ret compute.VirtualMac
 
 // vmssIdentityHolder implements `IdentityHolder` for vmss resources.
 type vmssIdentityHolder struct {
-	vm *compute.VirtualMachineScaleSet
+	vmss *compute.VirtualMachineScaleSet
 }
 
 func (h *vmssIdentityHolder) IdentityInfo() IdentityInfo {
-	if h.vm.Identity == nil {
+	if h.vmss.Identity == nil {
 		return nil
 	}
-	return &vmssIdentityInfo{h.vm.Identity}
+	return &vmssIdentityInfo{h.vmss.Identity}
 }
 
 func (h *vmssIdentityHolder) ResetIdentity() IdentityInfo {
-	h.vm.Identity = &compute.VirtualMachineScaleSetIdentity{}
+	h.vmss.Identity = &compute.VirtualMachineScaleSetIdentity{}
 	return h.IdentityInfo()
 }
 

--- a/pkg/config/azureconfig.go
+++ b/pkg/config/azureconfig.go
@@ -9,4 +9,5 @@ type AzureConfig struct {
 	SubscriptionID    string `json:"subscriptionId" yaml:"subscriptionId"`
 	ResourceGroupName string `json:"resourceGroup" yaml:"resourceGroup"`
 	SecurityGroupName string `json:"securityGroupName" yaml:"securityGroupName"`
+	VMType            string `json:"vmType" yaml:"vmType"`
 }

--- a/pkg/mic/node.go
+++ b/pkg/mic/node.go
@@ -1,0 +1,29 @@
+package mic
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	informerv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NodeClient handles fetching node details from kubernetes
+type NodeClient struct {
+	informer informerv1.NodeInformer
+}
+
+// Get gets the specified kubernetes node.
+//
+// Note that this is using a local, eventually consistent cache which may not
+// be up to date with the actual state of the cluster.
+func (c *NodeClient) Get(name string) (*corev1.Node, error) {
+	return c.informer.Lister().Get(name)
+}
+
+// Start starts syncing the underlying cache with kubernetes.
+//
+// The passed in channel should be used to signal that the client should stop
+// syncing. Close this channel when you want syncing to stop.
+func (c *NodeClient) Start(exit <-chan struct{}) {
+	go c.informer.Informer().Run(exit)
+	cache.WaitForCacheSync(exit, c.informer.Informer().HasSynced)
+}


### PR DESCRIPTION
This adds support for assigning identities to a VMSS when the underlying
cluster is using VMSS.

Note that identities get assigned to the entire VMSS.

This introduces a dependency on being able to list nodes from k8s so we can get the provider I, which allows us to determine (per node) if it is VMSS and what the real name of the resource we need to assign to is. This has the additional benefit in that it should be more robust than relying on the node names from k8s to match node names in Azure.

Closes #63