### PR TITLE
[WIP] Add states to assigned identity

### DIFF
--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -35,7 +35,7 @@ func filterUserIdentity(idType *compute.ResourceIdentityType, idList *[]string, 
 	case compute.ResourceIdentityTypeUserAssigned,
 		compute.ResourceIdentityTypeSystemAssignedUserAssigned:
 	default:
-		return errNotFound
+		return nil
 	}
 
 	origLen := len(*idList)

--- a/pkg/cloudprovider/identity_test.go
+++ b/pkg/cloudprovider/identity_test.go
@@ -9,8 +9,8 @@ import (
 func TestFilterIdentity(t *testing.T) {
 	idList := []string{}
 	idType := compute.ResourceIdentityTypeNone
-	if err := filterUserIdentity(&idType, &idList, "A"); err == nil || err != errNotFound {
-		t.Fatalf("expected error %q, got: %v", errNotFound, err)
+	if err := filterUserIdentity(&idType, &idList, "A"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
 
 	idType = compute.ResourceIdentityTypeUserAssigned


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Add states to assigned identity
- Created: When the assigned crd is created
- Assigned: The identity is successfully assigned to node
- Unassigned: When the identity is successfully removed from node

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
resolves https://github.com/Azure/aad-pod-identity/issues/256

**Notes for Reviewers**:
