### PR TITLE
NMI retries and ticker for periodic sync reconcile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ e2e:
 
 .PHONY: unit-test
 unit-test:
-	go test $(shell go list ./... | grep -v /test/e2e) -v
+	go test -count=1 $(shell go list ./... | grep -v /test/e2e) -v
 
 .PHONY: validate-version
 validate-version: validate-version-NMI validate-version-MIC validate-version-IDENTITY_VALIDATOR validate-version-DEMO

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	"github.com/Azure/aad-pod-identity/pkg/mic"
 	"github.com/Azure/aad-pod-identity/version"
@@ -12,10 +13,11 @@ import (
 )
 
 var (
-	kubeconfig      string
-	cloudconfig     string
-	forceNamespaced bool
-	versionInfo     bool
+	kubeconfig        string
+	cloudconfig       string
+	forceNamespaced   bool
+	versionInfo       bool
+	syncRetryInterval string
 )
 
 func main() {
@@ -24,6 +26,8 @@ func main() {
 	flag.StringVar(&cloudconfig, "cloudconfig", "", "Path to cloud config e.g. Azure.json file")
 	flag.BoolVar(&forceNamespaced, "forceNamespaced", false, "Forces namespaced identities, binding, and assignment")
 	flag.BoolVar(&versionInfo, "version", false, "Prints the version information")
+	flag.StringVar(&syncRetryInterval, "syncRetryInterval", "3600", "The interval in seconds at which sync loop should periodically check for errors and reconcile.")
+
 	flag.Parse()
 	if versionInfo {
 		version.PrintVersionAndExit()
@@ -43,7 +47,13 @@ func main() {
 	}
 
 	forceNamespaced = forceNamespaced || "true" == os.Getenv("FORCENAMESPACED")
-	micClient, err := mic.NewMICClient(cloudconfig, config, forceNamespaced)
+
+	syncRetryDuration, err := time.ParseDuration(syncRetryInterval)
+	if err != nil {
+		glog.Fatalf("Could not read syncRetryInterval. Error %+v", err)
+	}
+
+	micClient, err := mic.NewMICClient(cloudconfig, config, forceNamespaced, syncRetryDuration*time.Second)
 	if err != nil {
 		glog.Fatalf("Could not get the MIC client: %+v", err)
 	}

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -53,7 +53,7 @@ func main() {
 		glog.Fatalf("Could not read syncRetryInterval. Error %+v", err)
 	}
 
-	micClient, err := mic.NewMICClient(cloudconfig, config, forceNamespaced, syncRetryDuration*time.Second)
+	micClient, err := mic.NewMICClient(cloudconfig, config, forceNamespaced, syncRetryDuration)
 	if err != nil {
 		glog.Fatalf("Could not get the MIC client: %+v", err)
 	}

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -17,7 +17,7 @@ var (
 	cloudconfig       string
 	forceNamespaced   bool
 	versionInfo       bool
-	syncRetryInterval string
+	syncRetryDuration time.Duration
 )
 
 func main() {
@@ -26,7 +26,7 @@ func main() {
 	flag.StringVar(&cloudconfig, "cloudconfig", "", "Path to cloud config e.g. Azure.json file")
 	flag.BoolVar(&forceNamespaced, "forceNamespaced", false, "Forces namespaced identities, binding, and assignment")
 	flag.BoolVar(&versionInfo, "version", false, "Prints the version information")
-	flag.StringVar(&syncRetryInterval, "syncRetryInterval", "3600s", "The interval in seconds at which sync loop should periodically check for errors and reconcile.")
+	flag.DurationVar(&syncRetryDuration, "syncRetryDuration", 3600*time.Second, "The interval in seconds at which sync loop should periodically check for errors and reconcile.")
 
 	flag.Parse()
 	if versionInfo {
@@ -47,11 +47,6 @@ func main() {
 	}
 
 	forceNamespaced = forceNamespaced || "true" == os.Getenv("FORCENAMESPACED")
-
-	syncRetryDuration, err := time.ParseDuration(syncRetryInterval)
-	if err != nil {
-		glog.Fatalf("Could not read syncRetryInterval. Error %+v", err)
-	}
 
 	micClient, err := mic.NewMICClient(cloudconfig, config, forceNamespaced, syncRetryDuration)
 	if err != nil {

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -26,7 +26,7 @@ func main() {
 	flag.StringVar(&cloudconfig, "cloudconfig", "", "Path to cloud config e.g. Azure.json file")
 	flag.BoolVar(&forceNamespaced, "forceNamespaced", false, "Forces namespaced identities, binding, and assignment")
 	flag.BoolVar(&versionInfo, "version", false, "Prints the version information")
-	flag.StringVar(&syncRetryInterval, "syncRetryInterval", "3600", "The interval in seconds at which sync loop should periodically check for errors and reconcile.")
+	flag.StringVar(&syncRetryInterval, "syncRetryInterval", "3600s", "The interval in seconds at which sync loop should periodically check for errors and reconcile.")
 
 	flag.Parse()
 	if versionInfo {

--- a/pkg/apis/aadpodidentity/v1/types.go
+++ b/pkg/apis/aadpodidentity/v1/types.go
@@ -26,8 +26,14 @@ const (
 	CRDLabelKey = "aadpodidbinding"
 
 	BehaviorKey = "aadpodidentity.k8s.io/Behavior"
-	// Namespaced Behavior
+	// BehaviorNamespaced ...
 	BehaviorNamespaced = "namespaced"
+	// AssignedIDCreated status indicates azure assigned identity is created
+	AssignedIDCreated = "Created"
+	// AssignedIDAssigned status indicates identity has been assigned to the node
+	AssignedIDAssigned = "Assigned"
+	// AssignedIDUnAssigned status indicates identity has been unassigned from the node
+	AssignedIDUnAssigned = "Unassigned"
 )
 
 /*** Global data structures ***/

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -38,7 +38,7 @@ type ClientInt interface {
 	ListBindings() (res *[]aadpodid.AzureIdentityBinding, err error)
 	ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity, err error)
 	ListIds() (res *[]aadpodid.AzureIdentity, err error)
-	ListPodIds(podns, podname string, assignedIDStates []string) (*[]aadpodid.AzureIdentity, error)
+	ListPodIds(podns, podname string) (map[string][]aadpodid.AzureIdentity, error)
 }
 
 func NewCRDClientLite(config *rest.Config) (crdClient *Client, err error) {
@@ -257,26 +257,22 @@ func (c *Client) ListIds() (res *[]aadpodid.AzureIdentity, err error) {
 	return &ret.(*aadpodid.AzureIdentityList).Items, nil
 }
 
-//ListPodIds - given a pod with pod name space
-func (c *Client) ListPodIds(podns, podname string, assignedIDStates []string) (*[]aadpodid.AzureIdentity, error) {
+// ListPodIds - given a pod with pod name space
+// returns a map with list of azure identities in each state
+func (c *Client) ListPodIds(podns, podname string) (map[string][]aadpodid.AzureIdentity, error) {
 	azAssignedIDList, err := c.AssignedIDListWatch.List(v1.ListOptions{})
 	if err != nil {
 		glog.Error(err)
 		return nil, err
 	}
 
-	var matchedIds []aadpodid.AzureIdentity
+	idStateMap := make(map[string][]aadpodid.AzureIdentity)
 	for _, v := range azAssignedIDList.(*aadpodid.AzureAssignedIdentityList).Items {
 		if v.Spec.Pod == podname && v.Spec.PodNamespace == podns {
-			for _, desiredState := range assignedIDStates {
-				if v.Status.Status == desiredState {
-					matchedIds = append(matchedIds, *v.Spec.AzureIdentityRef)
-				}
-			}
+			idStateMap[v.Status.Status] = append(idStateMap[v.Status.Status], *v.Spec.AzureIdentityRef)
 		}
 	}
-
-	return &matchedIds, nil
+	return idStateMap, nil
 }
 
 type patchStatusOps struct {

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -267,7 +267,7 @@ func (c *Client) ListPodIds(podns, podname string) (*[]aadpodid.AzureIdentity, e
 
 	var matchedIds []aadpodid.AzureIdentity
 	for _, v := range azAssignedIDList.(*aadpodid.AzureAssignedIdentityList).Items {
-		if v.Spec.Pod == podname && v.Spec.PodNamespace == podns {
+		if v.Spec.Pod == podname && v.Spec.PodNamespace == podns && v.Status.Status == "Assigned" {
 			matchedIds = append(matchedIds, *v.Spec.AzureIdentityRef)
 		}
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -39,7 +39,7 @@ type Client interface {
 	// GetPodName return the matching azure identity or nil
 	GetPodName(podip string) (podns, podname string, err error)
 	// ListPodIds pod matching azure identity or nil
-	ListPodIds(podns, podname string) (*[]aadpodid.AzureIdentity, error)
+	ListPodIds(podns, podname string, assignedIDStates []string) (*[]aadpodid.AzureIdentity, error)
 	// GetSecret returns secret the secretRef represents
 	GetSecret(secretRef *v1.SecretReference) (*v1.Secret, error)
 }
@@ -168,8 +168,8 @@ func GetLocalIP() (string, error) {
 }
 
 // ListPodIds lists matching ids for pod or error
-func (c *KubeClient) ListPodIds(podns, podname string) (*[]aadpodid.AzureIdentity, error) {
-	return c.CrdClient.ListPodIds(podns, podname)
+func (c *KubeClient) ListPodIds(podns, podname string, assignedIDStates []string) (*[]aadpodid.AzureIdentity, error) {
+	return c.CrdClient.ListPodIds(podns, podname, assignedIDStates)
 }
 
 // GetSecret returns secret the secretRef represents

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -39,7 +39,7 @@ type Client interface {
 	// GetPodName return the matching azure identity or nil
 	GetPodName(podip string) (podns, podname string, err error)
 	// ListPodIds pod matching azure identity or nil
-	ListPodIds(podns, podname string, assignedIDStates []string) (*[]aadpodid.AzureIdentity, error)
+	ListPodIds(podns, podname string) (map[string][]aadpodid.AzureIdentity, error)
 	// GetSecret returns secret the secretRef represents
 	GetSecret(secretRef *v1.SecretReference) (*v1.Secret, error)
 }
@@ -168,8 +168,8 @@ func GetLocalIP() (string, error) {
 }
 
 // ListPodIds lists matching ids for pod or error
-func (c *KubeClient) ListPodIds(podns, podname string, assignedIDStates []string) (*[]aadpodid.AzureIdentity, error) {
-	return c.CrdClient.ListPodIds(podns, podname, assignedIDStates)
+func (c *KubeClient) ListPodIds(podns, podname string) (map[string][]aadpodid.AzureIdentity, error) {
+	return c.CrdClient.ListPodIds(podns, podname)
 }
 
 // GetSecret returns secret the secretRef represents

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -23,7 +23,7 @@ func (c *FakeClient) GetPodName(podip string) (podns, podname string, err error)
 }
 
 // ListPodIds for pod
-func (c *FakeClient) ListPodIds(podns, podname string, assignedIDState []string) (*[]aadpodid.AzureIdentity, error) {
+func (c *FakeClient) ListPodIds(podns, podname string) (map[string][]aadpodid.AzureIdentity, error) {
 	return nil, nil
 }
 

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -2,7 +2,7 @@ package k8s
 
 import (
 	aadpodid "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // FakeClient implements Interface
@@ -23,7 +23,7 @@ func (c *FakeClient) GetPodName(podip string) (podns, podname string, err error)
 }
 
 // ListPodIds for pod
-func (c *FakeClient) ListPodIds(podns string, podname string) (*[]aadpodid.AzureIdentity, error) {
+func (c *FakeClient) ListPodIds(podns, podname string, assignedIDState []string) (*[]aadpodid.AzureIdentity, error) {
 	return nil, nil
 }
 

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -160,7 +160,7 @@ func (c *Client) Sync(exit <-chan struct{}) {
 		case event = <-c.EventChannel:
 			glog.V(6).Infof("Received event: %v", event)
 		case <-ticker.C:
-			glog.V(6).Infof("Running sync retry loop")
+			glog.V(6).Infof("Running periodic sync loop")
 		}
 
 		stats.Init()

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -1091,7 +1091,11 @@ func TestSyncRetryLoop(t *testing.T) {
 	evtRecorder.eventChannel = make(chan bool, 100)
 
 	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder)
-	micClient.syncRetryInterval = 10 * time.Second
+	syncRetryInterval, err := time.ParseDuration("10s")
+	if err != nil {
+		t.Errorf("error parsing duration: %v",err)
+	}
+	micClient.syncRetryInterval = syncRetryInterval
 
 	// Add a pod, identity and binding.
 	crdClient.CreateID("test-id1", aadpodid.UserAssignedMSI, "test-user-msi-resourceid", "test-user-msi-clientid", nil, "", "", "")

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -441,8 +441,8 @@ func (c *TestCrdClient) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity
 	return &assignedIDList, nil
 }
 
-func (c *Client) ListPodIds(podns, podname string, assignedIDStates []string) (*[]aadpodid.AzureIdentity, error) {
-	return &[]aadpodid.AzureIdentity{}, nil
+func (c *Client) ListPodIds(podns, podname string) (map[string][]aadpodid.AzureIdentity, error) {
+	return map[string][]aadpodid.AzureIdentity{}, nil
 }
 
 func (c *TestCrdClient) SetError(err error) {

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -441,7 +441,7 @@ func (c *TestCrdClient) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity
 	return &assignedIDList, nil
 }
 
-func (c *Client) ListPodIds(podns, podname string) (*[]aadpodid.AzureIdentity, error) {
+func (c *Client) ListPodIds(podns, podname string, assignedIDStates []string) (*[]aadpodid.AzureIdentity, error) {
 	return &[]aadpodid.AzureIdentity{}, nil
 }
 
@@ -742,8 +742,8 @@ func TestSimpleMICClient(t *testing.T) {
 		t.Fatalf("list assigned failed")
 	}
 
-	if (*listAssignedIDs)[0].Status.Status != IdentityCreated {
-		t.Fatalf("expected status to be %s, got: %s", IdentityCreated, (*listAssignedIDs)[0].Status.Status)
+	if (*listAssignedIDs)[0].Status.Status != aadpodid.AssignedIDCreated {
+		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDCreated, (*listAssignedIDs)[0].Status.Status)
 	}
 
 	/*
@@ -1004,8 +1004,8 @@ func TestMICStateFlow(t *testing.T) {
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
 	}
-	if !((*listAssignedIDs)[0].Status.Status == IdentityAssigned) {
-		t.Fatalf("expected status to be %s, got: %s", IdentityCreated, (*listAssignedIDs)[0].Status.Status)
+	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
+		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
 	}
 
 	// delete the pod, simulate failure in cloud calls on trying to un-assign identity from node
@@ -1023,8 +1023,8 @@ func TestMICStateFlow(t *testing.T) {
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
 	}
-	if !((*listAssignedIDs)[0].Status.Status == IdentityAssigned) {
-		t.Fatalf("expected status to be %s, got: %s", IdentityAssigned, (*listAssignedIDs)[0].Status.Status)
+	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
+		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
 	}
 
 	cloudClient.UnSetError()
@@ -1052,13 +1052,13 @@ func TestMICStateFlow(t *testing.T) {
 	}
 	for _, assignedID := range *listAssignedIDs {
 		if assignedID.Spec.Pod == "test-pod1" {
-			if assignedID.Status.Status != IdentityUnassigned {
-				t.Fatalf("Expected status to be: %s. Got: %s", IdentityUnassigned, assignedID.Status.Status)
+			if assignedID.Status.Status != aadpodid.AssignedIDUnAssigned {
+				t.Fatalf("Expected status to be: %s. Got: %s", aadpodid.AssignedIDUnAssigned, assignedID.Status.Status)
 			}
 		}
 		if assignedID.Spec.Pod == "test-pod2" {
-			if assignedID.Status.Status != IdentityAssigned {
-				t.Fatalf("Expected status to be: %s. Got: %s", IdentityAssigned, assignedID.Status.Status)
+			if assignedID.Status.Status != aadpodid.AssignedIDAssigned {
+				t.Fatalf("Expected status to be: %s. Got: %s", aadpodid.AssignedIDAssigned, assignedID.Status.Status)
 			}
 		}
 	}
@@ -1093,7 +1093,7 @@ func TestSyncRetryLoop(t *testing.T) {
 	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder)
 	syncRetryInterval, err := time.ParseDuration("10s")
 	if err != nil {
-		t.Errorf("error parsing duration: %v",err)
+		t.Errorf("error parsing duration: %v", err)
 	}
 	micClient.syncRetryInterval = syncRetryInterval
 
@@ -1118,8 +1118,8 @@ func TestSyncRetryLoop(t *testing.T) {
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
 	}
-	if !((*listAssignedIDs)[0].Status.Status == IdentityAssigned) {
-		t.Fatalf("expected status to be %s, got: %s", IdentityCreated, (*listAssignedIDs)[0].Status.Status)
+	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
+		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
 	}
 
 	// delete the pod, simulate failure in cloud calls on trying to un-assign identity from node
@@ -1140,8 +1140,8 @@ func TestSyncRetryLoop(t *testing.T) {
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
 	}
-	if !((*listAssignedIDs)[0].Status.Status == IdentityAssigned) {
-		t.Fatalf("expected status to be %s, got: %s", IdentityAssigned, (*listAssignedIDs)[0].Status.Status)
+	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
+		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
 	}
 	cloudClient.UnSetError()
 

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -408,7 +408,7 @@ func listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log
 				}
 			}
 			if len(idStateMap[aadpodid.AssignedIDCreated]) == 0 && attempt >= maxAttemptsPerCheck {
-				break
+				return nil, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts. Error: %v", podns, podname, maxAttemptsPerCheck, err)
 			}
 		}
 		attempt++
@@ -421,5 +421,5 @@ func listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log
 		}
 		logger.Warningf("failed to get assigned ids for pod:%s/%s in ASSIGNED state, retrying attempt: %d", podns, podname, attempt)
 	}
-	return nil, fmt.Errorf("getting assigned identities for pod %s/%s in ASSIGNED state failed after %d attempts. Error: %v", podns, podname, maxAttemptsPerCheck, err)
+	return nil, fmt.Errorf("getting assigned identities for pod %s/%s in ASSIGNED state failed after %d attempts. Error: %v", podns, podname, 2*maxAttemptsPerCheck, err)
 }

--- a/pkg/nmi/server/server_test.go
+++ b/pkg/nmi/server/server_test.go
@@ -7,7 +7,7 @@ import (
 	aadpodid "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	"github.com/Azure/aad-pod-identity/pkg/k8s"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -37,5 +37,5 @@ func TestGetTokenForMatchingIDBySP(t *testing.T) {
 	}
 	podIDs := []aadpodid.AzureIdentity{podID}
 	logger := log.WithError(nil)
-	getTokenForMatchingID(kubeClient, logger, podID.Spec.ClientID, "https://management.azure.com/", &podIDs)
+	getTokenForMatchingID(kubeClient, logger, podID.Spec.ClientID, "https://management.azure.com/", podIDs)
 }

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		fmt.Println("\nTearing down the test environment...")
 
 		// Ensure a clean cluster after the end of each test
-		cmd := exec.Command("kubectl", "delete", "AzureIdentity,AzureIdentityBinding,AzureAssignedIdentity", "--all")
+		cmd := exec.Command("kubectl", "delete", "AzureIdentity,AzureIdentityBinding", "--all")
 		util.PrintCommand(cmd)
 		_, err := cmd.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
@@ -627,7 +627,7 @@ func setUpIdentityAndDeployment(azureIdentityName, suffix, replicas string) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(ok).To(Equal(true))
 
-	time.Sleep(30 * time.Second)
+	//time.Sleep(30 * time.Second)
 }
 
 // validateAzureAssignedIdentity will make sure a given AzureAssignedIdentity has the correct properties

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -626,8 +626,6 @@ func setUpIdentityAndDeployment(azureIdentityName, suffix, replicas string) {
 	ok, err = daemonset.WaitOnReady(nmiDaemonSet)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(ok).To(Equal(true))
-
-	//time.Sleep(30 * time.Second)
 }
 
 // validateAzureAssignedIdentity will make sure a given AzureAssignedIdentity has the correct properties

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	cfg = *c
 
-	setupInfra()
+	setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion)
 })
 
 var _ = AfterSuite(func() {
@@ -482,7 +482,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		}
 
 		// reset the infra to previous state
-		setupInfra()
+		setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion)
 	})
 
 	It("should not alter the system assigned identity after creating and deleting pod identity", func() {
@@ -556,12 +556,47 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 			}
 		}
 	})
+
+	It("should be backward compatible with old and new version of mic and nmi", func() {
+		// Uninstall CRDs and delete MIC and NMI
+		err := deploy.Delete("default", templateOutputPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		ok, err := pod.WaitOnDeletion("nmi")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		// setup mic and nmi with old releases
+		setupInfra("mcr.microsoft.com/k8s/aad-pod-identity", "1.4", "1.3")
+
+		setUpIdentityAndDeployment(keyvaultIdentity, "", "1")
+
+		ok, err = azureassignedidentity.WaitOnLengthMatched(1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		// update the infra to use latest mic and nmi images
+		setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion)
+
+		ok, err = daemonset.WaitOnReady(nmiDaemonSet)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		ok, err = waitForIPTableRulesToExist("busybox")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
+		Expect(err).NotTo(HaveOccurred())
+
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+	})
 })
 
 // setupInfra creates the crds, mic, nmi and blocks until iptable entries exist
-func setupInfra() {
+func setupInfra(registry, nmiVersion, micVersion string) {
 	// Install CRDs and deploy MIC and NMI
-	err := infra.CreateInfra("default", cfg.Registry, cfg.NMIVersion, cfg.MICVersion, templateOutputPath)
+	err := infra.CreateInfra("default", registry, nmiVersion, micVersion, templateOutputPath)
 
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -85,6 +85,8 @@ metadata:
   name: nmi
   namespace: {{.Namespace}}
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Wrap list pod ids call with retries
- Filter assigned ids based on state in NMI
- Change the status code to `404` instead of `403` when no valid assigned ids found after retries. 
- Add a ticker to periodically run sync cycle to reconcile any crds that are in error state. This is required because if no pod events are generated, then the sync loop will never get triggered to resync.
- Make the sync retry interval configurable

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/257

**Notes for Reviewers**:
