### PR TITLE
Adds support for MIC to authenticate with azure using system assigned/user assigned MSI

### DIFF
--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -27,6 +27,7 @@ var (
 	nodename                           = pflag.String("node", "", "node name")
 	ipTableUpdateTimeIntervalInSeconds = pflag.Int("ipt-update-interval-sec", defaultIPTableUpdateTimeIntervalInSeconds, "update interval of iptables")
 	forceNamespaced                    = pflag.Bool("forceNamespaced", false, "Forces mic to namespace identities, binding, and assignment")
+	micNamespace                       = pflag.String("MICNamespace", "default", "MIC namespace to short circuit MIC token requests")
 )
 
 func main() {
@@ -43,7 +44,7 @@ func main() {
 		log.Fatalf("%+v", err)
 	}
 	*forceNamespaced = *forceNamespaced || "true" == os.Getenv("FORCENAMESPACED")
-	s := server.NewServer(*forceNamespaced)
+	s := server.NewServer(*forceNamespaced, *micNamespace)
 	s.KubeClient = client
 	s.MetadataIP = *metadataIP
 	s.MetadataPort = *metadataPort

--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -18,9 +18,14 @@ and also operations on the user assigned identity.
 
 After the cluster is created to perform the following steps to obtain the principal id:
 for VMAs:
-```az vm identity show -g <resource group> -n <vm name> -o yaml```
+
+```bash
+az vm identity show -g <resource group> -n <vm name> -o yaml
+```
 for VMSS:
-```az vmss identity show -g <resource group>  -n <vmss scalset name> -o yaml```
+```bash
+az vmss identity show -g <resource group>  -n <vmss scalset name> -o yaml
+```
 
 The type in the output of the above command will identify the system assigned or user assigned MSI. Please record the corresponding
 principal id.

--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -1,0 +1,41 @@
+## Introduction
+
+The MIC component in aad-pod-identity needs to authenticate with the cloud to assign and remove user assign identities onto
+virtual machines (VMAs) or virtual machine scale sets(VMSS). This authentication is performed using either the cluster credentials
+obtained from azure.json in AKS/aks-engine clusters or credentials given via environment variables.
+
+MIC can authenticate using the following options:
+1. Service principal
+2. System assigned MSI
+3. User assigned MSI
+
+The rest of the README describes the prerequisite role assignments to be performed and how to configure MIC to use system assigned/user assigned MSI.
+
+## Pre-requisites - role assignments
+MIC is responsible for performing operations such as assigning user assigned identity to the underlying vm or vmss which makes up the
+nodes in the Kubernetes cluster. The system/user assigned MSI needs to have role assignments authorizing such operations on the vms/vmss
+and also operations on the user assigned identity.
+
+After the cluster is created to perform the following steps to obtain the principal id:
+for VMAs:
+`az vm identity show -g <resource group> -n <vm name> -o yaml`
+for VMSS:
+`az vmss identity show -g <resource group>  -n <vmss scalset name> -o yaml`
+
+The type in the output of the above command will identify the system assigned or user assigned MSI. Please record the corresponding
+principal id.
+
+For creating a role assignment to authorize assignment/removal of user assigned identities on VMS/VMSS, run the following command:
+`az role assignment create --role "Contributor" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<sub id>/resourcegroups/<resource group name>`
+
+Now to ensure that the operations are allowed on individual identity, perform the following for every identity in use:
+`az role assignment create --role "Managed Identity Operator" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<subscription id>/resourcegroups/<resource group name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity name>`
+
+
+## Authentication method
+In case the azure.json is used, the following keys indicates whether the cluster is configured with system assigned or user assigned identity:
+`UseManagedIdentityExtension` shows that MSI is to be used. If `UserAssignedIdentityID` is set, then the user assigned identity is used, otherwise
+system assigned identity is used for authentication.
+
+In case where the azure.json is not used and the environment variables are used, the following variables are used to setup the configuration:
+`USE_MSI` is to setup MSI. If the `USER_ASSIGNED_MSI_CLIENTID` is used then user assigned identity is used, otherwise system assigned identity is used.

--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -9,7 +9,7 @@ MIC can authenticate using the following options:
 2. System assigned MSI
 3. User assigned MSI
 
-The rest of the README describes the prerequisite role assignments to be performed and how to configure MIC to use system assigned/user assigned MSI.
+The rest of the README describes the prerequisite role assignments to be performed for using MSI and how to configure MIC to use system assigned/user assigned MSI.
 
 ## Pre-requisites - role assignments
 MIC is responsible for performing operations such as assigning user assigned identity to the underlying vm or vmss which makes up the

--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -43,7 +43,7 @@ az role assignment create --role "Managed Identity Operator" --assignee <princip
 
 ## Authentication method
 In case the azure.json is used, the following keys indicates whether the cluster is configured with system assigned or user assigned identity:
-```bash UseManagedIdentityExtension``` shows that MSI is to be used. If ```bash UserAssignedIdentityID``` is set, then the user assigned
+```UseManagedIdentityExtension``` shows that MSI is to be used. If ```UserAssignedIdentityID``` is set, then the user assigned
 identity is used, otherwise system assigned identity is used for authentication.
 
 In case where the azure.json is not used and the environment variables are used, the following variables are used to setup the configuration:

--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-The MIC component in aad-pod-identity needs to authenticate with the cloud to assign and remove user assign identities onto
+The MIC component in aad-pod-identity needs to authenticate with the cloud to assign and remove user assigned identities onto
 virtual machines (VMAs) or virtual machine scale sets(VMSS). This authentication is performed using either the cluster credentials
 obtained from azure.json in AKS/aks-engine clusters or credentials given via environment variables.
 
@@ -16,8 +16,8 @@ MIC is responsible for performing operations such as assigning user assigned ide
 nodes in the Kubernetes cluster. The system/user assigned MSI needs to have role assignments authorizing such operations on the vms/vmss
 and also operations on the user assigned identity.
 
-After the cluster is created to perform the following steps to obtain the principal id:
-for VMAs:
+After the cluster is created, run these commands to retrieve the principal id:
+for VMAS:
 
 ```bash
 az vm identity show -g <resource group> -n <vm name> -o yaml
@@ -47,4 +47,4 @@ In case the azure.json is used, the following keys indicates whether the cluster
 identity is used, otherwise system assigned identity is used for authentication.
 
 In case where the azure.json is not used and the environment variables are used, the following variables are used to setup the configuration:
-```USE_MSI``` is to setup MSI. If the ```USER_ASSIGNED_MSI_CLIENTID``` is used then user assigned identity is used, otherwise system assigned identity is used.
+```USE_MSI``` is to setup MSI. If the ```USER_ASSIGNED_MSI_CLIENT_ID``` is used then user assigned identity is used, otherwise system assigned identity is used.

--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -31,16 +31,20 @@ The type in the output of the above command will identify the system assigned or
 principal id.
 
 For creating a role assignment to authorize assignment/removal of user assigned identities on VMS/VMSS, run the following command:
-```az role assignment create --role "Contributor" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<sub id>/resourcegroups/<resource group name>```
+```bash
+az role assignment create --role "Contributor" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<sub id>/resourcegroups/<resource group name>
+```
 
 Now to ensure that the operations are allowed on individual identity, perform the following for every identity in use:
-```az role assignment create --role "Managed Identity Operator" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<subscription id>/resourcegroups/<resource group name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity name>```
+```bash
+az role assignment create --role "Managed Identity Operator" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<subscription id>/resourcegroups/<resource group name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity name>
+```
 
 
 ## Authentication method
 In case the azure.json is used, the following keys indicates whether the cluster is configured with system assigned or user assigned identity:
-```UseManagedIdentityExtension``` shows that MSI is to be used. If ```UserAssignedIdentityID``` is set, then the user assigned identity is used, otherwise
-system assigned identity is used for authentication.
+```bash UseManagedIdentityExtension``` shows that MSI is to be used. If ```bash UserAssignedIdentityID``` is set, then the user assigned
+identity is used, otherwise system assigned identity is used for authentication.
 
 In case where the azure.json is not used and the environment variables are used, the following variables are used to setup the configuration:
 ```USE_MSI``` is to setup MSI. If the ```USER_ASSIGNED_MSI_CLIENTID``` is used then user assigned identity is used, otherwise system assigned identity is used.

--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -18,24 +18,24 @@ and also operations on the user assigned identity.
 
 After the cluster is created to perform the following steps to obtain the principal id:
 for VMAs:
-`az vm identity show -g <resource group> -n <vm name> -o yaml`
+```az vm identity show -g <resource group> -n <vm name> -o yaml```
 for VMSS:
-`az vmss identity show -g <resource group>  -n <vmss scalset name> -o yaml`
+```az vmss identity show -g <resource group>  -n <vmss scalset name> -o yaml```
 
 The type in the output of the above command will identify the system assigned or user assigned MSI. Please record the corresponding
 principal id.
 
 For creating a role assignment to authorize assignment/removal of user assigned identities on VMS/VMSS, run the following command:
-`az role assignment create --role "Contributor" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<sub id>/resourcegroups/<resource group name>`
+```az role assignment create --role "Contributor" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<sub id>/resourcegroups/<resource group name>```
 
 Now to ensure that the operations are allowed on individual identity, perform the following for every identity in use:
-`az role assignment create --role "Managed Identity Operator" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<subscription id>/resourcegroups/<resource group name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity name>`
+```az role assignment create --role "Managed Identity Operator" --assignee <principal id from az vm/vmss identity command>  --scope /subscriptions/<subscription id>/resourcegroups/<resource group name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity name>```
 
 
 ## Authentication method
 In case the azure.json is used, the following keys indicates whether the cluster is configured with system assigned or user assigned identity:
-`UseManagedIdentityExtension` shows that MSI is to be used. If `UserAssignedIdentityID` is set, then the user assigned identity is used, otherwise
+```UseManagedIdentityExtension``` shows that MSI is to be used. If ```UserAssignedIdentityID``` is set, then the user assigned identity is used, otherwise
 system assigned identity is used for authentication.
 
 In case where the azure.json is not used and the environment variables are used, the following variables are used to setup the configuration:
-`USE_MSI` is to setup MSI. If the `USER_ASSIGNED_MSI_CLIENTID` is used then user assigned identity is used, otherwise system assigned identity is used.
+```USE_MSI``` is to setup MSI. If the ```USER_ASSIGNED_MSI_CLIENTID``` is used then user assigned identity is used, otherwise system assigned identity is used.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -23,7 +23,7 @@ func GetServicePrincipalTokenFromMSI(resource string) (*adal.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to acquire a token for MSI. Error: %v", err)
 	}
-	// Evectively acqurie the token
+	// Effectively acquire the token
 	err = spt.Refresh()
 	if err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ func GetServicePrincipalTokenFromMSIWithUserAssignedID(clientID, resource string
 		return nil, err
 	}
 
-	// Evectively acqurie the token
+	// Effectively acquire the token
 	err = spt.Refresh()
 	if err != nil {
 		return nil, err

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -11,6 +11,28 @@ const (
 	activeDirectoryEndpoint = "https://login.microsoftonline.com/"
 )
 
+// GetServicePrincipalTokenFromMSI return the token for the assigned user
+func GetServicePrincipalTokenFromMSI(resource string) (*adal.Token, error) {
+	// Get the MSI endpoint accoriding with the OS (Linux/Windows)
+	msiEndpoint, err := adal.GetMSIVMEndpoint()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get the MSI endpoint. Error: %v", err)
+	}
+	// Set up the configuration of the service principal
+	spt, err := adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to acquire a token for MSI. Error: %v", err)
+	}
+	// Evectively acqurie the token
+	err = spt.Refresh()
+	if err != nil {
+		return nil, err
+	}
+	token := spt.Token()
+
+	return &token, nil
+}
+
 // GetServicePrincipalTokenFromMSIWithUserAssignedID return the token for the assigned user
 func GetServicePrincipalTokenFromMSIWithUserAssignedID(clientID, resource string) (*adal.Token, error) {
 	// Get the MSI endpoint accoriding with the OS (Linux/Windows)

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strings"
 	"time"
 
 	config "github.com/Azure/aad-pod-identity/pkg/config"
@@ -59,6 +60,8 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 		azureConfig.SubscriptionID = os.Getenv("SUBSCRIPTION_ID")
 		azureConfig.ResourceGroupName = os.Getenv("RESOURCE_GROUP")
 		azureConfig.VMType = os.Getenv("VM_TYPE")
+		azureConfig.UseManagedIdentityExtension = strings.EqualFold(os.Getenv("USE_MSI"), "True")
+		azureConfig.UserAssignedIdentityID = os.Getenv("USER_ASSIGNED_MSI_CLIENTID")
 	}
 
 	azureEnv, err := azure.EnvironmentFromName(azureConfig.Cloud)
@@ -77,15 +80,40 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 		glog.Errorf("Create OAuth config error: %+v", err)
 		return nil, err
 	}
-	spt, err := adal.NewServicePrincipalToken(
-		*oauthConfig,
-		azureConfig.ClientID,
-		azureConfig.ClientSecret,
-		azureEnv.ResourceManagerEndpoint,
-	)
-	if err != nil {
-		glog.Errorf("Get service principle token error: %+v", err)
-		return nil, err
+
+	var spt *adal.ServicePrincipalToken
+	if azureConfig.UseManagedIdentityExtension {
+		// MSI endpoing is required for both types of MSI - system assigned and user assigned.
+		msiEndpoint, err := adal.GetMSIVMEndpoint()
+		if err != nil {
+			glog.Errorf("Failed to get msiEndpoint: %+v", err)
+			return nil, err
+		}
+		// UserAssignedIdentityID is empty, so we are going to use system assigned MSI
+		if azureConfig.UserAssignedIdentityID == "" {
+			spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, azureEnv.ResourceManagerEndpoint)
+			if err != nil {
+				glog.Errorf("Get token from system assigned MSI error: %+v", err)
+				return nil, err
+			}
+		} else { // User assigned identity usage.
+			spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, azureEnv.ResourceManagerEndpoint, azureConfig.UserAssignedIdentityID)
+			if err != nil {
+				glog.Errorf("Get token from user assigned MSI error: %+v", err)
+				return nil, err
+			}
+		}
+	} else { // This is the default scenario - use service principal to get the token.
+		spt, err = adal.NewServicePrincipalToken(
+			*oauthConfig,
+			azureConfig.ClientID,
+			azureConfig.ClientSecret,
+			azureEnv.ResourceManagerEndpoint,
+		)
+		if err != nil {
+			glog.Errorf("Get service principle token error: %+v", err)
+			return nil, err
+		}
 	}
 
 	extClient := compute.NewVirtualMachineExtensionsClient(azureConfig.SubscriptionID)

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -61,7 +61,7 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 		azureConfig.ResourceGroupName = os.Getenv("RESOURCE_GROUP")
 		azureConfig.VMType = os.Getenv("VM_TYPE")
 		azureConfig.UseManagedIdentityExtension = strings.EqualFold(os.Getenv("USE_MSI"), "True")
-		azureConfig.UserAssignedIdentityID = os.Getenv("USER_ASSIGNED_MSI_CLIENTID")
+		azureConfig.UserAssignedIdentityID = os.Getenv("USER_ASSIGNED_MSI_CLIENT_ID")
 	}
 
 	azureEnv, err := azure.EnvironmentFromName(azureConfig.Cloud)

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -91,12 +91,14 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 		}
 		// UserAssignedIdentityID is empty, so we are going to use system assigned MSI
 		if azureConfig.UserAssignedIdentityID == "" {
+			glog.Infof("MIC using system assigned identity for authentication.")
 			spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, azureEnv.ResourceManagerEndpoint)
 			if err != nil {
 				glog.Errorf("Get token from system assigned MSI error: %+v", err)
 				return nil, err
 			}
 		} else { // User assigned identity usage.
+			glog.Infof("MIC using user assigned identity: %s for authentication.", azureConfig.UserAssignedIdentityID)
 			spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, azureEnv.ResourceManagerEndpoint, azureConfig.UserAssignedIdentityID)
 			if err != nil {
 				glog.Errorf("Get token from user assigned MSI error: %+v", err)
@@ -194,6 +196,7 @@ func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs []string, removeUserAssigne
 		requiresUpdate = requiresUpdate || addedToList
 	}
 	if requiresUpdate {
+		glog.Infof("Updating user assigned MSIs on %s", node.Name)
 		timeStarted := time.Now()
 		if err := updateFunc(); err != nil {
 			return err

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -83,10 +83,10 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 
 	var spt *adal.ServicePrincipalToken
 	if azureConfig.UseManagedIdentityExtension {
-		// MSI endpoing is required for both types of MSI - system assigned and user assigned.
+		// MSI endpoint is required for both types of MSI - system assigned and user assigned.
 		msiEndpoint, err := adal.GetMSIVMEndpoint()
 		if err != nil {
-			glog.Errorf("Failed to get msiEndpoint: %+v", err)
+			glog.Errorf("Failed to get MSI endpoint. Error: %+v", err)
 			return nil, err
 		}
 		// UserAssignedIdentityID is empty, so we are going to use system assigned MSI

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -108,7 +108,9 @@ func (i *vmssIdentityInfo) RemoveUserIdentity(id string) error {
 	if err := filterUserIdentity(&i.info.Type, i.info.IdentityIds, id); err != nil {
 		return err
 	}
-	if i.info.Type == compute.ResourceIdentityTypeNone {
+	// If we have either no identity assigned or have the system assigned identity only, then we need to set the
+	// IdentityIds list as nil.
+	if i.info.Type == compute.ResourceIdentityTypeNone || i.info.Type == compute.ResourceIdentityTypeSystemAssigned {
 		i.info.IdentityIds = nil
 	}
 	return nil

--- a/pkg/config/azureconfig.go
+++ b/pkg/config/azureconfig.go
@@ -2,12 +2,14 @@ package config
 
 // AzureConfig is representing /etc/kubernetes/azure.json
 type AzureConfig struct {
-	Cloud             string `json:"cloud" yaml:"cloud"`
-	TenantID          string `json:"tenantId" yaml:"tenantId"`
-	ClientID          string `json:"aadClientId" yaml:"aadClientId"`
-	ClientSecret      string `json:"aadClientSecret" yaml:"aadClientSecret"`
-	SubscriptionID    string `json:"subscriptionId" yaml:"subscriptionId"`
-	ResourceGroupName string `json:"resourceGroup" yaml:"resourceGroup"`
-	SecurityGroupName string `json:"securityGroupName" yaml:"securityGroupName"`
-	VMType            string `json:"vmType" yaml:"vmType"`
+	Cloud                       string `json:"cloud" yaml:"cloud"`
+	TenantID                    string `json:"tenantId" yaml:"tenantId"`
+	ClientID                    string `json:"aadClientId" yaml:"aadClientId"`
+	ClientSecret                string `json:"aadClientSecret" yaml:"aadClientSecret"`
+	SubscriptionID              string `json:"subscriptionId" yaml:"subscriptionId"`
+	ResourceGroupName           string `json:"resourceGroup" yaml:"resourceGroup"`
+	SecurityGroupName           string `json:"securityGroupName" yaml:"securityGroupName"`
+	VMType                      string `json:"vmType" yaml:"vmType"`
+	UseManagedIdentityExtension bool   `json:"useManagedIdentityExtension,omitempty" yaml:"useManagedIdentityExtension,omitempty"`
+	UserAssignedIdentityID      string `json:"userAssignedIdentityID,omitempty" yaml:"userAssignedIdentityID,omitempty"`
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -118,41 +118,41 @@ func (c *KubeClient) getPodList(podip string) (*v1.PodList, error) {
 	// Confirm that we are able to cast properly.
 	podList, ok := listObject.(*v1.PodList)
 	if !ok {
-		return nil, fmt.Errorf("list object could not be converted to podlist")
+		return nil, fmt.Errorf("list object could not be converted to podllist")
 	}
 
 	if podList == nil {
-		return nil, fmt.Errorf("pod list nil")
+		return nil, fmt.Errorf("Podlist nil")
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("pod list empty")
+		return nil, fmt.Errorf("Pod List empty")
 	}
 
 	return podList, nil
 }
 
-func (c *KubeClient) getPodListRetry(podip string, retries int, sleeptime time.Duration) (*v1.PodList, error) {
+func (c *KubeClient) getPodListWithTries(podip string, tries int, sleeptime time.Duration) (*v1.PodList, error) {
 	var podList *v1.PodList
 	var err error
-	i := 0
 
-	for {
-		// Atleast run the getpodlist once.
+	for i := 0; i < tries; i++ {
 		podList, err = c.getPodList(podip)
-		if err == nil {
-			return podList, nil
-		}
-		if i >= retries {
+		if err != nil {
+			log.Warningf("List pod error: %+v. Retrying, attempt number: %d", err, i)
+			time.Sleep(sleeptime * time.Millisecond)
+			continue
+		} else {
 			break
 		}
-		i++
-		log.Warningf("List pod error: %+v. Retrying, attempt number: %d", err, i)
-		time.Sleep(sleeptime * time.Millisecond)
 	}
-	// We reach here only if there is an error and we have exhausted all retries.
-	// Return the last error
-	return nil, err
+	if err != nil {
+		return nil, err
+	}
+	if podList == nil {
+		return nil, fmt.Errorf("pod list nil")
+	}
+	return podList, nil
 }
 
 // GetLocalIP returns the non loopback local IP of the host

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -104,8 +104,7 @@ func (c *KubeClient) GetPodInfo(podip string) (podns, poddname, rsName string, e
 	}
 	numMatching := len(podList.Items)
 	if numMatching == 1 {
-		rsName := c.getReplicasetName(podList.Items[0])
-		return podList.Items[0].Namespace, podList.Items[0].Name, rsName, nil
+		return podList.Items[0].Namespace, podList.Items[0].Name, c.getReplicasetName(podList.Items[0]), nil
 	}
 
 	return "", "", "", fmt.Errorf("match failed, ip:%s matching pods:%v", podip, podList)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -88,7 +88,7 @@ func (c *KubeClient) GetPodInfo(podip string) (podns, poddname, deployment strin
 		return "", "", "", fmt.Errorf("podip is empty")
 	}
 
-	podList, err := c.getPodListRetry(podip, getPodListRetries, getPodListSleepTimeMilliseconds)
+	podList, err := c.getPodListWithTries(podip, getPodListRetries, getPodListSleepTimeMilliseconds)
 
 	if err != nil {
 		return "", "", "", err

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"fmt"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -103,3 +104,24 @@ func TestPodListRetries(t *testing.T) {
 	}
 }
 */
+
+func TestGetReplicaSet(t *testing.T) {
+	pod := &v1.Pod{}
+	rsIndex := 1
+	for i := 0; i < 3; i++ {
+		owner := metav1.OwnerReference{}
+		owner.Name = "test" + fmt.Sprintf("%d", i)
+		if i == rsIndex {
+			owner.Kind = "ReplicaSet"
+		} else {
+			owner.Kind = "Kind" + fmt.Sprintf("%d", i)
+		}
+		pod.OwnerReferences = append(pod.OwnerReferences, owner)
+	}
+
+	c := &KubeClient{}
+	rsName := c.getReplicasetName(*pod)
+	if rsName != "test1" {
+		t.Fatalf("Expected rsName: test1. Got: %s", rsName)
+	}
+}

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -17,9 +17,9 @@ func NewFakeClient() (Client, error) {
 	return fakeClient, nil
 }
 
-// GetPodInfo returns fake pod name
-func (c *FakeClient) GetPodInfo(podip string) (podns, podname, deployment string, err error) {
-	return "ns", "podname", "deployment", nil
+// GetPodInfo returns fake pod name, namespace and replicaset
+func (c *FakeClient) GetPodInfo(podip string) (podns, podname, rsName string, err error) {
+	return "ns", "podname", "rsName", nil
 }
 
 // ListPodIds for pod

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -17,9 +17,9 @@ func NewFakeClient() (Client, error) {
 	return fakeClient, nil
 }
 
-// GetPodName returns fake pod name
-func (c *FakeClient) GetPodName(podip string) (podns, podname string, err error) {
-	return "ns", "podname", nil
+// GetPodInfo returns fake pod name
+func (c *FakeClient) GetPodInfo(podip string) (podns, podname, deployment string, err error) {
+	return "ns", "podname", "deployment", nil
 }
 
 // ListPodIds for pod

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -240,6 +240,7 @@ func (s *Server) getMICToken(logger *log.Entry, rqClientID, rqResource string) (
 	}
 	if err != nil {
 		logger.Errorf("Failed to get service principal token. Error: %+v", err)
+		// TODO: return the right status code based on the error we got from adal.
 		return nil, http.StatusForbidden, err
 	}
 	response, err := json.Marshal(*token)

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -245,10 +245,10 @@ func (s *Server) getMICToken(logger *log.Entry, rqClientID, rqResource string) (
 	}
 	response, err := json.Marshal(*token)
 	if err != nil {
-		logger.Errorf("Failed to unmarshal service principal token. Error: %+v", err)
+		logger.Errorf("Failed to marshal service principal token. Error: %+v", err)
 		return nil, http.StatusInternalServerError, err
 	}
-	return response, 0, nil
+	return response, http.StatusOK, nil
 }
 
 // msiHandler uses the remote address to identify the pod ip and uses it

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -232,8 +232,10 @@ func (s *Server) getMICToken(logger *log.Entry, rqClientID, rqResource string) (
 	var err error
 	// ClientID is empty, so we are going to use System assigned MSI
 	if rqClientID == "" {
+		logger.Infof("Fetching MIC token for system assigned MSI")
 		token, err = auth.GetServicePrincipalTokenFromMSI(rqResource)
 	} else { // User assigned identity usage.
+		logger.Infof("Fetching MIC token for user assigned MSI for id: %s", rqResource)
 		token, err = auth.GetServicePrincipalTokenFromMSIWithUserAssignedID(rqClientID, rqResource)
 	}
 	if err != nil {
@@ -271,7 +273,8 @@ func (s *Server) msiHandler(logger *log.Entry, w http.ResponseWriter, r *http.Re
 	}
 
 	// If its mic, then just directly get the token and pass back.
-	if s.isMIC(rsName, podns) {
+	if s.isMIC(podns, rsName) {
+		logger.Infof("MIC pod token handling")
 		response, errorCode, err := s.getMICToken(logger, rqClientID, rqResource)
 		if err != nil {
 			logger.Errorf("failed to get service principal token for pod:%s/%s.  Error code: %d. Error: %+v", podns, podname, errorCode, err)

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -243,10 +243,6 @@ func (s *Server) msiHandler(logger *log.Entry, w http.ResponseWriter, r *http.Re
 	micRegEx := regexp.MustCompile(`^mic-*`)
 	micMatch := micRegEx.MatchString(deployment)
 
-	// Request id and request resource extraction are common steps required for
-	// requests from mic as well as other applications.
-	rqClientID, rqResource := parseRequestClientIDAndResource(r)
-
 	// If its mic, then just directly get the token and pass back.
 	if micMatch {
 		var token *adal.Token


### PR DESCRIPTION
This PR adds the capability for MIC to look at azure.json or environment variables
to determine whether the system assigned or user assigned MSI has to be used for accessing
azure resources. The MIC requests for token based on MSI. Also contains changes in NMI to determine if the request is originating from an MIC replicaset. If so, NMI directly generates the tokens instead of looking up the azure assigned identity for the pod-binding match.

<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Adds ability for MIC to authenticate using system assigned/user assigned MSI.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Resolves the item in #261.

**Notes for Reviewers**:
TODO: run the e2e on system assigned identity cluster.