### PR TITLE
Fix the nil cast on error for podlist and refactor pod retry call

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -15,6 +15,7 @@ import (
 
 	aadpodid "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	crd "github.com/Azure/aad-pod-identity/pkg/crd"
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -100,19 +101,53 @@ func (c *KubeClient) GetPodName(podip string) (podns, poddname string, err error
 	return "", "", fmt.Errorf("match failed, ip:%s matching pods:%v", podip, podList)
 }
 
-func (c *KubeClient) getPodListWithTries(podip string, tries int, sleeptime time.Duration) (*v1.PodList, error) {
-	podList, err := c.PodListWatch.List(metav1.ListOptions{
+func (c *KubeClient) getPodList(podip string) (*v1.PodList, error) {
+	listObject, err := c.PodListWatch.List(metav1.ListOptions{
 		FieldSelector: "status.podIP==" + podip + phaseStatusFilter,
 	})
 
-	if err != nil || len(podList.(*v1.PodList).Items) == 0 {
-		if tries > 1 {
-			time.Sleep(sleeptime * time.Millisecond)
-			return c.getPodListWithTries(podip, tries-1, sleeptime)
-		}
+	if err != nil {
+		return nil, err
 	}
 
-	return podList.(*v1.PodList), err
+	// Confirm that we are able to cast properly.
+	podList, ok := listObject.(*v1.PodList)
+	if !ok {
+		return nil, fmt.Errorf("list object could not be converted to podllist")
+	}
+
+	if podList == nil {
+		return nil, fmt.Errorf("Podlist nil")
+	}
+
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("Pod List empty")
+	}
+
+	return podList, nil
+}
+
+func (c *KubeClient) getPodListWithTries(podip string, tries int, sleeptime time.Duration) (*v1.PodList, error) {
+	var podList *v1.PodList
+	var err error
+
+	for i := 0; i < tries; i++ {
+		podList, err = c.getPodList(podip)
+		if err != nil {
+			log.Warningf("List pod error: %+v. Retrying, attempt number: %d", err, i)
+			time.Sleep(sleeptime * time.Millisecond)
+			continue
+		} else {
+			break
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if podList == nil {
+		return nil, fmt.Errorf("pod list nil")
+	}
+	return podList, nil
 }
 
 // GetLocalIP returns the non loopback local IP of the host

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	getPodListTries                 = 5
+	getPodListRetries               = 4
 	getPodListSleepTimeMilliseconds = 300
 )
 
@@ -88,7 +88,7 @@ func (c *KubeClient) GetPodName(podip string) (podns, poddname string, err error
 		return "", "", fmt.Errorf("podip is empty")
 	}
 
-	podList, err := c.getPodListWithTries(podip, getPodListTries, getPodListSleepTimeMilliseconds)
+	podList, err := c.getPodListRetry(podip, getPodListRetries, getPodListSleepTimeMilliseconds)
 
 	if err != nil {
 		return "", "", err
@@ -127,27 +127,27 @@ func (c *KubeClient) getPodList(podip string) (*v1.PodList, error) {
 	return podList, nil
 }
 
-func (c *KubeClient) getPodListWithTries(podip string, tries int, sleeptime time.Duration) (*v1.PodList, error) {
+func (c *KubeClient) getPodListRetry(podip string, retries int, sleeptime time.Duration) (*v1.PodList, error) {
 	var podList *v1.PodList
 	var err error
+	i := 0
 
-	for i := 0; i < tries; i++ {
+	for {
+		// Atleast run the getpodlist once.
 		podList, err = c.getPodList(podip)
-		if err != nil {
-			log.Warningf("List pod error: %+v. Retrying, attempt number: %d", err, i)
-			time.Sleep(sleeptime * time.Millisecond)
-			continue
-		} else {
+		if err == nil {
+			return podList, nil
+		}
+		if i >= retries {
 			break
 		}
+		i++
+		log.Warningf("List pod error: %+v. Retrying, attempt number: %d", err, i)
+		time.Sleep(sleeptime * time.Millisecond)
 	}
-	if err != nil {
-		return nil, err
-	}
-	if podList == nil {
-		return nil, fmt.Errorf("pod list nil")
-	}
-	return podList, nil
+	// We reach here only if there is an error and we have exhausted all retries.
+	// Return the last error
+	return nil, err
 }
 
 // GetLocalIP returns the non loopback local IP of the host

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -117,11 +117,11 @@ func (c *KubeClient) getPodList(podip string) (*v1.PodList, error) {
 	}
 
 	if podList == nil {
-		return nil, fmt.Errorf("podlist nil")
+		return nil, fmt.Errorf("pod list nil")
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("pod List empty")
+		return nil, fmt.Errorf("pod list empty")
 	}
 
 	return podList, nil

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -113,15 +113,15 @@ func (c *KubeClient) getPodList(podip string) (*v1.PodList, error) {
 	// Confirm that we are able to cast properly.
 	podList, ok := listObject.(*v1.PodList)
 	if !ok {
-		return nil, fmt.Errorf("list object could not be converted to podllist")
+		return nil, fmt.Errorf("list object could not be converted to podlist")
 	}
 
 	if podList == nil {
-		return nil, fmt.Errorf("Podlist nil")
+		return nil, fmt.Errorf("podlist nil")
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("Pod List empty")
+		return nil, fmt.Errorf("pod List empty")
 	}
 
 	return podList, nil


### PR DESCRIPTION
In pod retry the object returned from listing was used to cast even when error was returned. This PR
fixes this issue. The retry call has been refactored to account for other error conditions and simplify
the usage. This PR introduces getPodList call and then a retry call built on top of that.

<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Fix the nil cast panic in case of error return from Listpod.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
