### PR TITLE
Update E2E to run tests based on generated images 

### DIFF
--- a/test/common/k8s/deploy/deploy.go
+++ b/test/common/k8s/deploy/deploy.go
@@ -48,7 +48,7 @@ func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath
 		return errors.Wrap(err, "Failed to parse deployment-rbac.yaml")
 	}
 
-	deployFilePath := path.Join(templateOutputPath, namespace+"-deployment-rbac.yaml")
+	deployFilePath := path.Join(templateOutputPath, namespace+"-deployment.yaml")
 	deployFile, err := os.Create(deployFilePath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create a deployment file from deployment-rbac.yaml")

--- a/test/common/k8s/deploy/deploy.go
+++ b/test/common/k8s/deploy/deploy.go
@@ -41,8 +41,47 @@ type Status struct {
 	AvailableReplicas int `json:"availableReplicas"`
 }
 
+// CreateInfra will deploy all the infrastructure components (nmi and mic) on a Kubernetes cluster
+func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath string) error {
+	t, err := template.New("deployment-rbac.yaml").ParseFiles(path.Join("template", "deployment-rbac.yaml"))
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse deployment-rbac.yaml")
+	}
+
+	deployFilePath := path.Join(templateOutputPath, namespace+"-deployment-rbac.yaml")
+	deployFile, err := os.Create(deployFilePath)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create a deployment file from deployment-rbac.yaml")
+	}
+	defer deployFile.Close()
+
+	deployData := struct {
+		Namespace  string
+		Registry   string
+		NMIVersion string
+		MICVersion string
+	}{
+		namespace,
+		registry,
+		nmiVersion,
+		micVersion,
+	}
+	if err := t.Execute(deployFile, deployData); err != nil {
+		return errors.Wrap(err, "Failed to create a deployment file from deployment-rbac.yaml")
+	}
+
+	cmd := exec.Command("kubectl", "apply", "-f", deployFilePath)
+	util.PrintCommand(cmd)
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "Failed to deploy Infrastructure to the Kubernetes cluster")
+	}
+
+	return nil
+}
+
 // CreateIdentityValidator will create an identity validator deployment on a Kubernetes cluster
