### PR TITLE
Fix removal of user assigned identity from nodes with system assigned 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ else
 endif
 
 GO_BUILD_OPTIONS := --tags "netgo osusergo"  -ldflags "-s -X $(NMI_VERSION_VAR)=$(NMI_VERSION) -X $(MIC_VERSION_VAR)=$(MIC_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
-# TODO (@aramase) remove the skip test once https://github.com/Azure/aad-pod-identity/issues/214 is resolved
-E2E_TEST_OPTIONS := -count=1 -v -timeout 24h -ginkgo.failFast -ginkgo.skip="should not alter the system assigned identity after creating and deleting pod identity"
+E2E_TEST_OPTIONS := -count=1 -v -timeout 24h -ginkgo.failFast 
 
 # useful for other docker repos
 REGISTRY_NAME ?= upstreamk8sci

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -100,7 +100,9 @@ func (i *vmIdentityInfo) RemoveUserIdentity(id string) error {
 	if err := filterUserIdentity(&i.info.Type, i.info.IdentityIds, id); err != nil {
 		return err
 	}
-	if i.info.Type == compute.ResourceIdentityTypeNone {
+	// If we have either no identity assigned or have the system assigned identity only, then we need to set the
+	// IdentityIds list as nil.
+	if i.info.Type == compute.ResourceIdentityTypeNone || i.info.Type == compute.ResourceIdentityTypeSystemAssigned {
 		i.info.IdentityIds = nil
 	}
 	return nil


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
During the removal of user assigned identity from a node with system assigned identity, we were not making the identity list as nil. This was resulting in the cloud call to fail with the error saying that identity list should be nil. This PR makes the identity list nil (when only system assigned identity should be left on the node) before calling the cloud call to remove the identities.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#214 

**Notes for Reviewers**:
