### PR TITLE
Add leader election code to MIC

### DIFF
--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -39,7 +39,7 @@ func main() {
 	flag.StringVar(&leaderElectionCfg.ThisLeaderName, "leader-election-name", hostName, "leader name. default is 'hostname'")
 	flag.StringVar(&leaderElectionCfg.LeaderElectionNamespace, "leader-election-namespace", "default", "name space to create leader election objects. default is 'default' namesapce")
 	flag.StringVar(&leaderElectionCfg.LeaderElectionId, "leader-election-id", "aad-pod-identity-mic", "leader election id")
-	flag.DurationVar(&leaderElectionCfg.LeaderElectionTtl, "leader-election-ttl", time.Second*30, "leader election ttl")
+	flag.DurationVar(&leaderElectionCfg.LeaderElectionTtl, "leader-election-ttl", time.Second*15, "leader election ttl")
 
 	flag.Parse()
 	if versionInfo {

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -25,7 +25,7 @@ func main() {
 	defer glog.Flush()
 	hostName, err := os.Hostname()
 	if err != nil {
-		glog.Fatalf("Get hostname failure.")
+		glog.Fatalf("Get hostname failure. Error: %+v", err)
 	}
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to the kube config")
 	flag.StringVar(&cloudconfig, "cloudconfig", "", "Path to cloud config e.g. Azure.json file")
@@ -34,9 +34,9 @@ func main() {
 	flag.DurationVar(&syncRetryDuration, "syncRetryDuration", 3600*time.Second, "The interval in seconds at which sync loop should periodically check for errors and reconcile.")
 
 	// Leader election parameters
-	flag.StringVar(&leaderElectionCfg.ResourceName, "leader-election-name", hostName, "leader name. default is 'hostname'")
-	flag.StringVar(&leaderElectionCfg.Namespace, "leader-election-namespace", "default", "name space to create leader election objects. default is 'default' namesapce")
-	flag.StringVar(&leaderElectionCfg.ID, "leader-election-id", "aad-pod-identity-mic", "leader election id")
+	flag.StringVar(&leaderElectionCfg.Instance, "leader-election-instance", hostName, "leader election instance name. default is 'hostname'")
+	flag.StringVar(&leaderElectionCfg.Namespace, "leader-election-namespace", "default", "namespace to create leader election objects")
+	flag.StringVar(&leaderElectionCfg.Name, "leader-election-name", "aad-pod-identity-mic", "leader election name")
 	flag.DurationVar(&leaderElectionCfg.Duration, "leader-election-duration", time.Second*15, "leader election duration")
 
 	flag.Parse()

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -52,9 +52,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Could not get the MIC client: %+v", err)
 	}
-
-	exit := make(chan struct{})
-	micClient.Start(exit)
+	micClient.Run()
 	glog.Info("AAD Pod identity controller initialized!!")
 	//Infinite loop :-)
 	select {}

--- a/deploy/infra/master/replicaset/deployment-rbac.yaml
+++ b/deploy/infra/master/replicaset/deployment-rbac.yaml
@@ -103,7 +103,7 @@ spec:
         name: iptableslock
       containers:
       - name: nmi
-        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.4"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.5-rc1"
         imagePullPolicy: Always
         args:
           - "--host-ip=$(HOST_IP)"
@@ -150,7 +150,7 @@ rules:
   verbs: ["create", "patch"]
 - apiGroups: [""]
   resources: ["endpoints"]
-  verbs: ["create", "get", "list", "watch", "update", "patch"]
+  verbs: ["create", "get","update"]
 - apiGroups: ["aadpodidentity.k8s.io"]
   resources: ["azureidentitybindings", "azureidentities"]
   verbs: ["get", "list", "watch", "post"]
@@ -191,7 +191,7 @@ spec:
       serviceAccountName: aad-pod-id-mic-service-account
       containers:
       - name: mic
-        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.3"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.5-rc1"
         imagePullPolicy: Always
         args:
           - "--cloudconfig=/etc/kubernetes/azure.json"

--- a/deploy/infra/master/replicaset/deployment-rbac.yaml
+++ b/deploy/infra/master/replicaset/deployment-rbac.yaml
@@ -1,0 +1,208 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-id-nmi-service-account
+  namespace: default
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureassignedidentities.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureAssignedIdentity
+    plural: azureassignedidentities
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentitybindings.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentityBinding
+    plural: azureidentitybindings
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentities.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentity
+    singular: azureidentity
+    plural: azureidentities
+  scope: Namespaced
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-id-nmi-role
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-id-nmi-binding
+  labels:
+    k8s-app: aad-pod-id-nmi-binding
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-id-nmi-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-id-nmi-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    component: nmi
+    tier: node
+    k8s-app: aad-pod-id
+  name: nmi
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        component: nmi
+        tier: node
+    spec:
+      serviceAccountName: aad-pod-id-nmi-service-account
+      hostNetwork: true
+      volumes:
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: iptableslock
+      containers:
+      - name: nmi
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.4"
+        imagePullPolicy: Always
+        args:
+          - "--host-ip=$(HOST_IP)"
+          - "--node=$(NODE_NAME)"
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: iptableslock
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-id-mic-service-account
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-id-mic-role
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: [ "list", "watch" ]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["create", "get", "list", "watch", "update", "patch"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list", "watch", "post"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-id-mic-binding
+  labels:
+    k8s-app: aad-pod-id-mic-binding
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-id-mic-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-id-mic-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: mic
+    k8s-app: aad-pod-id
+  name: mic
+  namespace: default
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: mic
+    spec:
+      serviceAccountName: aad-pod-id-mic-service-account
+      containers:
+      - name: mic
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.3"
+        imagePullPolicy: Always
+        args:
+          - "--cloudconfig=/etc/kubernetes/azure.json"
+          - "--logtostderr"
+        volumeMounts:
+        - name: k8s-azure-file
+          mountPath: /etc/kubernetes/azure.json
+          readOnly: true
+      volumes:
+      - name: k8s-azure-file
+        hostPath:
+          path: /etc/kubernetes/azure.json
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/deploy/infra/master/replicaset/deployment.yaml
+++ b/deploy/infra/master/replicaset/deployment.yaml
@@ -1,0 +1,130 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureassignedidentities.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureAssignedIdentity
+    plural: azureassignedidentities
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentitybindings.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentityBinding
+    plural: azureidentitybindings
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentities.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentity
+    singular: azureidentity
+    plural: azureidentities
+  scope: Namespaced
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    component: nmi
+    tier: node
+  name: nmi
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        component: nmi
+        tier: node
+    spec:
+      hostNetwork: true
+      volumes:
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: iptableslock
+      containers:
+      - name: nmi
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:master"
+        imagePullPolicy: Always
+        args:
+          - "--host-ip=$(HOST_IP)"
+          - "--node=$(NODE_NAME)"
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: iptableslock
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: mic
+  name: mic
+  namespace: default
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        component: mic
+    spec:
+      containers:
+      - name: mic
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:master"
+        imagePullPolicy: Always
+        args:
+          - "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
+          - "--cloudconfig=/etc/kubernetes/azure.json"
+          - "--logtostderr"
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /etc/kubernetes/kubeconfig
+            readOnly: true
+          - name: certificates
+            mountPath: /etc/kubernetes/certs
+            readOnly: true
+          - name: k8s-azure-file
+            mountPath: /etc/kubernetes/azure.json
+            readOnly: true
+      volumes:
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kubelet
+      - name: certificates
+        hostPath:
+          path: /etc/kubernetes/certs
+      - name: k8s-azure-file
+        hostPath:
+          path: /etc/kubernetes/azure.json
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -2,6 +2,7 @@ package mic
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,6 +21,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -34,6 +37,13 @@ type NodeGetter interface {
 	Start(<-chan struct{})
 }
 
+type leaderElectionConfig struct {
+	LeaderElectionNamespace string
+	LeaderElectionTtl       time.Duration
+	LeaderElectionId        string
+	ThisLeaderName          string
+}
+
 // Client has the required pointers to talk to the api server
 // and interact with the CRD related datastructure.
 type Client struct {
@@ -46,7 +56,9 @@ type Client struct {
 	IsNamespaced      bool
 	syncRetryInterval time.Duration
 
-	syncing int32 // protect against conucrrent sync's
+	syncing       int32 // protect against conucrrent sync's
+	leaderElector *leaderelection.LeaderElector
+	*leaderElectionConfig
 }
 
 // ClientInt ...
@@ -90,7 +102,7 @@ func NewMICClient(cloudconfig string, config *rest.Config, isNamespaced bool, sy
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: aadpodid.CRDGroup})
 
-	return &Client{
+	c := &Client{
 		CRDClient:         crdClient,
 		CloudClient:       cloudClient,
 		PodClient:         podClient,
@@ -99,7 +111,57 @@ func NewMICClient(cloudconfig string, config *rest.Config, isNamespaced bool, sy
 		NodeClient:        &NodeClient{informer.Core().V1().Nodes()},
 		IsNamespaced:      isNamespaced,
 		syncRetryInterval: syncRetryInterval,
-	}, nil
+	}
+
+	leaderElector, err := c.NewLeaderElector(clientSet, recorder)
+	if err != nil {
+		return nil, err
+	}
+	c.leaderElector = leaderElector
+
+	return c, nil
+}
+
+// Run - Initiates the leader election run call to find if its leader and run it
+func (c *Client) Run() {
+	c.leaderElector.Run()
+}
+
+// NewLeaderElector - does the required leader election initialization
+func (c *Client) NewLeaderElector(clientSet *kubernetes.Clientset, recorder record.EventRecorder) (leaderElector *leaderelection.LeaderElector, err error) {
+	resourceLock, err := resourcelock.New(resourcelock.EndpointsResourceLock,
+		c.LeaderElectionNamespace,
+		c.LeaderElectionNamespace,
+		clientSet.CoreV1(),
+		resourcelock.ResourceLockConfig{
+			Identity:      c.ThisLeaderName,
+			EventRecorder: recorder})
+	if err != nil {
+		glog.Errorf("Resource lock creation for leadeer election failed with error : %v", err)
+		return nil, err
+	}
+	config := leaderelection.LeaderElectionConfig{
+		LeaseDuration: c.LeaderElectionTtl,
+		RenewDeadline: c.LeaderElectionTtl / 2,
+		RetryPeriod:   c.LeaderElectionTtl / 4,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(exit <-chan struct{}) {
+				c.Start(exit)
+			},
+			OnStoppedLeading: func() {
+				glog.Errorf("Lost Leader Lease")
+				glog.Flush()
+				os.Exit(1)
+			},
+		},
+		Lock: resourceLock,
+	}
+
+	leaderElector, err = leaderelection.NewLeaderElector(config)
+	if err != nil {
+		return nil, err
+	}
+	return leaderElector, nil
 }
 
 // Start ...

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -140,6 +140,9 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["create", "get", "list", "watch", "update", "patch"]
 - apiGroups: ["aadpodidentity.k8s.io"]
   resources: ["azureidentitybindings", "azureidentities"]
   verbs: ["get", "list", "watch", "post"]
@@ -171,6 +174,7 @@ metadata:
   name: mic
   namespace: {{.Namespace}}
 spec:
+  replicas: 2
   template:
     metadata:
       labels:

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -142,7 +142,7 @@ rules:
   verbs: ["create", "patch"]
 - apiGroups: [""]
   resources: ["endpoints"]
-  verbs: ["create", "get", "list", "watch", "update", "patch"]
+  verbs: [ "create", "get", "update"]
 - apiGroups: ["aadpodidentity.k8s.io"]
   resources: ["azureidentitybindings", "azureidentities"]
   verbs: ["get", "list", "watch", "post"]


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Add leader election code to MIC to run it as ReplicaSet with multiple replicas which can come up and continue in case of a failure of the active MIC. Also added are deployment yamls which configures the ReplicaSet appropriately under deploy/master/replicaset.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:

TODO: 
1. Add tests in e2e