### PR TITLE
Log binary versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ deepcopy-gen:
 
 .PHONY: image-nmi
 image-nmi:
-	docker build -t "$(REGISTRY)/$(NMI_IMAGE)" --build-arg NMI_VEARSION="$(NMI_VERSION)" --target=nmi .
+	docker build -t "$(REGISTRY)/$(NMI_IMAGE)" --build-arg NMI_VERSION="$(NMI_VERSION)" --target=nmi .
 
 .PHONY: image-mic
 image-mic:

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ NMI_VERSION ?= $(DEFAULT_VERSION)
 MIC_VERSION ?= $(DEFAULT_VERSION)
 DEMO_VERSION ?= $(DEFAULT_VERSION)
 IDENTITY_VALIDATOR_VERSION ?= $(DEFAULT_VERSION)
-BINARY_VERSION := ${MIC_VERSION}-mic-${NMI_VERSION}-nmi
 
-VERSION_VAR := $(REPO_PATH)/version.Version
+NMI_VERSION_VAR := $(REPO_PATH)/version.NMIVersion
+MIC_VERSION_VAR := $(REPO_PATH)/version.MICVersion
 GIT_VAR := $(REPO_PATH)/version.GitCommit
 BUILD_DATE_VAR := $(REPO_PATH)/version.BuildDate
 BUILD_DATE := $$(date +%Y-%m-%d-%H:%M)
@@ -34,7 +34,7 @@ else
 	endif
 endif
 
-GO_BUILD_OPTIONS := --tags "netgo osusergo"  -ldflags "-s -X $(VERSION_VAR)=$(BINARY_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
+GO_BUILD_OPTIONS := --tags "netgo osusergo"  -ldflags "-s -X $(NMI_VERSION_VAR)=$(NMI_VERSION) -X $(MIC_VERSION_VAR)=$(MIC_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
 E2E_TEST_OPTIONS := -count=1 -v -timeout 24h -ginkgo.failFast
 
 # useful for other docker repos

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ NMI_VERSION ?= $(DEFAULT_VERSION)
 MIC_VERSION ?= $(DEFAULT_VERSION)
 DEMO_VERSION ?= $(DEFAULT_VERSION)
 IDENTITY_VALIDATOR_VERSION ?= $(DEFAULT_VERSION)
+BINARY_VERSION := ${MIC_VERSION}-mic-${NMI_VERSION}-nmi
 
 VERSION_VAR := $(REPO_PATH)/version.Version
 GIT_VAR := $(REPO_PATH)/version.GitCommit
@@ -33,7 +34,7 @@ else
 	endif
 endif
 
