### PR TITLE
Modifying Log Level for failing to update iptables error from Fatal to Error

### DIFF
--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -93,10 +93,10 @@ loop:
 		case <-ticker.C:
 			log.Infof("node(%s) hostip(%s) metadataaddress(%s:%s) nmiport(%s)", s.NodeName, s.HostIP, s.MetadataIP, s.MetadataPort, s.NMIPort)
 			if err := iptables.AddCustomChain(s.MetadataIP, s.MetadataPort, s.HostIP, s.NMIPort); err != nil {
-				log.Fatalf("%s", err)
+				log.Errorf("%s", err)
 			}
 			if err := iptables.LogCustomChain(); err != nil {
-				log.Fatalf("%s", err)
+				log.Errorf("%s", err)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
Modified the log level from `Fatal` to `Error`, if there is an error while accessing the iptables.
Currently, `NMI` exits with a status code, if there is an error while accessing the iptables, this causes disruption in the datapath operations for applications, and could lead to customer facing errors.
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
**Issue Fixed**:
#249 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
**Notes for Reviewers**:
This PR is not a fix for the issue, as I am not able to reach to the RCA, what is causing iptables to be inaccessible, but this PR improves upon the current error handling.