### PR TITLE
Fixes the issue #141 raised for delete list appended with create list

### DIFF
--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -1,7 +1,7 @@
 package crd
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	aadpodid "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
@@ -42,28 +42,7 @@ func (c *TestCrdClient) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureA
 // This function is not used currently
 // TODO: consider remove
 func (c *TestCrdClient) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) error {
-	assignedID := &aadpodid.AzureAssignedIdentity{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "some-name",
-			Namespace: "default",
-		},
-		Spec: aadpodid.AzureAssignedIdentitySpec{
-			Pod:          "test-pod",
-			PodNamespace: "defaut",
-			NodeName:     "test-node",
-			AzureBindingRef: &aadpodid.AzureIdentityBinding{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "testbinding",
-				},
-			},
-			AzureIdentityRef: &aadpodid.AzureIdentity{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "test-id",
-				},
-			},
-		},
-	}
-	c.assignedIDMap["some-name"] = assignedID
+	c.assignedIDMap[assignedIdentity.Name] = assignedIdentity
 	return nil
 }
 

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -360,9 +360,9 @@ func (c *Client) splitAzureAssignedIDs(old *[]aadpodid.AzureAssignedIdentity, ne
 		}
 		if !idMatch {
 			glog.V(5).Infof("ok: %v, Delete added: %s", idMatch, oldAssignedID.Name)
-			// We are done checking that this new id is not present in the old
-			// list. So we will add it to the create list.
-			delete = append(create, oldAssignedID)
+			// We are done checking that this old id is not present in the new
+			// list. So we will add it to the delete list.
+			delete = append(delete, oldAssignedID)
 		}
 	}
 	stats.Put(stats.FindAssignedIDDel, time.Since(begin))


### PR DESCRIPTION
The issue manifests when there are delete and add in the same cycle. Because we are running delete cycles first and then performing create cycles, the effect of create list adding itself to delete gets nullified there because create eventually gets done, right after the delete. Nevertheless this causes an unnecessary deletion and addition to the underlying vm identity. As for deletions take effect one at a time because only one 'real' to-be-deleted one gets appended in one cycle. Eventually the others also get deleted in subsequent cycles.

Inorder to repro the issue, the test adds two pods in one cycle, and then deletes both and and adds one more pod in the next cycle. With the bug - only one assigned id gets deleted in one cycle and the second one gets deleted in the second cycle. With the test both gets deleted and the assigned identity for the new pod gets added in one cycle.