### PR TITLE
List CRDs via cache and avoid extra work on pod update

### DIFF
--- a/pkg/apis/aadpodidentity/v1/types.go
+++ b/pkg/apis/aadpodidentity/v1/types.go
@@ -144,9 +144,9 @@ const (
 )
 
 const (
-	AzureIDResource        = "azureidentities"
-	AzureIDBindingResource = "azureidentitybindings"
-	AureAssignedIDResource = "azureassignedidentities"
+	AzureIDResource         = "azureidentities"
+	AzureIDBindingResource  = "azureidentitybindings"
+	AzureAssignedIDResource = "azureassignedidentities"
 )
 
 // AzureIdentityBindingSpec matches the pod with the Identity.

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/aad-pod-identity/pkg/stats"
 
 	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,9 +18,12 @@ import (
 )
 
 type Client struct {
-	rest           *rest.RESTClient
-	BindingWatcher cache.SharedInformer
-	IdWatcher      cache.SharedInformer
+	rest                *rest.RESTClient
+	BindingListWatch    *cache.ListWatch
+	BindingWatcher      cache.SharedInformer
+	IDListWatch         *cache.ListWatch
+	IdWatcher           cache.SharedInformer
+	AssignedIDListWatch *cache.ListWatch
 }
 
 type ClientInt interface {
@@ -52,22 +55,31 @@ func NewCRDClient(config *rest.Config, eventCh chan aadpodid.EventType) (crdClie
 		return nil, err
 	}
 
-	bindingWatcher, err := newBindingWatcher(restClient, eventCh)
+	bindingListWatch := newBindingListWatch(restClient)
+
+	bindingWatcher, err := newBindingWatcher(restClient, eventCh, bindingListWatch)
 	if err != nil {
 		glog.Error(err)
 		return nil, err
 	}
 
-	idWatcher, err := newIdWatcher(restClient, eventCh)
+	idListWatch := newIDListWatch(restClient)
+
+	idWatcher, err := newIdWatcher(restClient, eventCh, idListWatch)
 	if err != nil {
 		glog.Error(err)
 		return nil, err
 	}
+
+	assignedIDListWatch := newAssignedIDListWatch(restClient)
 
 	return &Client{
-		rest:           restClient,
-		BindingWatcher: bindingWatcher,
-		IdWatcher:      idWatcher,
+		rest:                restClient,
+		BindingListWatch:    bindingListWatch,
+		BindingWatcher:      bindingWatcher,
+		IdWatcher:           idWatcher,
+		IDListWatch:         idListWatch,
+		AssignedIDListWatch: assignedIDListWatch,
 	}, nil
 }
 
@@ -96,9 +108,13 @@ func newRestClient(config *rest.Config) (r *rest.RESTClient, err error) {
 	return restClient, nil
 }
 
