### PR TITLE
fix: handle new OAuthConfig error consistently

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -62,11 +62,11 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 		glog.Errorf("Get cloud env error: %+v", err)
 		return nil, err
 	}
-	oauthConfig, _ := adal.NewOAuthConfig(azureEnv.ActiveDirectoryEndpoint, azureConfig.TenantID)
+	oauthConfig, err := adal.NewOAuthConfig(azureEnv.ActiveDirectoryEndpoint, azureConfig.TenantID)
 	if err != nil {
-		return nil, fmt.Errorf("creating the OAuth config: %v", err)
+		glog.Errorf("creating the OAuth config: %+v", err)
+		return nil, err
 	}
-	//glog.Info("%+v\n", oauthConfig)
 	spt, err := adal.NewServicePrincipalToken(
 		*oauthConfig,
 		azureConfig.ClientID,

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -64,7 +64,7 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 	}
 	oauthConfig, err := adal.NewOAuthConfig(azureEnv.ActiveDirectoryEndpoint, azureConfig.TenantID)
 	if err != nil {
-		glog.Errorf("creating the OAuth config: %+v", err)
+		glog.Errorf("Create OAuth config error: %+v", err)
 		return nil, err
 	}
 	spt, err := adal.NewServicePrincipalToken(


### PR DESCRIPTION
**Reason for Change**:
The error from `adal.NewOAuthConfig` was ignored, so the subsequent error handling block could never be entered since it was comparing the previous `err` to `nil` again. I also made the handling consistent with the rest of the function.

<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
