### PR TITLE
fix deployment template for e2e

### DIFF
--- a/test/common/k8s/deploy/deploy.go
+++ b/test/common/k8s/deploy/deploy.go
@@ -56,7 +56,7 @@ func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath
 	defer deployFile.Close()
 
 	// this arg is required only for these specific versions
-	// we can get remove this after next release
+	// we can remove this after next release
 	var micArg, nmiArg bool
 	micArg = micVersion == "1.3"
 	nmiArg = nmiVersion == "1.4"

--- a/test/common/k8s/deploy/deploy.go
+++ b/test/common/k8s/deploy/deploy.go
@@ -55,16 +55,26 @@ func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath
 	}
 	defer deployFile.Close()
 
+	// this arg is required only for these specific versions
+	// we can get remove this after next release
+	var micArg, nmiArg bool
+	micArg = micVersion == "1.3"
+	nmiArg = nmiVersion == "1.4"
+
 	deployData := struct {
 		Namespace  string
 		Registry   string
 		NMIVersion string
 		MICVersion string
+		MICArg     bool
+		NMIArg     bool
 	}{
 		namespace,
 		registry,
 		nmiVersion,
 		micVersion,
+		micArg,
+		nmiArg,
 	}
 	if err := t.Execute(deployFile, deployData); err != nil {
 		return errors.Wrap(err, "Failed to create a deployment file from deployment-rbac.yaml")

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -561,7 +561,7 @@ func setUpIdentityAndDeployment(azureIdentityName, suffix string) {
 	err = azureidentitybinding.Create(azureIdentityName, templateOutputPath)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = deploy.CreateIdentityValidator(cfg.SubscriptionID, cfg.ResourceGroup, cfg.Registry, identityValidator, "test-identity", cfg.IdentityValidatorVersion, templateOutputPath)
+	err = deploy.CreateIdentityValidator(cfg.SubscriptionID, cfg.ResourceGroup, cfg.Registry, identityValidator, azureIdentityName, cfg.IdentityValidatorVersion, templateOutputPath)
 	Expect(err).NotTo(HaveOccurred())
 
 	ok, err := deploy.WaitOnReady(identityValidatorName)

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -98,6 +98,7 @@ spec:
         image: "{{.Registry}}/nmi:{{.NMIVersion}}"
         imagePullPolicy: Always
         args:
+          {{if .NMIArg}}- nmi {{ end }}
           - "--host-ip=$(HOST_IP)"
           - "--node=$(NODE_NAME)"
         env:
@@ -179,6 +180,7 @@ spec:
         image: "{{.Registry}}/mic:{{.MICVersion}}"
         imagePullPolicy: Always
         args:
+          {{if .MICArg}}- mic {{ end }}
           - "--cloudconfig=/etc/kubernetes/azure.json"
           - "--logtostderr"
         volumeMounts:


### PR DESCRIPTION
This is needed because `mic:1.3` and `nmi:1.4` required the `- mic` and `- nmi` args. I'll remove these during next release.