### PR TITLE
Handle iptables cleanup on uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,21 @@ Update the `deploy/demo/deployment.yaml` arguments with your subscription, clien
 kubectl create -f deploy/demo/deployment.yaml
 ```
 
+## Uninstall notes
+
+The NMI pods modify the nodes iptables to intercept calls to Azure Instance Metadata endpoint. This allows NMI to assert identities assigned to pod before executing the request on behalf of the caller. These iptable entries will be cleaned up when the pod-identity pods are uninstalled. However if the pods are terminated because of other reasons (non actionable signals), they can be manually removed with
+
+```
+#remove the custom chain reference
+iptables -t nat -D PREROUTING -j aad-metadata
+
+#flush the custom chain
+iptables -t nat -F aad-metadata
+
+#remove the custom chain
+iptables -t nat -X aad-metadata
+```
+
 ## Tutorial
 
 A detailed tutorial can be found here: [docs/tutorial/README.md](docs/tutorial/README.md).

--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"os"
+
 	"github.com/Azure/aad-pod-identity/pkg/k8s"
 	server "github.com/Azure/aad-pod-identity/pkg/nmi/server"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
-	"os"
 )
 
 const (

--- a/deploy/infra/deployment.yaml
+++ b/deploy/infra/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         name: iptableslock
       containers:
       - name: nmi
-        image: "aramase/nmi:test"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.4"
         imagePullPolicy: Always
         args:
           - nmi

--- a/deploy/infra/deployment.yaml
+++ b/deploy/infra/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         name: iptableslock
       containers:
       - name: nmi
-        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.4"
+        image: "aramase/nmi:test"
         imagePullPolicy: Always
         args:
           - nmi

--- a/pkg/nmi/iptables/iptables.go
+++ b/pkg/nmi/iptables/iptables.go
@@ -115,7 +115,7 @@ func DeleteCustomChain() error {
 	if err != nil {
 		return err
 	}
-	if err := removeCustonChainReference(ipt, tablename, "PREROUTING"); err != nil {
+	if err := removeCustomChainReference(ipt, tablename, "PREROUTING"); err != nil {
 		return err
 	}
 	if err := removeCustomChain(ipt, tablename); err != nil {
@@ -124,8 +124,8 @@ func DeleteCustomChain() error {
 	return nil
 }
 
-// removeCustonChainReference - iptables -t "table" -D "chain" -j "customchainname"
-func removeCustonChainReference(ipt *iptables.IPTables, table, chain string) error {
+// removeCustomChainReference - iptables -t "table" -D "chain" -j "customchainname"
+func removeCustomChainReference(ipt *iptables.IPTables, table, chain string) error {
 	exists, err := ipt.Exists(table, chain, "-j", customchainname)
 	if err == nil && exists {
 		return ipt.Delete(table, chain, "-j", customchainname)

--- a/pkg/nmi/iptables/iptables.go
+++ b/pkg/nmi/iptables/iptables.go
@@ -108,24 +108,24 @@ func flushCreateCustomChainrules(ipt *iptables.IPTables, destIP, destPort, targe
 	return nil
 }
 
-// DeleteCustomChain deletes the custom chain aad-metadata reference from PREROUTING
-// chain and then deletes the chain aad-metadata
+// DeleteCustomChain removees the custom chain aad-metadata reference from PREROUTING
+// chain and then removes the chain aad-metadata from nat table
 func DeleteCustomChain() error {
 	ipt, err := iptables.New()
 	if err != nil {
 		return err
 	}
-	if err := deleteCustomChainInChain(ipt, tablename, "PREROUTING"); err != nil {
+	if err := removeCustonChainReference(ipt, tablename, "PREROUTING"); err != nil {
 		return err
 	}
-	if err := deleteCustomChain(ipt, tablename); err != nil {
+	if err := removeCustomChain(ipt, tablename); err != nil {
 		return err
 	}
 	return nil
 }
 
-// deleteCustomChainInChain - iptables -t "table" -D "chain" -j "customchainname"
-func deleteCustomChainInChain(ipt *iptables.IPTables, table, chain string) error {
+// removeCustonChainReference - iptables -t "table" -D "chain" -j "customchainname"
+func removeCustonChainReference(ipt *iptables.IPTables, table, chain string) error {
 	exists, err := ipt.Exists(table, chain, "-j", customchainname)
 	if err == nil && exists {
 		return ipt.Delete(table, chain, "-j", customchainname)
@@ -133,10 +133,10 @@ func deleteCustomChainInChain(ipt *iptables.IPTables, table, chain string) error
 	return nil
 }
 
-// deleteCustomChain -  flush and then delete custom chain
+// removeCustomChain -  flush and then delete custom chain
 // iptables -t "table" -F "customchainname"
 // iptables -t "table" -X "customchainname"
-func deleteCustomChain(ipt *iptables.IPTables, table string) error {
+func removeCustomChain(ipt *iptables.IPTables, table string) error {
 	if err := ipt.ClearChain(table, customchainname); err != nil {
 		return err
 	}

--- a/pkg/nmi/iptables/iptables.go
+++ b/pkg/nmi/iptables/iptables.go
@@ -108,7 +108,7 @@ func flushCreateCustomChainrules(ipt *iptables.IPTables, destIP, destPort, targe
 	return nil
 }
 
-// DeleteCustomChain removees the custom chain aad-metadata reference from PREROUTING
+// DeleteCustomChain removes the custom chain aad-metadata reference from PREROUTING
 // chain and then removes the chain aad-metadata from nat table
 func DeleteCustomChain() error {
 	ipt, err := iptables.New()

--- a/pkg/nmi/iptables/iptables.go
+++ b/pkg/nmi/iptables/iptables.go
@@ -130,7 +130,7 @@ func deleteCustomChainInChain(ipt *iptables.IPTables, table, chain string) error
 	if err == nil && exists {
 		return ipt.Delete(table, chain, "-j", customchainname)
 	}
-	return err
+	return nil
 }
 
 // deleteCustomChain -  flush and then delete custom chain

--- a/test/common/k8s/pod/pod.go
+++ b/test/common/k8s/pod/pod.go
@@ -72,6 +72,34 @@ func GetNameByPrefix(prefix string) (string, error) {
 	return "", nil
 }
 
+// GetAllNameByPrefix will return the name of all pods that matches a prefix
+func GetAllNameByPrefix(prefix string) ([]string, error) {
+	var pods []string
+	list, err := GetAll()
+	if err != nil {
+		return pods, err
+	}
+
+	for _, pod := range list.Pods {
+		if strings.HasPrefix(pod.Metadata.Name, prefix) && pod.Status.Phase == "Running" {
+			pods = append(pods, pod.Metadata.Name)
+		}
+	}
+
+	return pods, nil
+}
+
+// RunCommandInPod runs command with kubectl exec in pod
+func RunCommandInPod(execCmd ...string) (string, error) {
+	cmd := exec.Command("kubectl", execCmd...)
+	util.PrintCommand(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), errors.Wrap(err, fmt.Sprintf("Failed to execute command in pod"))
+	}
+	return string(out), err
+}
+
 // GetNodeName will return the name of the node the pod is running on
 func GetNodeName(podName string) (string, error) {
 	cmd := exec.Command("kubectl", "get", "pod", podName, "-ojson")

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -49,7 +49,7 @@ var _ = BeforeSuite(func() {
 	cfg = *c // To avoid 'Declared and not used' linting error
 
 	// Install CRDs and deploy MIC and NMI
-	cmd := exec.Command("kubectl", "apply", "-f", "../../deploy/infra/deployment-rbac.yaml")
+	cmd := exec.Command("kubectl", "apply", "-f", "../../deploy/infra/deployment.yaml")
 	util.PrintCommand(cmd)
 	_, err = cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred())
@@ -59,7 +59,7 @@ var _ = AfterSuite(func() {
 	fmt.Println("\nTearing down the test suite environment...")
 
 	// Uninstall CRDs and delete MIC and NMI
-	cmd := exec.Command("kubectl", "delete", "-f", "../../deploy/infra/deployment-rbac.yaml", "--ignore-not-found")
+	cmd := exec.Command("kubectl", "delete", "-f", "../../deploy/infra/deployment.yaml", "--ignore-not-found")
 	util.PrintCommand(cmd)
 	_, err := cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred())
@@ -445,6 +445,65 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 
 	// 	removeUserAssignedIdentityFromCluster(nodeList, clusterIdentity)
 	// })
+
+	It("should cleanup iptable rules after deleting aad-pod-identity", func() {
+		// create the helper ssh daemon for validating the iptable rules
+		cmd := exec.Command("kubectl", "apply", "-f", "template/busyboxds.yaml")
+		_, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(90 * time.Second)
+
+		// check if the iptable rules exist before test
+		pods, err := pod.GetAllNameByPrefix("busybox")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pods).NotTo(BeNil())
+
+		for _, p := range pods {
+			// install iptables in the busybox to keep the vanilla alpine image for busybox
+			_, err := pod.RunCommandInPod("exec", p, "--", "apk", "add", "iptables")
+			Expect(err).NotTo(HaveOccurred())
+
+			// ensure aad-metadata target reference exists
+			_, err = pod.RunCommandInPod("exec", p, "--", "iptables", "-t", "nat", "--check", "PREROUTING", "-j", "aad-metadata")
+			Expect(err).NotTo(HaveOccurred())
+
+			// ensure aad-metadata custom chain rules exists
+			_, err = pod.RunCommandInPod("exec", p, "--", "iptables", "-t", "nat", "-L", "aad-metadata")
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// delete the aad-pod-identity deployment
+		cmd = exec.Command("kubectl", "delete", "-f", "../../deploy/infra/deployment.yaml")
+		_, err = cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred())
+
+		ok, err := pod.WaitOnDeletion("nmi")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		// check to ensure the custom iptable rules have been cleaned up
+		for _, p := range pods {
+			// ensure aad-metadata target reference doesn't exist anymore
+			out, err := pod.RunCommandInPod("exec", p, "--", "iptables", "-t", "nat", "--check", "PREROUTING", "-j", "aad-metadata")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring("No such file or directory"))
+
+			// ensure aad-metadata custom chain rule doesn't exist anymore
+			out, err = pod.RunCommandInPod("exec", p, "--", "iptables", "-t", "nat", "-L", "aad-metadata")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring("No chain/target/match by that name."))
+		}
+
+		// put back the deployment for further tests and cleanup ssh daemon
+		cmd = exec.Command("kubectl", "delete", "-f", "template/busyboxds.yaml")
+		_, err = cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "apply", "-f", "../../deploy/infra/deployment.yaml")
+		_, err = cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	It("should not alter the system assigned identity after creating and deleting pod identity", func() {
 		// Assign system assigned identity to every node

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -49,7 +49,7 @@ var _ = BeforeSuite(func() {
 	cfg = *c // To avoid 'Declared and not used' linting error
 
 	// Install CRDs and deploy MIC and NMI
-	cmd := exec.Command("kubectl", "apply", "-f", "../../deploy/infra/deployment.yaml")
+	cmd := exec.Command("kubectl", "apply", "-f", "../../deploy/infra/deployment-rbac.yaml")
 	util.PrintCommand(cmd)
 	_, err = cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred())
@@ -59,7 +59,7 @@ var _ = AfterSuite(func() {
 	fmt.Println("\nTearing down the test suite environment...")
 
 	// Uninstall CRDs and delete MIC and NMI
-	cmd := exec.Command("kubectl", "delete", "-f", "../../deploy/infra/deployment.yaml", "--ignore-not-found")
+	cmd := exec.Command("kubectl", "delete", "-f", "../../deploy/infra/deployment-rbac.yaml", "--ignore-not-found")
 	util.PrintCommand(cmd)
 	_, err := cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred())
@@ -474,7 +474,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		}
 
 		// delete the aad-pod-identity deployment
-		cmd = exec.Command("kubectl", "delete", "-f", "../../deploy/infra/deployment.yaml")
+		cmd = exec.Command("kubectl", "delete", "-f", "../../deploy/infra/deployment-rbac.yaml", "--ignore-not-found")
 		_, err = cmd.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -500,7 +500,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		_, err = cmd.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
 
-		cmd = exec.Command("kubectl", "apply", "-f", "../../deploy/infra/deployment.yaml")
+		cmd = exec.Command("kubectl", "apply", "-f", "../../deploy/infra/deployment-rbac.yaml")
 		_, err = cmd.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/test/e2e/template/busyboxds.yaml
+++ b/test/e2e/template/busyboxds.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        component: busybox
+    spec:
+      hostNetwork: true
+      containers:
+      - name: busybox
+        image: alpine:3.8
+        stdin: true
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
+      nodeSelector:
+        beta.kubernetes.io/os: linux


### PR DESCRIPTION
resolves https://github.com/Azure/aad-pod-identity/issues/113

This will handle graceful shutdown of the pod, cleanup the ip table chain and rules that were inserted by NMI.