### PR TITLE
fix: use buffered channel for os.Signal and other cleanup

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -131,12 +131,21 @@ func testInstanceMetadataRequests(logger *log.Entry) {
 		Timeout: time.Duration(2) * time.Second,
 	}
 	req, err := http.NewRequest("GET", "http://169.254.169.254/metadata/instance?api-version=2017-08-01", nil)
+	if err != nil {
+		logger.Error(err)
+		return
+	}
 	req.Header.Add("Metadata", "true")
 	resp, err := client.Do(req)
 	if err != nil {
-		logger.Errorf("failed, GET on instance metadata")
+		logger.Error(err)
+		return
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error(err)
+		return
+	}
 	logger.Infof("succesfully made GET on instance metadata, %s", body)
 }

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -77,7 +77,7 @@ func (s *Server) Run() error {
 // NOT originating from HostIP destined to metadata endpoint are
 // routed to NMI endpoint
 func (s *Server) updateIPTableRules() {
-	signalChan := make(chan os.Signal)
+	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT)
 
 	ticker := time.NewTicker(time.Second * time.Duration(s.IPTableUpdateTimeIntervalInSeconds))

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -354,6 +354,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		Expect(ok).To(Equal(true))
 
 		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
+		Expect(err).NotTo(HaveOccurred())
 		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
 
 		// Delete pod identity to verify that the VM identity did not get deleted


### PR DESCRIPTION
**Reason for Change**:
Buffers a channel in NMI startup so `os.Signal` won't be missed during a (small) window, and handles some ignored error values as pointed out by the `staticcheck` linter.

See https://golang.org/pkg/os/signal/#Notify for an explanation of why `os.Signal` channels should be buffered.

**Issue Fixed**:

**Notes for Reviewers**:
