### PR TITLE
Add retry sleep interval as option

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -75,7 +75,7 @@ func (c *KubeClient) GetPodName(podip string) (podns, poddname string, err error
 		return "", "", fmt.Errorf("podip is empty")
 	}
 
-	podList, err := c.getPodListWithTries(podip, getPodListTries)
+	podList, err := c.getPodListWithTries(podip, getPodListTries, getPodListSleepTimeMilliseconds)
 
 	if err != nil {
 		return "", "", err
@@ -88,15 +88,15 @@ func (c *KubeClient) GetPodName(podip string) (podns, poddname string, err error
 	return "", "", fmt.Errorf("match failed, ip:%s matching pods:%v", podip, podList)
 }
 
-func (c *KubeClient) getPodListWithTries(podip string, tries int) (*v1.PodList, error) {
+func (c *KubeClient) getPodListWithTries(podip string, tries int, sleeptime time.Duration) (*v1.PodList, error) {
 	podList, err := c.ClientSet.CoreV1().Pods("").List(metav1.ListOptions{
 		FieldSelector: "status.podIP==" + podip + phaseStatusFilter,
 	})
 
 	if err != nil || len(podList.Items) == 0 {
 		if tries > 1 {
-			time.Sleep(getPodListSleepTimeMilliseconds * time.Millisecond)
-			return c.getPodListWithTries(podip, tries-1)
+			time.Sleep(sleeptime * time.Millisecond)
+			return c.getPodListWithTries(podip, tries-1, sleeptime)
 		}
 	}
 

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,5 +29,75 @@ func TestGetSecret(t *testing.T) {
 	}
 	if retrievedSecret.ObjectMeta.Name != secretName {
 		t.Fatalf("Incorrect secret name: %v", retrievedSecret.ObjectMeta.Name)
+	}
+}
+
+func TestGetPodName(t *testing.T) {
+	podIP := "10.0.0.8"
+
+	fakeClient := fake.NewSimpleClientset()
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpodname",
+			Namespace: "default",
+		},
+		Status: v1.PodStatus{
+			PodIP: podIP,
+		},
+	}
+	fakeClient.CoreV1().Pods("default").Create(pod)
+
+	kubeClient := &KubeClient{ClientSet: fakeClient}
+
+	podNs, podName, err := kubeClient.GetPodName(podIP)
+	if err != nil {
+		t.Fatalf("Error getting pod: %v", err)
+	}
+	if podName != "testpodname" {
+		t.Fatalf("Incorrect pod name: %v", podName)
+	}
+	if podNs != "default" {
+		t.Fatalf("Incorrect pod ns: %v", podNs)
+	}
+}
+
+func TestPodListRetries(t *testing.T) {
+	// this test is to solely test the retry and sleep logic works as expected
+	podIP := "10.0.0.8"
+
+	fakeClient := fake.NewSimpleClientset()
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpodname1",
+			Namespace: "default",
+		},
+		Status: v1.PodStatus{
+			PodIP: podIP,
+		},
+	}
+	kubeClient := &KubeClient{ClientSet: fakeClient}
+
+	time.AfterFunc(time.Duration(1200*time.Millisecond), func() {
+		fakeClient.CoreV1().Pods("default").Create(pod)
+	})
+
+	start := time.Now()
+	podNs, podName, err := kubeClient.GetPodName(podIP)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Error getting pod: %v", err)
+	}
+	if podName != "testpodname1" {
+		t.Fatalf("Incorrect pod name: %v", podName)
+	}
+	if podNs != "default" {
+		t.Fatalf("Incorrect pod ns: %v", podNs)
+	}
+	// check the retries actually work as the pod object is created only after 1.2s
+	if elapsed < 1200*time.Millisecond {
+		t.Fatalf("Retry logic not working as expected. Elapsed time: %v", elapsed)
 	}
 }


### PR DESCRIPTION
Changes in reference to https://github.com/Azure/aad-pod-identity/issues/108

- Add retry sleep interval as an option
- Add UT for `GetPodName` and test retry logic