### PR TITLE
Add linux node selector to MIC and demo deployments

### DIFF
--- a/charts/aad-pod-identity/templates/infra.yaml
+++ b/charts/aad-pod-identity/templates/infra.yaml
@@ -164,3 +164,5 @@ spec:
       - name: k8s-azure-file
         hostPath:
           path: /etc/kubernetes/azure.json
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/deploy/demo/deployment.yaml
+++ b/deploy/demo/deployment.yaml
@@ -37,3 +37,5 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -189,3 +189,5 @@ spec:
       - name: k8s-azure-file
         hostPath:
           path: /etc/kubernetes/azure.json
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/deploy/infra/deployment.yaml
+++ b/deploy/infra/deployment.yaml
@@ -117,3 +117,5 @@ spec:
       - name: k8s-azure-file
         hostPath: 
           path: /etc/kubernetes/azure.json
+      nodeSelector:
+        beta.kubernetes.io/os: linux


### PR DESCRIPTION
Address #146 by adding the linux node selector to all deployments of MIC.

Also added the selector to the demo deployment as the current image is also linux-specific.