-GO_BUILD_OPTIONS := --tags "netgo osusergo"  -ldflags "-s -X $(VERSION_VAR)=$(NMI_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
+GO_BUILD_OPTIONS := --tags "netgo osusergo"  -ldflags "-s -X $(VERSION_VAR)=$(BINARY_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
 E2E_TEST_OPTIONS := -count=1 -v -timeout 24h -ginkgo.failFast
 
 # useful for other docker repos

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -15,6 +15,7 @@ var (
 	kubeconfig      string
 	cloudconfig     string
 	forceNamespaced bool
+	versionInfo     bool
 )
 
 func main() {
@@ -22,8 +23,12 @@ func main() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to the kube config")
 	flag.StringVar(&cloudconfig, "cloudconfig", "", "Path to cloud config e.g. Azure.json file")
 	flag.BoolVar(&forceNamespaced, "forceNamespaced", false, "Forces namespaced identities, binding, and assignment")
+	flag.BoolVar(&versionInfo, "version", false, "Prints the version information")
 	flag.Parse()
-	log.Info("Starting mic process. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
+	if versionInfo {
+		version.PrintVersionAndExit()
+	}
+	glog.Info("Starting mic process. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
 	if cloudconfig == "" {
 		glog.Fatalf("Could not get the cloud config")
 	}

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Azure/aad-pod-identity/pkg/mic"
+	"github.com/Azure/aad-pod-identity/version"
 	"github.com/golang/glog"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -22,6 +23,7 @@ func main() {
 	flag.StringVar(&cloudconfig, "cloudconfig", "", "Path to cloud config e.g. Azure.json file")
 	flag.BoolVar(&forceNamespaced, "forceNamespaced", false, "Forces namespaced identities, binding, and assignment")
 	flag.Parse()
+	log.Info("Starting mic process. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
 	if cloudconfig == "" {
 		glog.Fatalf("Could not get the cloud config")
 	}

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -28,7 +28,7 @@ func main() {
 	if versionInfo {
 		version.PrintVersionAndExit()
 	}
-	glog.Info("Starting mic process. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
+	glog.Infof("Starting mic process. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
 	if cloudconfig == "" {
 		glog.Fatalf("Could not get the cloud config")
 	}

--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -19,6 +19,7 @@ const (
 
 var (
 	debug                              = pflag.Bool("debug", true, "sets log to debug level")
+	versionInfo                        = pflag.Bool("version", false, "prints the version information")
 	nmiPort                            = pflag.String("nmi-port", defaultNmiPort, "NMI application port")
 	metadataIP                         = pflag.String("metadata-ip", defaultMetadataIP, "instance metadata host ip")
 	metadataPort                       = pflag.String("metadata-port", defaultMetadataPort, "instance metadata host ip")
@@ -30,6 +31,9 @@ var (
 
 func main() {
 	pflag.Parse()
+	if *versionInfo {
+		version.PrintVersionAndExit()
+	}
 	if *debug {
 		log.SetLevel(log.DebugLevel)
 	}

--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -37,7 +37,7 @@ func main() {
 	if *debug {
 		log.SetLevel(log.DebugLevel)
 	}
-	log.Info("Starting nmi process. Version: %v. Build date: %v", version.NMIVersion, version.BuildDate)
+	log.Infof("Starting nmi process. Version: %v. Build date: %v", version.NMIVersion, version.BuildDate)
 	client, err := k8s.NewKubeClient()
 	if err != nil {
 		log.Fatalf("%+v", err)

--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/aad-pod-identity/pkg/k8s"
 	server "github.com/Azure/aad-pod-identity/pkg/nmi/server"
+	"github.com/Azure/aad-pod-identity/version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
@@ -32,7 +33,7 @@ func main() {
 	if *debug {
 		log.SetLevel(log.DebugLevel)
 	}
-	log.Info("starting nmi process")
+	log.Info("Starting nmi process. Version: %v. Build date: %v", version.NMIVersion, version.BuildDate)
 	client, err := k8s.NewKubeClient()
 	if err != nil {
 		log.Fatalf("%+v", err)

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/aad-pod-identity/pkg/crd"
 	"github.com/Azure/aad-pod-identity/pkg/pod"
 	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
@@ -49,7 +48,7 @@ type ClientInt interface {
 }
 
 func NewMICClient(cloudconfig string, config *rest.Config, isNamespaced bool) (*Client, error) {
-	glog.Infof("Starting to create the pod identity client. Version: %v. Build date: %v", version.Version, version.BuildDate)
+	glog.Infof("Starting to create the pod identity client. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
 
 	clientSet := kubernetes.NewForConfigOrDie(config)
 	informer := informers.NewSharedInformerFactory(clientSet, 30*time.Second)

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/aad-pod-identity/pkg/crd"
 	"github.com/Azure/aad-pod-identity/pkg/pod"
 	"github.com/golang/glog"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"

--- a/version/version.go
+++ b/version/version.go
@@ -11,11 +11,14 @@ var BuildDate string
 // GitCommit is the commit hash when the binary was built
 var GitCommit string
 
-// Version is the version of the binary
-var Version string
+// MICVersion is the version of the MIC component
+var MICVersion string
+
+// NMIVersion is the version of the NMI component
+var NMIVersion string
 
 // PrintVersionAndExit prints the version and exits
 func PrintVersionAndExit() {
-	fmt.Printf("Version: %s - Commit: %s - Date: %s\n", Version, GitCommit, BuildDate)
+	fmt.Printf("MIC Version: %s - NMI Version: %s - Commit: %s - Date: %s\n", MICVersion, NMIVersion, GitCommit, BuildDate)
 	os.Exit(0)
 }


### PR DESCRIPTION
Acceptance criteria: As a user, I would like to see binary versions of NMI and MIC in the logs.

Fix a typo in the Makefile that caused the ARG for `NMI_VERSION` to be always empty. Add handling for `MIC_VERSION`.

These versions will show in the logs next time we build an image using `NMI_VERSION` and  `MIC_VERSION` args.

Fixes #207 