### PR TITLE
Fix vmss identity deletion for ID in use

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -220,15 +220,15 @@ var (
 )
 
 const (
-	vmRT   = "virtualMachines"
-	vmssRT = "virtualMachineScaleSets"
+	VMResourceType   = "virtualMachines"
+	VMSSResourceType = "virtualMachineScaleSets"
 )
 
 func vmTypeOrDefault(r *azure.Resource, val string) string {
 	switch r.ResourceType {
-	case vmRT:
+	case VMResourceType:
 		return "vm"
-	case vmssRT:
+	case VMSSResourceType:
 		return "vmss"
 	}
 	return val

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -386,8 +386,14 @@ func (c *TestNodeClient) Get(name string) (*corev1.Node, error) {
 
 func (c *TestNodeClient) Start(<-chan struct{}) {}
 
-func (c *TestNodeClient) AddNode(name string) {
-	c.nodes[name] = &corev1.Node{ObjectMeta: v1.ObjectMeta{Name: name}}
+func (c *TestNodeClient) AddNode(name string, opts ...func(*corev1.Node)) {
+	n := &corev1.Node{ObjectMeta: v1.ObjectMeta{Name: name}, Spec: corev1.NodeSpec{
+		ProviderID: "azure:///subscriptions/testSub/resourceGroups/fakeGroup/providers/Microsoft.Compute/virtualMachines/" + name,
+	}}
+	for _, o := range opts {
+		o(n)
+	}
+	c.nodes[name] = n
 }
 
 /************************ EVENT RECORDER MOCK *************************************/
@@ -516,6 +522,8 @@ func TestMapMICClient(t *testing.T) {
 }
 
 func TestSimpleMICClient(t *testing.T) {
+	exit := make(chan struct{}, 0)
+	defer close(exit)
 
 	exit := make(<-chan struct{})
 	eventCh := make(chan aadpodid.EventType, 100)
@@ -571,7 +579,9 @@ func TestSimpleMICClient(t *testing.T) {
 	podClient.DeletePod("test-pod", "default")
 
 	eventCh <- aadpodid.PodDeleted
-	time.Sleep(5 * time.Second)
+	if !evtRecorder.WaitForEvents(1) {
+		t.Fatal("timeout waiting for event sync")
+	}
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
@@ -630,7 +640,6 @@ func TestSimpleMICClient(t *testing.T) {
 
 	podClient.DeletePod("test-pod", "default")
 	eventCh <- aadpodid.PodDeleted
-	time.Sleep(5 * time.Second)
 	/*
 		testPass = evtRecorder.Validate(&LastEvent{Type: "Warning", Reason: "binding remove error",
 			Message: "Binding testbinding removal from node test-node for pod test-pod resulted in error remove error returned from cloud provider"})
@@ -643,6 +652,8 @@ func TestSimpleMICClient(t *testing.T) {
 
 func TestAddDelMICClient(t *testing.T) {
 	exit := make(<-chan struct{})
+	defer close(exit)
+
 	eventCh := make(chan aadpodid.EventType, 100)
 	cloudClient := NewTestCloudClient(config.AzureConfig{})
 	crdClient := NewTestCrdClient(nil)
@@ -668,6 +679,7 @@ func TestAddDelMICClient(t *testing.T) {
 	podClient.AddPod("test-pod4", "default", "test-node2", "test-select4")
 	podClient.GetPods()
 
+	eventCh <- aadpodid.PodCreated
 	eventCh <- aadpodid.PodCreated
 	go micClient.Sync(exit)
 
@@ -699,6 +711,8 @@ func TestAddDelMICClient(t *testing.T) {
 	podClient.GetPods()
 
 	eventCh <- aadpodid.PodCreated
+	eventCh <- aadpodid.PodDeleted
+	eventCh <- aadpodid.PodDeleted
 	go micClient.Sync(exit)
 
 	if !evtRecorder.WaitForEvents(3) {
@@ -724,5 +738,85 @@ func TestAddDelMICClient(t *testing.T) {
 			glog.Errorf("Expected %s. Got: %s", expectedID, gotID)
 			t.Fatalf("Add and delete id at same time. Found wrong id")
 		}
+	}
+}
+
+func TestMicAddDelVMSS(t *testing.T) {
+	exit := make(chan struct{}, 0)
+	defer close(exit)
+
+	eventCh := make(chan aadpodid.EventType, 100)
+	cloudClient := NewTestCloudClient(config.AzureConfig{VMType: "vmss"})
+	crdClient := NewTestCrdClient(nil)
+	podClient := NewTestPodClient()
+	nodeClient := NewTestNodeClient()
+	var evtRecorder TestEventRecorder
+	evtRecorder.lastEvent = new(LastEvent)
+	evtRecorder.eventChannel = make(chan bool, 1)
+
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder)
+
+	// Test to add and delete at the same time.
+	// Add a pod, identity and binding.
+	crdClient.CreateID("test-id1", aadpodid.UserAssignedMSI, "test-user-msi-resourceid", "test-user-msi-clientid", nil, "", "", "")
+	crdClient.CreateBinding("testbinding1", "test-id1", "test-select1")
+
+	nodeClient.AddNode("test-node1", func(n *corev1.Node) {
+		n.Spec.ProviderID = "azure:///subscriptions/fakeSub/resourceGroups/fakeGroup/providers/Microsoft.Compute/virtualMachineScaleSets/testvmss1/virtualMachines/0"
+	})
+
+	nodeClient.AddNode("test-node2", func(n *corev1.Node) {
+		n.Spec.ProviderID = "azure:///subscriptions/fakeSub/resourceGroups/fakeGroup/providers/Microsoft.Compute/virtualMachineScaleSets/testvmss1/virtualMachines/1"
+	})
+
+	nodeClient.AddNode("test-node3", func(n *corev1.Node) {
+		n.Spec.ProviderID = "azure:///subscriptions/fakeSub/resourceGroups/fakeGroup/providers/Microsoft.Compute/virtualMachineScaleSets/testvmss2/virtualMachines/0"
+	})
+
+	podClient.AddPod("test-pod1", "default", "test-node1", "test-select1")
+	podClient.AddPod("test-pod2", "default", "test-node2", "test-select1")
+	podClient.AddPod("test-pod3", "default", "test-node3", "test-select1")
+
+	go micClient.Sync(exit)
+
+	eventCh <- aadpodid.PodCreated
+	eventCh <- aadpodid.PodCreated
+	eventCh <- aadpodid.PodCreated
+	if !evtRecorder.WaitForEvents(3) {
+		t.Fatalf("Timeout waiting for mic sync cycles")
+	}
+
+	if !cloudClient.CompareMSI("testvmss1", []string{"test-user-msi-resourceid"}) {
+		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss1"])
+	}
+	if !cloudClient.CompareMSI("testvmss2", []string{"test-user-msi-resourceid"}) {
+		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss2"])
+	}
+
+	podClient.DeletePod("test-pod1", "default")
+	eventCh <- aadpodid.PodDeleted
+
+	if !evtRecorder.WaitForEvents(1) {
+		t.Fatal("Timeout waiting for mic sync cycles")
+	}
+
+	if !cloudClient.CompareMSI("testvmss1", []string{"test-user-msi-resourceid"}) {
+		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss1"])
+	}
+	if !cloudClient.CompareMSI("testvmss2", []string{"test-user-msi-resourceid"}) {
+		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss2"])
+	}
+
+	podClient.DeletePod("test-pod2", "default")
+	eventCh <- aadpodid.PodDeleted
+	if !evtRecorder.WaitForEvents(1) {
+		t.Fatal("Timeout waiting for mic sync cycles")
+	}
+
+	if !cloudClient.CompareMSI("testvmss1", []string{}) {
+		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss1"])
+	}
+	if !cloudClient.CompareMSI("testvmss2", []string{"test-user-msi-resourceid"}) {
+		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss2"])
 	}
 }

--- a/pkg/mic/vmss.go
+++ b/pkg/mic/vmss.go
@@ -1,0 +1,121 @@
+package mic
+
+import (
+	"path"
+
+	"github.com/Azure/aad-pod-identity/pkg/cloudprovider"
+	"github.com/Azure/go-autorest/autorest/azure"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+type vmssGroup struct {
+	nodes map[string]bool // index of node refs assigned to this vmss group
+}
+
+type vmssGroupList struct {
+	groups  map[string]*vmssGroup
+	nodeIdx map[string]*vmssGroup // index node refs for matching to a vmss group
+}
+
+func (ls *vmssGroupList) addNode(vmss, node string) {
+	g := ls.groups[vmss]
+	if g == nil {
+		g = &vmssGroup{nodes: make(map[string]bool)}
+		ls.groups[vmss] = g
+	}
+	g.nodes[node] = true
+	ls.nodeIdx[node] = g
+}
+
+// getByNode takes a node reference and returns the vmss group it belongs to
+func (ls *vmssGroupList) getByNode(ref string) *vmssGroup {
+	return ls.nodeIdx[ref]
+}
+
+// get takes a vmss id and returns the corresponding vmss group
+func (ls *vmssGroupList) get(id string) *vmssGroup {
+	return ls.groups[id]
+}
+
+func (g *vmssGroup) hasNode(ref string) bool {
+	if g.nodes == nil {
+		return false
+	}
+	return g.nodes[ref]
+}
+
+func vmssFromNodeRef(nc NodeGetter, ref string) (string, bool, error) {
+	n, err := nc.Get(ref)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return "", false, err
+		}
+		return "", false, nil
+	}
+
+	return isVMSS(n)
+}
+
+// getVMSSGroups takes a list of node references and groups them by vmss ID
+// nodes not in a vmss are elided
+func getVMSSGroups(nc NodeGetter, refs map[string]bool) (*vmssGroupList, error) {
+	ls := &vmssGroupList{groups: make(map[string]*vmssGroup), nodeIdx: make(map[string]*vmssGroup)}
+	for ref := range refs {
+		id, ok, err := vmssFromNodeRef(nc, ref)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return nil, err
+			}
+			continue
+		}
+
+		if !ok {
+			continue
+		}
+
+		ls.addNode(id, ref)
+	}
+
+	return ls, nil
+}
+
+func isVMSS(n *corev1.Node) (string, bool, error) {
+	r, err := cloudprovider.ParseResourceID(n.Spec.ProviderID)
+	if err != nil && n.Spec.ProviderID != "" {
+		return "", false, err
+	}
+
+	if r.ResourceType != cloudprovider.VMSSResourceType {
+		return "", false, nil
+	}
+	return makeVMSSID(r), true, nil
+}
+
+func makeVMSSID(r azure.Resource) string {
+	return path.Join(r.SubscriptionID, r.ResourceGroup, r.ResourceName)
+}
+
+// Either get a vmss group by node reference or lookup the vmss ID from the node's provider ID.
+// The reason for this is we may have request to delete an identity from a node and it is the last identity, so
+// the node will not be referenced by any pods and will be absent from the group list
+//
+// This does end up caching any missing node references into the vmss group list.
+func getVMSSGroupFromPossiblyUnreferencedNode(nc NodeGetter, groups *vmssGroupList, ref string) (*vmssGroup, error) {
+	vmss := groups.getByNode(ref)
+	if vmss != nil {
+		return vmss, nil
+	}
+
+	vmssID, isVMSS, err := vmssFromNodeRef(nc, ref)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	if isVMSS {
+		groups.addNode(vmssID, ref) // cache this reference so we don't have to parse again
+		return groups.get(vmssID), nil
+	}
+
+	// not a vmss
+	return nil, nil
+}


### PR DESCRIPTION
Before this change, an identity on a VMSS node may be deleted from the
VMSS even if it's used on another node in the VMSS.

This makes the check for identity in use vmss aware since identities on
a vmss are managed for the entire vmss, not just a single node in the
vmss.

Fixes #198