### PR TITLE
Fix the lite CRD client to include assigned identity watcher

### DIFF
--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -43,8 +43,12 @@ func NewCRDClientLite(config *rest.Config) (crdClient *Client, err error) {
 		glog.Error(err)
 		return nil, err
 	}
+
+	assignedIDListWatch := newAssignedIDListWatch(restClient)
+
 	return &Client{
-		rest: restClient,
+		AssignedIDListWatch: assignedIDListWatch,
+		rest:                restClient,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Fix the lite CRDClient to include initialization of the AzureAssignedID cache list watcher.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**: