### PR TITLE
Fix alpine migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ push-demo:
 	docker push $(DEMO_IMAGE_NAME):$(DEMO_VERSION)
 
 push-identity-validator:
-	docker push $(IDENTITY_VALIDATOR_BINARY_NAME):$(IDENTITY_VALIDATOR_VERSION)
+	docker push $(IDENTITY_VALIDATOR_IMAGE_NAME):$(IDENTITY_VALIDATOR_VERSION)
 
 push:push-nmi push-mic push-demo push-identity-validator
 

--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -46,8 +46,17 @@ kind: ClusterRole
 metadata:
   name: aad-pod-id-nmi-role
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
   verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/images/mic/Dockerfile
+++ b/images/mic/Dockerfile
@@ -3,7 +3,6 @@ FROM alpine:3.8
 # install without cache
 RUN apk update && apk add --no-cache \
     ca-certificates \
-    iptables \
     && update-ca-certificates
 
 ADD ./mic /bin/mic

--- a/images/mic/Dockerfile
+++ b/images/mic/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.8
 # install without cache
 RUN apk update && apk add --no-cache \
     ca-certificates \
+    gcompat \
     && update-ca-certificates
 
 ADD ./mic /bin/mic

--- a/images/nmi/Dockerfile
+++ b/images/nmi/Dockerfile
@@ -4,6 +4,7 @@ FROM alpine:3.8
 RUN apk update && apk add --no-cache \
     ca-certificates \
     iptables \
+    gcompat \
     && update-ca-certificates
 
 ADD ./nmi /bin/nmi


### PR DESCRIPTION
* The alpine migration broke NMI and MIC, this PR fixes it by adding the package gcompat to both Dockerfiles. 
* Removes the iptables package from MIC.
* Fixes the image name for identity_validator.