-func CreateIdentityValidator(subscriptionID, resourceGroup, name, identityBinding, templateOutputPath string) error {
+func CreateIdentityValidator(subscriptionID, resourceGroup, registryName, name, identityBinding, identityValidatorVersion, templateOutputPath string) error {
 	t, err := template.New("deployment.yaml").ParseFiles(path.Join("template", "deployment.yaml"))
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse deployment.yaml")
@@ -57,11 +96,15 @@ func CreateIdentityValidator(subscriptionID, resourceGroup, name, identityBindin
 
 	// Go template parameters to be translated in test/e2e/template/deployment.yaml
 	deployData := struct {
-		Name            string
-		IdentityBinding string
+		Name                     string
+		IdentityBinding          string
+		Registry                 string
+		IdentityValidatorVersion string
 	}{
 		name,
 		identityBinding,
+		registryName,
+		identityValidatorVersion,
 	}
 	if err := t.Execute(deployFile, deployData); err != nil {
 		return errors.Wrap(err, "Failed to create a deployment file from deployment.yaml")
@@ -83,7 +126,7 @@ func Delete(name, templateOutputPath string) error {
 	util.PrintCommand(cmd)
 	_, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, "Failed to delete AzureIdentityBinding from the Kubernetes cluster")
+		return errors.Wrapf(err, "Failed to delete %v from the Kubernetes cluster", name)
 	}
 
 	return nil

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,7 +30,7 @@ export KEYVAULT_SECRET_VERSION='...'
 
 Optionally, to use custom images:
 
-# The registry where to get the images from. Defaults to `mcr.microsoft.com/k8s/aad-pod-identity/`.
+# The registry where to get the images from. Defaults to `mcr.microsoft.com/k8s/aad-pod-identity`.
 export REGISTRY='...'
 
 # The version of the NMI image to test. Defaults to `1.4`.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -26,11 +26,25 @@ export KEYVAULT_SECRET_NAME='...'
 
 # The version of the secret inserted into the keyvault
 export KEYVAULT_SECRET_VERSION='...'
+
+# The registry where to get the images from. Use "mcr.microsoft.com/k8s/aad-pod-identity/" to run the tests with released images
+export REGISTRY='...'
+
+# The version of the NMI image to test
+export NMI_VERSION='...'
+
+# The version of the MIC image to test
+export MIC_VERSION='...'
+
+# The version of the identity validator to test
+export IDENTITY_VALIDATOR_VERSION='...'
+
 ```
 
 At the same time, the tests utilizes two user assigned identities, `keyvault-identity` (have read access to the keyvault that you create) and `cluster-identity` (have read access to the resource group level). You can create necessary Azure resources and roles with the bash script [`setup.sh`](./setup.sh) (Note that reader assignment in the script might need a few attempts to succeed).
 
 Finally, to start the E2E tests, execute the following commands:
+
 ```bash
 cd $GOPATH/src/github.com/Azure/aad-pod-identity
 
@@ -40,10 +54,10 @@ dep ensure
 make e2e
 ```
 
-
 ## Identity Validator
 
 During the E2E test run, the image [`identityvalidator`](../../images/identityvalidator/Dockerfile) is deployed as a Kubernetes deployment to the cluster to validate the pod identity. The binary `identityvalidator` within the pod is essentially the compiled version of [`identityvalidator.go`](identityvalidator/identityvalidator.go). If the binary execution returns an exit status of 0, it means that the pod identity and its binding are working properly. Otherwise, it means that the pod identity is not established. You can manually try out the identity validator by executing the following command:
+
 ```bash
 # Deploy aad pod identity infra and create an identity validator deployment (make sure the go template parameters are replaced by the desired values)
 kubectl apply -f ../../deploy/infra/deployment-rbac.yaml

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,16 +27,19 @@ export KEYVAULT_SECRET_NAME='...'
 # The version of the secret inserted into the keyvault
 export KEYVAULT_SECRET_VERSION='...'
 
-# The registry where to get the images from. Use "mcr.microsoft.com/k8s/aad-pod-identity/" to run the tests with released images
+
+Optionally, to use custom images:
+
+# The registry where to get the images from. Defaults to `mcr.microsoft.com/k8s/aad-pod-identity/`.
 export REGISTRY='...'
 
-# The version of the NMI image to test
+# The version of the NMI image to test. Defaults to `1.4`.
 export NMI_VERSION='...'
 
-# The version of the MIC image to test
+# The version of the MIC image to test. Defaults to `1.3`.
 export MIC_VERSION='...'
 
-# The version of the identity validator to test
+# The version of the identity validator to test. Defaults to `1.4`.
 export IDENTITY_VALIDATOR_VERSION='...'
 
 ```
@@ -49,7 +52,7 @@ Finally, to start the E2E tests, execute the following commands:
 cd $GOPATH/src/github.com/Azure/aad-pod-identity
 
 # Ensure that the local project and the dependencies are in sync
-dep ensure
+make mod
 
 make e2e
 ```

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -560,7 +560,7 @@ func setUpIdentityAndDeployment(azureIdentityName, suffix string) {
 	err = azureidentitybinding.Create(azureIdentityName, templateOutputPath)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = deploy.CreateIdentityValidator(cfg.SubscriptionID, cfg.ResourceGroup, cfg.Registry, "identity-validator", "test-identity", cfg.IdentityValidatorVersion, templateOutputPath)
+	err = deploy.CreateIdentityValidator(cfg.SubscriptionID, cfg.ResourceGroup, cfg.Registry, identityValidator, "test-identity", cfg.IdentityValidatorVersion, templateOutputPath)
 	Expect(err).NotTo(HaveOccurred())
 
 	ok, err := deploy.WaitOnReady(identityValidatorName)

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -56,7 +56,7 @@ var _ = AfterSuite(func() {
 	fmt.Println("\nTearing down the test suite environment...")
 
 	// Uninstall CRDs and delete MIC and NMI
-	err := deploy.Delete("default-deployment-rbac.yaml", templateOutputPath)
+	err := deploy.Delete("default", templateOutputPath)
 	Expect(err).NotTo(HaveOccurred())
 
 	cmd = exec.Command("kubectl", "delete", "deploy", "--all")

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -44,8 +44,9 @@ var _ = BeforeSuite(func() {
 	err := os.Mkdir(templateOutputPath, os.ModePerm)
 	Expect(err).NotTo(HaveOccurred())
 
-	cfg, err := config.ParseConfig()
+	c, err := config.ParseConfig()
 	Expect(err).NotTo(HaveOccurred())
+	cfg = *c
 
 	// Install CRDs and deploy MIC and NMI
 	err = deploy.CreateInfra("default", cfg.Registry, cfg.NMIVersion, cfg.MICVersion, templateOutputPath)

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -28,7 +28,7 @@ import (
 const (
 	clusterIdentity   = "cluster-identity"
 	keyvaultIdentity  = "keyvault-identity"
-	identityValidator = "identity-validator-deployment.yaml"
+	identityValidator = "identity-validator"
 )
 
 var (
@@ -560,7 +560,7 @@ func setUpIdentityAndDeployment(azureIdentityName, suffix string) {
 	err = azureidentitybinding.Create(azureIdentityName, templateOutputPath)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = deploy.CreateIdentityValidator(cfg.SubscriptionID, cfg.ResourceGroup, cfg.Registry, azureIdentityName, templateOutputPath)
+	err = deploy.CreateIdentityValidator(cfg.SubscriptionID, cfg.ResourceGroup, cfg.Registry, "identity-validator", "test-identity", cfg.IdentityValidatorVersion, templateOutputPath)
 	Expect(err).NotTo(HaveOccurred())
 
 	ok, err := deploy.WaitOnReady(identityValidatorName)

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -59,7 +59,7 @@ var _ = AfterSuite(func() {
 	err := deploy.Delete("default", templateOutputPath)
 	Expect(err).NotTo(HaveOccurred())
 
-	cmd = exec.Command("kubectl", "delete", "deploy", "--all")
+	cmd := exec.Command("kubectl", "delete", "deploy", "--all")
 	util.PrintCommand(cmd)
 	_, err = cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -10,10 +10,10 @@ type Config struct {
 	KeyvaultName             string `envconfig:"KEYVAULT_NAME"`
 	KeyvaultSecretName       string `envconfig:"KEYVAULT_SECRET_NAME"`
 	KeyvaultSecretVersion    string `envconfig:"KEYVAULT_SECRET_VERSION"`
-	MICVersion               string `envconfig:"MIC_VERSION"`
-	NMIVersion               string `envconfig:"NMI_VERSION"`
-	Registry                 string `envconfig:"REGISTRY"`
-	IdentityValidatorVersion string `envconfig:"IDENTITY_VALIDATOR_VERSION"`
+	MICVersion               string `envconfig:"MIC_VERSION" default:"1.3"`
+	NMIVersion               string `envconfig:"NMI_VERSION" default:"1.4"`
+	Registry                 string `envconfig:"REGISTRY" default:"mcr.microsoft.com/k8s/aad-pod-identity"`
+	IdentityValidatorVersion string `envconfig:"IDENTITY_VALIDATOR_VERSION" default:"1.4"`
 }
 
 // ParseConfig will parse needed environment variables for running the tests

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -4,12 +4,16 @@ import "github.com/kelseyhightower/envconfig"
 
 // Config holds global test configuration translated from environment variables
 type Config struct {
-	SubscriptionID        string `envconfig:"SUBSCRIPTION_ID"`
-	ResourceGroup         string `envconfig:"RESOURCE_GROUP"`
-	AzureClientID         string `envconfig:"AZURE_CLIENT_ID"`
-	KeyvaultName          string `envconfig:"KEYVAULT_NAME"`
-	KeyvaultSecretName    string `envconfig:"KEYVAULT_SECRET_NAME"`
-	KeyvaultSecretVersion string `envconfig:"KEYVAULT_SECRET_VERSION"`
+	SubscriptionID           string `envconfig:"SUBSCRIPTION_ID"`
+	ResourceGroup            string `envconfig:"RESOURCE_GROUP"`
+	AzureClientID            string `envconfig:"AZURE_CLIENT_ID"`
+	KeyvaultName             string `envconfig:"KEYVAULT_NAME"`
+	KeyvaultSecretName       string `envconfig:"KEYVAULT_SECRET_NAME"`
+	KeyvaultSecretVersion    string `envconfig:"KEYVAULT_SECRET_VERSION"`
+	MICVersion               string `envconfig:"MIC_VERSION"`
+	NMIVersion               string `envconfig:"NMI_VERSION"`
+	Registry                 string `envconfig:"REGISTRY"`
+	IdentityValidatorVersion string `envconfig:"IDENTITY_VALIDATOR_VERSION"`
 }
 
 // ParseConfig will parse needed environment variables for running the tests

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -1,0 +1,191 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-id-nmi-service-account
+  namespace: {{.Namespace}}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureassignedidentities.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureAssignedIdentity
+    plural: azureassignedidentities
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentitybindings.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentityBinding
+    plural: azureidentitybindings
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentities.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentity
+    singular: azureidentity
+    plural: azureidentities
+  scope: Namespaced
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-id-nmi-role
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-id-nmi-binding
+  labels:
+    k8s-app: aad-pod-id-nmi-binding
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-id-nmi-service-account
+  namespace: {{.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-id-nmi-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    component: nmi
+    tier: node
+    k8s-app: aad-pod-id
+  name: nmi
+  namespace: {{.Namespace}}
+spec:
+  template:
+    metadata:
+      labels:
+        component: nmi
+        tier: node
+    spec:
+      serviceAccountName: aad-pod-id-nmi-service-account
+      hostNetwork: true
+      containers:
+      - name: nmi
+        image: "{{.Registry}}/nmi:{{.NMIVersion}}"
+        imagePullPolicy: Always
+        args:
+          - "--host-ip=$(HOST_IP)"
+          - "--node=$(NODE_NAME)"
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-id-mic-service-account
+  namespace: {{.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-id-mic-role
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: [ "list", "watch" ]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list", "watch", "post"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-id-mic-binding
+  labels:
+    k8s-app: aad-pod-id-mic-binding
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-id-mic-service-account
+  namespace: {{.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-id-mic-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: mic
+    k8s-app: aad-pod-id
+  name: mic
+  namespace: {{.Namespace}}
+spec:
+  template:
+    metadata:
+      labels:
+        component: mic
+    spec:
+      serviceAccountName: aad-pod-id-mic-service-account
+      containers:
+      - name: mic
+        image: "{{.Registry}}/mic:{{.MICVersion}}"
+        imagePullPolicy: Always
+        args:
+          - "--cloudconfig=/etc/kubernetes/azure.json"
+          - "--logtostderr"
+        volumeMounts:
+          - name: k8s-azure-file
+            mountPath: /etc/kubernetes/azure.json
+            readOnly: true
+      volumes:
+      - name: k8s-azure-file
+        hostPath:
+          path: /etc/kubernetes/azure.json

--- a/test/e2e/template/deployment.yaml
+++ b/test/e2e/template/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: mcr.microsoft.com/k8s/aad-pod-identity/identityvalidator:1.4
+        image: {{.Registry}}/identityvalidator:{{.IdentityValidatorVersion}}
         command:
           - sleep
           - "3600"


### PR DESCRIPTION
Based on #129 from @pjbgf 

The former E2E tests were being executed against the publicly available docker images, instead of using the images generated locally and published into custom container registry. Making it easier for new contributors to support this project.

New ENV config variables:

REGISTRY 
NMI_VERSION
MIC_VERSION
IDENTITY_VALIDATOR_VERSION

Once the environment variables are set, changes can be built and tested in a cluster with:
make build && make image && make push && make e2e