-func newBindingWatcher(r *rest.RESTClient, eventCh chan aadpodid.EventType) (cache.SharedInformer, error) {
+func newBindingListWatch(r *rest.RESTClient) *cache.ListWatch {
+	return cache.NewListWatchFromClient(r, aadpodid.AzureIDBindingResource, v1.NamespaceAll, fields.Everything())
+}
+
+func newBindingWatcher(r *rest.RESTClient, eventCh chan aadpodid.EventType, lw *cache.ListWatch) (cache.SharedInformer, error) {
 	azBindingWatcher := cache.NewSharedInformer(
-		cache.NewListWatchFromClient(r, aadpodid.AzureIDBindingResource, v1.NamespaceAll, fields.Everything()),
+		lw,
 		&aadpodid.AzureIdentityBinding{},
 		time.Minute*10)
 	if azBindingWatcher == nil {
@@ -123,9 +139,13 @@ func newBindingWatcher(r *rest.RESTClient, eventCh chan aadpodid.EventType) (cac
 	return azBindingWatcher, nil
 }
 
-func newIdWatcher(r *rest.RESTClient, eventCh chan aadpodid.EventType) (cache.SharedInformer, error) {
+func newIDListWatch(r *rest.RESTClient) *cache.ListWatch {
+	return cache.NewListWatchFromClient(r, aadpodid.AzureIDResource, v1.NamespaceAll, fields.Everything())
+}
+
+func newIdWatcher(r *rest.RESTClient, eventCh chan aadpodid.EventType, lw *cache.ListWatch) (cache.SharedInformer, error) {
 	azIdWatcher := cache.NewSharedInformer(
-		cache.NewListWatchFromClient(r, aadpodid.AzureIDResource, v1.NamespaceAll, fields.Everything()),
+		lw,
 		&aadpodid.AzureIdentity{},
 		time.Minute*10)
 	if azIdWatcher == nil {
@@ -148,6 +168,10 @@ func newIdWatcher(r *rest.RESTClient, eventCh chan aadpodid.EventType) (cache.Sh
 		},
 	)
 	return azIdWatcher, nil
+}
+
+func newAssignedIDListWatch(r *rest.RESTClient) *cache.ListWatch {
+	return cache.NewListWatchFromClient(r, aadpodid.AzureAssignedIDResource, v1.NamespaceAll, fields.Everything())
 }
 
 func (c *Client) Start(exit <-chan struct{}) {
@@ -191,50 +215,48 @@ func (c *Client) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 
 func (c *Client) ListBindings() (res *[]aadpodid.AzureIdentityBinding, err error) {
 	begin := time.Now()
-	var ret aadpodid.AzureIdentityBindingList
-	err = c.rest.Get().Namespace(v1.NamespaceAll).Resource("azureidentitybindings").Do().Into(&ret)
+
+	ret, err := c.BindingListWatch.List(v1.ListOptions{})
 	if err != nil {
 		glog.Error(err)
 		return nil, err
 	}
 	stats.Update(stats.BindingList, time.Since(begin))
-	return &ret.Items, nil
+	return &ret.(*aadpodid.AzureIdentityBindingList).Items, nil
 }
 
 func (c *Client) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity, err error) {
 	begin := time.Now()
-	var ret aadpodid.AzureAssignedIdentityList
-	err = c.rest.Get().Namespace(v1.NamespaceAll).Resource("azureassignedidentities").Do().Into(&ret)
+	ret, err := c.AssignedIDListWatch.List(v1.ListOptions{})
 	if err != nil {
 		glog.Error(err)
 		return nil, err
 	}
 	stats.Update(stats.AssignedIDList, time.Since(begin))
-	return &ret.Items, nil
+	return &ret.(*aadpodid.AzureAssignedIdentityList).Items, nil
 }
 
 func (c *Client) ListIds() (res *[]aadpodid.AzureIdentity, err error) {
 	begin := time.Now()
-	var ret aadpodid.AzureIdentityList
-	err = c.rest.Get().Namespace(v1.NamespaceAll).Resource("azureidentities").Do().Into(&ret)
+	ret, err := c.IDListWatch.List(v1.ListOptions{})
 	if err != nil {
 		glog.Error(err)
 		return nil, err
 	}
 	stats.Update(stats.IDList, time.Since(begin))
-	return &ret.Items, nil
+	return &ret.(*aadpodid.AzureIdentityList).Items, nil
 }
 
 //ListPodIds - given a pod with pod name space
 func (c *Client) ListPodIds(podns, podname string) (*[]aadpodid.AzureIdentity, error) {
-	var azAssignedIDList aadpodid.AzureAssignedIdentityList
-	var matchedIds []aadpodid.AzureIdentity
-	err := c.rest.Get().Namespace(v1.NamespaceAll).Resource("azureassignedidentities").Do().Into(&azAssignedIDList)
+	azAssignedIDList, err := c.AssignedIDListWatch.List(v1.ListOptions{})
 	if err != nil {
 		glog.Error(err)
 		return nil, err
 	}
-	for _, v := range azAssignedIDList.Items {
+
+	var matchedIds []aadpodid.AzureIdentity
+	for _, v := range azAssignedIDList.(*aadpodid.AzureAssignedIdentityList).Items {
 		if v.Spec.Pod == podname && v.Spec.PodNamespace == podns {
 			matchedIds = append(matchedIds, *v.Spec.AzureIdentityRef)
 		}


### PR DESCRIPTION
Two main items:
        	- Utilize the client cache for listing of CRDs
		- Avoids going to API Server for every list call.
		- Resolve the part of #182 related to the API Server calls.
	- Avoid calling sync loop at every pod update. Only call where there is a change in scheduled node name.