### PR TITLE
Performance  Improvement - reduce identity assignment time

### DIFF
--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -118,6 +118,28 @@ func TestSimple(t *testing.T) {
 				cloudClient.PrintMSI(t)
 				t.Error("MSI mismatch")
 			}
+
+			// test the UpdateUserMSI interface
+			cloudClient.UpdateUserMSI([]string{"ID1", "ID2", "ID3"}, []string{"ID0again"}, node0)
+			testMSI = []string{"ID1", "ID2", "ID3"}
+			if !cloudClient.CompareMSI(node0, testMSI) {
+				cloudClient.PrintMSI(t)
+				t.Error("MSI mismatch")
+			}
+
+			cloudClient.UpdateUserMSI(nil, []string{"ID3"}, node3)
+			testMSI = []string{}
+			if !cloudClient.CompareMSI(node3, testMSI) {
+				cloudClient.PrintMSI(t)
+				t.Error("MSI mismatch")
+			}
+
+			cloudClient.UpdateUserMSI([]string{"ID3"}, nil, node4)
+			testMSI = []string{"ID4", "ID3"}
+			if !cloudClient.CompareMSI(node4, testMSI) {
+				cloudClient.PrintMSI(t)
+				t.Error("MSI mismatch")
+			}
 		})
 	}
 }

--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -36,7 +36,7 @@ func filterUserIdentity(idType *compute.ResourceIdentityType, idList *[]string, 
 	case compute.ResourceIdentityTypeUserAssigned,
 		compute.ResourceIdentityTypeSystemAssignedUserAssigned:
 	default:
-		return errNotFound
+		return nil
 	}
 
 	origLen := len(*idList)

