### PR TITLE
Change to filtered list watch to fix fieldselector

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -68,12 +68,12 @@ func NewKubeClient() (Client, error) {
 		return nil, err
 	}
 
-	optionsModifer := func(options *metav1.ListOptions) {}
+	optionsModifier := func(options *metav1.ListOptions) {}
 	podListWatch := cache.NewFilteredListWatchFromClient(
 		clientset.CoreV1().RESTClient(),
 		"pods",
 		v1.NamespaceAll,
-		optionsModifer,
+		optionsModifier,
 	)
 
 	kubeClient := &KubeClient{CrdClient: crdclient, ClientSet: clientset, PodListWatch: podListWatch}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/fields"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -70,11 +68,13 @@ func NewKubeClient() (Client, error) {
 		return nil, err
 	}
 
-	podListWatch := cache.NewListWatchFromClient(
+	optionsModifer := func(options *metav1.ListOptions) {}
+	podListWatch := cache.NewFilteredListWatchFromClient(
 		clientset.CoreV1().RESTClient(),
 		"pods",
 		v1.NamespaceAll,
-		fields.Everything())
+		optionsModifer,
+	)
 
 	kubeClient := &KubeClient{CrdClient: crdclient, ClientSet: clientset, PodListWatch: podListWatch}
 


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
`NewListWatchFromClient` doesn't respect the fieldselector options provided to filter pods. Instead we'll create `NewFilteredListWatchFromClient` with empty options modifier. In this case ListWatch will use the options we provide during list.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes https://github.com/Azure/aad-pod-identity/issues/260

**Notes for Reviewers**:
