### PR TITLE
Fix incorrect resource endpoint with service principal

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	activeDirectoryEndpoint = "https://login.microsoftonline.com/"
-	resourceManagerEndpoint = "https://management.azure.com/"
 )
 
 // GetServicePrincipalTokenFromMSIWithUserAssignedID return the token for the assigned user
@@ -36,7 +35,7 @@ func GetServicePrincipalTokenFromMSIWithUserAssignedID(clientID, resource string
 }
 
 // GetServicePrincipalToken return the token for the assigned user
-func GetServicePrincipalToken(tenantID, clientID, secret string) (*adal.Token, error) {
+func GetServicePrincipalToken(tenantID, clientID, secret, resource string) (*adal.Token, error) {
 	oauthConfig, err := adal.NewOAuthConfig(activeDirectoryEndpoint, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("creating the OAuth config: %v", err)
@@ -45,7 +44,7 @@ func GetServicePrincipalToken(tenantID, clientID, secret string) (*adal.Token, e
 		*oauthConfig,
 		clientID,
 		secret,
-		resourceManagerEndpoint,
+		resource,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGetServicePrincipalToken(t *testing.T) {
-	_, err := GetServicePrincipalToken("tid", "cid", "")
+	_, err := GetServicePrincipalToken("tid", "cid", "", "")
 	if err == nil {
 		t.Fatal("should be error with empty secret")
 	}

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -271,7 +271,7 @@ func getTokenForMatchingID(kubeClient k8s.Client, logger *log.Entry, rqClientID 
 			return token, clientID, err
 		case aadpodid.ServicePrincipal:
 			tenantid := v.Spec.TenantID
-			logger.Infof("matched identityType:%v tenantid:%s clientid:%s", idType, tenantid, clientID)
+			logger.Infof("matched identityType:%v tenantid:%s clientid:%s resource:%s", idType, tenantid, clientID, rqResource)
 			secret, err := kubeClient.GetSecret(&v.Spec.ClientPassword)
 			if err != nil {
 				return nil, clientID, err
@@ -281,7 +281,7 @@ func getTokenForMatchingID(kubeClient k8s.Client, logger *log.Entry, rqClientID 
 				clientSecret = string(v)
 				break
 			}
-			token, err := auth.GetServicePrincipalToken(tenantid, clientID, clientSecret)
+			token, err := auth.GetServicePrincipalToken(tenantid, clientID, clientSecret, rqResource)
 			return token, clientID, err
 		default:
 			return nil, clientID, fmt.Errorf("unsupported identity type %+v", idType)


### PR DESCRIPTION
**Reason for Change**:
Resource endpoint for service principal was hard coded to https://management.azure.com/, so we are unable to use token to auth azure services such as Azure SQL, we should use the endpoint from request to generate the token.

**Issue Fixed**:
n/a