--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -21,6 +21,7 @@ type IdentityHolder interface {
 type IdentityInfo interface {
 	AppendUserIdentity(id string) bool
 	RemoveUserIdentity(id string) error
+	GetUserIdentityList() []string
 }
 
 var (
@@ -78,10 +79,8 @@ func appendUserIdentity(idType *compute.ResourceIdentityType, idList *[]string, 
 	switch *idType {
 	case compute.ResourceIdentityTypeUserAssigned, compute.ResourceIdentityTypeSystemAssignedUserAssigned:
 		// check if this ID is already in the list
-		for _, id := range *idList {
-			if id == newID {
-				return false
-			}
+		if checkIfIDInList(*idList, newID) {
+			return false
 		}
 	case compute.ResourceIdentityTypeSystemAssigned:
 		*idType = compute.ResourceIdentityTypeSystemAssignedUserAssigned
@@ -91,4 +90,13 @@ func appendUserIdentity(idType *compute.ResourceIdentityType, idList *[]string, 
 
 	*idList = append(*idList, newID)
 	return true
+}
+
+func checkIfIDInList(idList []string, desiredID string) bool {
+	for _, id := range idList {
+		if id == desiredID {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cloudprovider/identity_test.go
+++ b/pkg/cloudprovider/identity_test.go
@@ -9,8 +9,8 @@ import (
 func TestFilterIdentity(t *testing.T) {
 	idList := []string{}
 	idType := compute.ResourceIdentityTypeNone
-	if err := filterUserIdentity(&idType, &idList, "A"); err == nil || err != errNotFound {
-		t.Fatalf("expected error %q, got: %v", errNotFound, err)
+	if err := filterUserIdentity(&idType, &idList, "A"); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
 	}
 
 	idType = compute.ResourceIdentityTypeUserAssigned

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -115,3 +115,7 @@ func (i *vmIdentityInfo) AppendUserIdentity(id string) bool {
 	}
 	return appendUserIdentity(&i.info.Type, i.info.IdentityIds, id)
 }
+
+func (i *vmIdentityInfo) GetUserIdentityList() []string {
+	return *i.info.IdentityIds
+}

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -121,3 +121,7 @@ func (i *vmssIdentityInfo) AppendUserIdentity(id string) bool {
 	}
 	return appendUserIdentity(&i.info.Type, i.info.IdentityIds, id)
 }
+
+func (i *vmssIdentityInfo) GetUserIdentityList() []string {
+	return *i.info.IdentityIds
+}

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -698,14 +698,14 @@ func (c *Client) updateUserMSI(newAssignedIDs []aadpodid.AzureAssignedIdentity, 
 			removedBinding := delID.Spec.AzureBindingRef
 			isUserAssignedMSI := c.checkIfUserAssignedMSI(id)
 			idExistsOnNode := c.checkIfMSIExistsOnNode(id, delID.Spec.NodeName, idList)
-			vmssGroups, err := getVMSSGroups(c.NodeClient, nodeRefs)
-			if err != nil {
-				glog.Error(err)
+			vmssGroups, getErr := getVMSSGroups(c.NodeClient, nodeRefs)
+			if getErr != nil {
+				glog.Error(getErr)
 				continue
 			}
-			inUse, err := c.checkIfInUse(delID, newAssignedIDs, vmssGroups)
-			if err != nil {
-				glog.Error(err)
+			inUse, checkErr := c.checkIfInUse(delID, newAssignedIDs, vmssGroups)
+			if checkErr != nil {
+				glog.Error(checkErr)
 				continue
 			}
 			// the identity still exists on node, which means removing the identity from the node failed

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -157,7 +157,6 @@ func (c *Client) Sync(exit <-chan struct{}) {
 		begin := time.Now()
 		workDone := false
 		glog.V(6).Infof("Received event: %v", event)
-		fmt.Printf("Received event: %v\n", event)
 		// List all pods in all namespaces
 		systemTime := time.Now()
 		listPods, err := c.PodClient.GetPods()
@@ -262,7 +261,6 @@ func (c *Client) Sync(exit <-chan struct{}) {
 		}
 
 		glog.V(5).Infof("del: %v, add: %v", deleteList, addList)
-		fmt.Printf("del: %v, add: %v\n", deleteList, addList)
 
 		nodeMap := make(map[string]trackUserAssignedMSIIds)
 
@@ -557,8 +555,6 @@ func (c *Client) handleNodeErrors(nodesWithError []string, addList, deleteList *
 		nodeIdentityList[n] = idList
 	}
 
-	fmt.Println("nodes with error ", nodesWithError)
-	fmt.Println("node identity list ", nodeIdentityList)
 	isNodeErrored := func(node string) bool {
 		for _, n := range nodesWithError {
 			if n == node {
@@ -630,7 +626,6 @@ func (c *Client) handleNodeErrors(nodesWithError []string, addList, deleteList *
 			}
 
 			if isUserAssignedMSI && !inUse {
-				fmt.Println("coming in here")
 				message := fmt.Sprintf("Binding %s removal from node %s for pod %s failed", removedBinding.Name, delID.Spec.NodeName, delID.Spec.Pod)
 				c.EventRecorder.Event(removedBinding, corev1.EventTypeWarning, "binding remove error", message)
 				glog.Error(message)

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -33,9 +33,10 @@ type TestCloudClient struct {
 type TestVMClient struct {
 	*cp.VMClient
 
-	mu      sync.Mutex
-	nodeMap map[string]*compute.VirtualMachine
-	err     *error
+	mu       sync.Mutex
+	nodeMap  map[string]*compute.VirtualMachine
+	err      *error
+	identity *compute.VirtualMachineIdentity
 }
 
 func (c *TestVMClient) SetError(err error) {
@@ -64,7 +65,7 @@ func (c *TestVMClient) CreateOrUpdate(rg string, nodeName string, vm compute.Vir
 	defer c.mu.Unlock()
 
 	if c.err != nil {
-		c.nodeMap[nodeName].Identity = nil
+		c.nodeMap[nodeName].Identity = c.identity
 		return *c.err
 	}
 	c.nodeMap[nodeName] = &vm
@@ -107,9 +108,10 @@ func (c *TestVMClient) CompareMSI(nodeName string, userIDs []string) bool {
 type TestVMSSClient struct {
 	*cp.VMSSClient
 
-	mu      sync.Mutex
-	nodeMap map[string]*compute.VirtualMachineScaleSet
-	err     *error
+	mu       sync.Mutex
+	nodeMap  map[string]*compute.VirtualMachineScaleSet
+	err      *error
+	identity *compute.VirtualMachineScaleSetIdentity
 }
 
 func (c *TestVMSSClient) SetError(err error) {
@@ -138,6 +140,7 @@ func (c *TestVMSSClient) CreateOrUpdate(rg string, nodeName string, vm compute.V
 	defer c.mu.Unlock()
 
 	if c.err != nil {
+		c.nodeMap[nodeName].Identity = c.identity
 		return *c.err
 	}
 	c.nodeMap[nodeName] = &vm
@@ -211,20 +214,24 @@ func (c *TestCloudClient) UnSetError() {
 func NewTestVMClient() *TestVMClient {
 	nodeMap := make(map[string]*compute.VirtualMachine)
 	vmClient := &cp.VMClient{}
+	identity := &compute.VirtualMachineIdentity{IdentityIds: &[]string{}}
 
 	return &TestVMClient{
 		VMClient: vmClient,
 		nodeMap:  nodeMap,
+		identity: identity,
 	}
 }
 
 func NewTestVMSSClient() *TestVMSSClient {
 	nodeMap := make(map[string]*compute.VirtualMachineScaleSet)
 	vmssClient := &cp.VMSSClient{}
+	identity := &compute.VirtualMachineScaleSetIdentity{IdentityIds: &[]string{}}
 
 	return &TestVMSSClient{
 		VMSSClient: vmssClient,
 		nodeMap:    nodeMap,
+		identity:   identity,
 	}
 }
 
@@ -272,7 +279,7 @@ func (c *TestPodClient) GetPods() ([]*corev1.Pod, error) {
 	return pods, nil
 }
 
-func (c *TestPodClient) AddPod(podName string, podNs string, nodeName string, binding string) {
+func (c *TestPodClient) AddPod(podName, podNs, nodeName, binding string) {
 	labels := make(map[string]string)
 	labels[aadpodid.CRDLabelKey] = binding
 	pod := &corev1.Pod{
@@ -319,6 +326,7 @@ type TestCrdClient struct {
 	assignedIDMap map[string]*aadpodid.AzureAssignedIdentity
 	bindingMap    map[string]*aadpodid.AzureIdentityBinding
 	idMap         map[string]*aadpodid.AzureIdentity
+	err           *error
 }
 
 func NewTestCrdClient(config *rest.Config) *TestCrdClient {
@@ -342,8 +350,12 @@ func (c *TestCrdClient) CreateCrdWatchers(eventCh chan aadpodid.EventType) (err 
 
 func (c *TestCrdClient) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) error {
 	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.err != nil {
+		return *c.err
+	}
 	delete(c.assignedIDMap, assignedIdentity.Name)
-	c.mu.Unlock()
 	return nil
 }
 
@@ -354,6 +366,13 @@ func (c *TestCrdClient) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureA
 	c.mu.Lock()
 	c.assignedIDMap[assignedIdentity.Name] = &assignedIdentityToStore
 	c.mu.Unlock()
+	return nil
+}
+
+func (c *TestCrdClient) UpdateAzureAssignedIdentityStatus(assignedIdentity *aadpodid.AzureAssignedIdentity, status string) error {
+	assignedIdentity.Status.Status = status
+	assignedIdentityToStore := *assignedIdentity //Make a copy to store in the map.
+	c.assignedIDMap[assignedIdentity.Name] = &assignedIdentityToStore
 	return nil
 }
 
@@ -421,8 +440,17 @@ func (c *TestCrdClient) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity
 	c.mu.Unlock()
 	return &assignedIDList, nil
 }
+
 func (c *Client) ListPodIds(podns, podname string) (*[]aadpodid.AzureIdentity, error) {
 	return &[]aadpodid.AzureIdentity{}, nil
+}
+
+func (c *TestCrdClient) SetError(err error) {
+	c.err = &err
+}
+
+func (c *TestCrdClient) UnSetError() {
+	c.err = nil
 }
 
 /************************ NODE MOCK *************************************/
@@ -713,8 +741,8 @@ func TestSimpleMICClient(t *testing.T) {
 		t.Fatalf("list assigned failed")
 	}
 
-	if len(*listAssignedIDs) != 0 {
-		t.Fatalf("ID assigned")
+	if (*listAssignedIDs)[0].Status.Status != IdentityCreated {
+		t.Fatalf("expected status to be %s, got: %s", IdentityCreated, (*listAssignedIDs)[0].Status.Status)
 	}
 
 	/*
@@ -880,6 +908,14 @@ func TestMicAddDelVMSS(t *testing.T) {
 	if !evtRecorder.WaitForEvents(3) {
 		t.Fatalf("Timeout waiting for mic sync cycles")
 	}
+	listAssignedIDs, err := crdClient.ListAssignedIDs()
+	if err != nil {
+		glog.Error(err)
+		t.Errorf("list assigned failed")
+	}
+	if !(len(*listAssignedIDs) == 3) {
+		t.Fatalf("expected assigned identities len: %d, got: %d", 3, len(*listAssignedIDs))
+	}
 
 	if !cloudClient.CompareMSI("testvmss1", []string{"test-user-msi-resourceid"}) {
 		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss1"])
@@ -894,6 +930,14 @@ func TestMicAddDelVMSS(t *testing.T) {
 	if !evtRecorder.WaitForEvents(1) {
 		t.Fatal("Timeout waiting for mic sync cycles")
 	}
+	listAssignedIDs, err = crdClient.ListAssignedIDs()
+	if err != nil {
+		glog.Error(err)
+		t.Errorf("list assigned failed")
+	}
+	if !(len(*listAssignedIDs) == 2) {
+		t.Fatalf("expected assigned identities len: %d, got: %d", 2, len(*listAssignedIDs))
+	}
 
 	if !cloudClient.CompareMSI("testvmss1", []string{"test-user-msi-resourceid"}) {
 		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss1"])
@@ -903,9 +947,19 @@ func TestMicAddDelVMSS(t *testing.T) {
 	}
 
 	podClient.DeletePod("test-pod2", "default")
+
 	eventCh <- aadpodid.PodDeleted
+
 	if !evtRecorder.WaitForEvents(1) {
 		t.Fatal("Timeout waiting for mic sync cycles")
+	}
+	listAssignedIDs, err = crdClient.ListAssignedIDs()
+	if err != nil {
+		glog.Error(err)
+		t.Errorf("list assigned failed")
+	}
+	if !(len(*listAssignedIDs) == 1) {
+		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
 	}
 
 	if !cloudClient.CompareMSI("testvmss1", []string{}) {
@@ -913,6 +967,117 @@ func TestMicAddDelVMSS(t *testing.T) {
 	}
 	if !cloudClient.CompareMSI("testvmss2", []string{"test-user-msi-resourceid"}) {
 		t.Fatalf("missing identity: %+v", cloudClient.ListMSI()["testvmss2"])
+	}
+}
+
+func TestMICStateFlow(t *testing.T) {
+	eventCh := make(chan aadpodid.EventType, 100)
+	cloudClient := NewTestCloudClient(config.AzureConfig{})
+	crdClient := NewTestCrdClient(nil)
+	podClient := NewTestPodClient()
+	nodeClient := NewTestNodeClient()
+	var evtRecorder TestEventRecorder
+	evtRecorder.lastEvent = new(LastEvent)
+	evtRecorder.eventChannel = make(chan bool, 100)
+
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder)
+
+	// Add a pod, identity and binding.
+	crdClient.CreateID("test-id1", aadpodid.UserAssignedMSI, "test-user-msi-resourceid", "test-user-msi-clientid", nil, "", "", "")
+	crdClient.CreateBinding("testbinding1", "test-id1", "test-select1")
+
+	nodeClient.AddNode("test-node1")
+	podClient.AddPod("test-pod1", "default", "test-node1", "test-select1")
+
+	eventCh <- aadpodid.PodCreated
+	defer micClient.testRunSync()(t)
+
+	if !evtRecorder.WaitForEvents(1) {
+		t.Fatalf("Timeout waiting for mic sync cycles")
+	}
+	listAssignedIDs, err := crdClient.ListAssignedIDs()
+	if err != nil {
+		glog.Error(err)
+		t.Errorf("list assigned failed")
+	}
+	if !(len(*listAssignedIDs) == 1) {
+		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
+	}
+	if !((*listAssignedIDs)[0].Status.Status == IdentityAssigned) {
+		t.Fatalf("expected status to be %s, got: %s", IdentityCreated, (*listAssignedIDs)[0].Status.Status)
+	}
+
+	// delete the pod, simulate failure in cloud calls on trying to un-assign identity from node
+	podClient.DeletePod("test-pod1", "default")
+	cloudClient.SetError(errors.New("error removing identity from node"))
+	cloudClient.testVMClient.identity = nil
+
+	eventCh <- aadpodid.PodDeleted
+	if !evtRecorder.WaitForEvents(1) {
+		t.Fatalf("Timeout waiting for mic sync cycles")
+	}
+	listAssignedIDs, err = crdClient.ListAssignedIDs()
+	if err != nil {
+		glog.Error(err)
+		t.Errorf("list assigned failed")
+	}
+	if !(len(*listAssignedIDs) == 1) {
+		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
+	}
+	if !((*listAssignedIDs)[0].Status.Status == IdentityAssigned) {
+		t.Fatalf("expected status to be %s, got: %s", IdentityCreated, (*listAssignedIDs)[0].Status.Status)
+	}
+
+	cloudClient.UnSetError()
+	crdClient.SetError(errors.New("error from crd client"))
+
+	// add new pod, this time the old assigned identity which is in Assigned state should be tried to delete
+	// simulate failure on kube api call to delete crd
+	crdClient.CreateID("test-id2", aadpodid.UserAssignedMSI, "test-user-msi-resourceid2", "test-user-msi-clientid2", nil, "", "", "")
+	crdClient.CreateBinding("testbinding2", "test-id2", "test-select2")
+
+	nodeClient.AddNode("test-node2")
+	podClient.AddPod("test-pod2", "default", "test-node2", "test-select2")
+
+	eventCh <- aadpodid.PodCreated
+	if !evtRecorder.WaitForEvents(2) {
+		t.Fatalf("Timeout waiting for mic sync cycles")
+	}
+	listAssignedIDs, err = crdClient.ListAssignedIDs()
+	if err != nil {
+		glog.Error(err)
+		t.Errorf("list assigned failed")
+	}
+	if !(len(*listAssignedIDs) == 2) {
+		t.Fatalf("expected assigned identities len: %d, got: %d", 2, len(*listAssignedIDs))
+	}
+	for _, assignedID := range *listAssignedIDs {
+		if assignedID.Spec.Pod == "test-pod1" {
+			if assignedID.Status.Status != IdentityUnassigned {
+				t.Fatalf("Expected status to be: %s. Got: %s", IdentityUnassigned, assignedID.Status.Status)
+			}
+		}
+		if assignedID.Spec.Pod == "test-pod2" {
+			if assignedID.Status.Status != IdentityAssigned {
+				t.Fatalf("Expected status to be: %s. Got: %s", IdentityAssigned, assignedID.Status.Status)
+			}
+		}
+	}
+	crdClient.UnSetError()
+
+	// delete pod2 and everything should be cleaned up now
+	podClient.DeletePod("test-pod2", "default")
+	eventCh <- aadpodid.PodDeleted
+	if !evtRecorder.WaitForEvents(2) {
+		t.Fatalf("Timeout waiting for mic sync cycles")
+	}
+	listAssignedIDs, err = crdClient.ListAssignedIDs()
+	if err != nil {
+		glog.Error(err)
+		t.Errorf("list assigned failed")
+	}
+	if !(len(*listAssignedIDs) == 0) {
+		t.Fatalf("expected assigned identities len: %d, got: %d", 0, len(*listAssignedIDs))
 	}
 }
 

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -64,9 +64,9 @@ func (c *TestVMClient) CreateOrUpdate(rg string, nodeName string, vm compute.Vir
 	defer c.mu.Unlock()
 
 	if c.err != nil {
+		c.nodeMap[nodeName].Identity = nil
 		return *c.err
 	}
-
 	c.nodeMap[nodeName] = &vm
 	return nil
 }
@@ -703,6 +703,7 @@ func TestSimpleMICClient(t *testing.T) {
 	cloudClient.SetError(err)
 
 	podClient.AddPod("test-pod", "default", "test-node", "test-select")
+
 	eventCh <- aadpodid.PodCreated
 	evtRecorder.WaitForEvents(1)
 
@@ -725,7 +726,7 @@ func TestSimpleMICClient(t *testing.T) {
 		} */
 
 	// Test4: Removal error event test
-	//Reset the state to add the id.
+	// Reset the state to add the id.
 	cloudClient.UnSetError()
 
 	//podClient.AddPod("test-pod", "default", "test-node", "test-select")

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -1013,9 +1013,7 @@ func TestMICStateFlow(t *testing.T) {
 	cloudClient.testVMClient.identity = nil
 
 	eventCh <- aadpodid.PodDeleted
-	if !evtRecorder.WaitForEvents(1) {
-		t.Fatalf("Timeout waiting for mic sync cycles")
-	}
+
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
 		glog.Error(err)
@@ -1025,7 +1023,7 @@ func TestMICStateFlow(t *testing.T) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
 	}
 	if !((*listAssignedIDs)[0].Status.Status == IdentityAssigned) {
-		t.Fatalf("expected status to be %s, got: %s", IdentityCreated, (*listAssignedIDs)[0].Status.Status)
+		t.Fatalf("expected status to be %s, got: %s", IdentityAssigned, (*listAssignedIDs)[0].Status.Status)
 	}
 
 	cloudClient.UnSetError()

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -78,7 +78,9 @@ func (c *TestVMClient) ListMSI() (ret map[string]*[]string) {
 	defer c.mu.Unlock()
 
 	for key, val := range c.nodeMap {
-		ret[key] = val.Identity.IdentityIds
+		if val.Identity != nil {
+			ret[key] = val.Identity.IdentityIds
+		}
 	}
 	return ret
 }
@@ -793,7 +795,7 @@ func TestAddDelMICClient(t *testing.T) {
 		t.Fatalf("Add and delete id at same time mismatch")
 	}
 
-	//Delete the pod
+	// Delete the pod
 	podClient.DeletePod("test-pod2", "default")
 	podClient.DeletePod("test-pod4", "default")
 

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -28,6 +28,7 @@ const (
 	AssignedIDAdd        StatsType = "Assigned ID addition"
 	TotalIDDel           StatsType = "Total time to delete assigned IDs"
 	TotalIDAdd           StatsType = "Total time to add assigned IDs"
+	TotalCreateOrUpdate  StatsType = "Total time to assign or remove IDs"
 
 	EventRecord StatsType = "Event recording"
 )
@@ -77,8 +78,7 @@ func PrintSync() {
 		Print(FindAssignedIDCreate)
 		Print(FindAssignedIDDel)
 
-		Print(TotalIDAdd)
-		Print(TotalIDDel)
+		Print(TotalCreateOrUpdate)
 
 		Print(EventRecord)
 		Print(Total)

--- a/test/common/k8s/azureassignedidentity/azureassignedidentity.go
+++ b/test/common/k8s/azureassignedidentity/azureassignedidentity.go
@@ -46,10 +46,32 @@ func GetByPrefix(prefix string) (aadpodid.AzureAssignedIdentity, error) {
 	return aadpodid.AzureAssignedIdentity{}, errors.Errorf("No AzureAssignedIdentity has a name prefix with '%s'", prefix)
 }
 
+// GetAllByPrefix will return all AzureAssignedIdentity with matched prefix
+func GetAllByPrefix(prefix string) ([]aadpodid.AzureAssignedIdentity, error) {
+	var aaidList []aadpodid.AzureAssignedIdentity
+	list, err := GetAll()
+	if err != nil {
+		return aaidList, err
+	}
+
+	for _, azureAssignedIdentity := range list.Items {
+		if strings.HasPrefix(azureAssignedIdentity.ObjectMeta.Name, prefix) {
+			aaidList = append(aaidList, azureAssignedIdentity)
+		}
+	}
+
+	if len(aaidList) < 1 {
+		err = errors.Errorf("No AzureAssignedIdentity has a name prefix with '%s'", prefix)
+	}
+
+	return aaidList, err
+}
+
 // WaitOnLengthMatched will block until the number of Azure Assigned Identity matches the target
 func WaitOnLengthMatched(target int) (bool, error) {
 	successChannel, errorChannel := make(chan bool, 1), make(chan error)
-	duration, sleep := 70*time.Second, 10*time.Second
+	// defining ~2 mins as an acceptable timeframe for ids to be assigned to node
+	duration, sleep := 120*time.Second, 10*time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 

--- a/test/common/k8s/infra/infra.go
+++ b/test/common/k8s/infra/infra.go
@@ -60,13 +60,13 @@ func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath
 }
 
 // CreateIdentityValidator will create an identity validator deployment on a Kubernetes cluster
-func CreateIdentityValidator(subscriptionID, resourceGroup, registryName, name, identityBinding, identityValidatorVersion, templateOutputPath string) error {
+func CreateIdentityValidator(subscriptionID, resourceGroup, registryName, deploymentName, identityBinding, identityValidatorVersion, templateOutputPath, replicas string) error {
 	t, err := template.New("deployment.yaml").ParseFiles(path.Join("template", "deployment.yaml"))
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse deployment.yaml")
 	}
 
-	deployFilePath := path.Join(templateOutputPath, name+"-deployment.yaml")
+	deployFilePath := path.Join(templateOutputPath, deploymentName+"-deployment.yaml")
 	deployFile, err := os.Create(deployFilePath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create a deployment file from deployment.yaml")
@@ -79,11 +79,13 @@ func CreateIdentityValidator(subscriptionID, resourceGroup, registryName, name, 
 		IdentityBinding          string
 		Registry                 string
 		IdentityValidatorVersion string
+		Replicas                 string
 	}{
-		name,
+		deploymentName,
 		identityBinding,
 		registryName,
 		identityValidatorVersion,
+		replicas,
 	}
 	if err := t.Execute(deployFile, deployData); err != nil {
 		return errors.Wrap(err, "Failed to create a deployment file from deployment.yaml")

--- a/test/e2e/template/deployment.yaml
+++ b/test/e2e/template/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{.Name}}
   namespace: default
 spec:
+  replicas: {{.Replicas}}
   template:
     metadata:
       labels:


### PR DESCRIPTION
resolves 
https://github.com/Azure/aad-pod-identity/issues/145
https://github.com/Azure/aad-pod-identity/issues/181
https://github.com/Azure/aad-pod-identity/issues/217

- Batch process id assignments to node on each sync cycle (pooling delete and add ids, issuing one CreateOrUpdate call for each sync cycle)
- Reduces identity assignment for 44 pods from 29m to ~3m

Add states to the assigned identities
1. Created - assigned identity will be in created state when the crd is created.
2. Assigned - once the identity has been successfully assigned to underlying node, the state of the assigned identity will be changed to Assigned.
3. Unassigned - the assigned identity will be in this state when the identity has been successfully removed from the underlying node.

**Note**
1. Assigned identities will be created and then the identity will be tried to be assigned to the node. If assignment fails, then the identity will be deleted. No change in this behavior compared to previous version.
2. Assigned identities will be deleted only after the identity has been successfully removed from the node. This is change in behavior from previous version to ensure we successfully remove the identities from the underlying node.