### PR TITLE
Handle case sensitive id check

### DIFF
--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -2,6 +2,7 @@ package cloudprovider
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 )
@@ -65,7 +66,7 @@ func filter(ls *[]string, filter string) {
 	}
 
 	for i, v := range *ls {
-		if v == filter {
+		if strings.EqualFold(v, filter) {
 			copy((*ls)[i:], (*ls)[i+1:])
 			*ls = (*ls)[:len(*ls)-1]
 			return
@@ -94,7 +95,7 @@ func appendUserIdentity(idType *compute.ResourceIdentityType, idList *[]string, 
 
 func checkIfIDInList(idList []string, desiredID string) bool {
 	for _, id := range idList {
-		if id == desiredID {
+		if strings.EqualFold(id, desiredID) {
 			return true
 		}
 	}

--- a/pkg/cloudprovider/identity_test.go
+++ b/pkg/cloudprovider/identity_test.go
@@ -120,6 +120,27 @@ func TestAppendUserIdentity(t *testing.T) {
 	if idType != compute.ResourceIdentityTypeUserAssigned {
 		t.Fatalf("expected type %s, got: %s", compute.ResourceIdentityTypeUserAssigned, idType)
 	}
+
+	// test case sensitivity
+	idList = []string{}
+	expect = []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/devcluster/providers/Microsoft.ManagedIdentity/userAssignedIdentities/keyvault-identity"}
+	append = appendUserIdentity(&idType, &idList, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/devcluster/providers/Microsoft.ManagedIdentity/userAssignedIdentities/keyvault-identity")
+	if !append {
+		t.Fatalf("Expecting the id to be not present. But present returned by Append.")
+	}
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("expected type %s, got: %s", compute.ResourceIdentityTypeUserAssigned, idType)
+	}
+	// append same id with non camel case resourcegroups
+	append = appendUserIdentity(&idType, &idList, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/devcluster/providers/Microsoft.ManagedIdentity/userAssignedIdentities/keyvault-identity")
+	if append {
+		t.Fatalf("Expecting the id to be present. But not present returned by Append.")
+	}
+	checkIDList(t, expect, idList)
+	if idType != compute.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("expected type %s, got: %s", compute.ResourceIdentityTypeUserAssigned, idType)
+	}
 }
 
 func checkIDList(t *testing.T, expect, actual []string) {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
MIC fails when trying to compare same identity but with different cases for resource groups `resourceGroups` | `resourcegroups` in the resourceID format. This results in error when trying to assign the identity which already exists. This change will ensure we validate the identities case insensitively.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://github.com/Azure/aad-pod-identity/issues/269

**Notes for Reviewers**:
