### PR TITLE
Add e2e test for vmss deletion

### DIFF
--- a/test/common/azure/azure.go
+++ b/test/common/azure/azure.go
@@ -9,8 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
 )
+
+type Resource = azure.Resource
 
 // UserAssignedIdentity is used to parse user assigned identity data from 'az vm identity show'
 type UserAssignedIdentity struct {
@@ -193,9 +196,21 @@ func StopKubelet(resourceGroup, vmName string) error {
 func EnableUserAssignedIdentityOnVM(resourceGroup, vmName, identityName string) error {
 	fmt.Printf("# Assigning user assigned identity '%s' to %s...\n", identityName, vmName)
 	cmd := exec.Command("az", "vm", "identity", "assign", "-g", resourceGroup, "-n", vmName, "--identities", identityName)
-	_, err := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, "Failed to assign user assigned identity to VM")
+		return errors.Wrapf(err, "Failed to assign user assigned identity to VM: %s", string(out))
+	}
+
+	return nil
+}
+
+// EnableUserAssignedIdentityOnVMSS will enable a user assigned identity to a VM
+func EnableUserAssignedIdentityOnVMSS(resourceGroup, vmName, identityName string) error {
+	fmt.Printf("# Assigning user assigned identity '%s' to %s...\n", identityName, vmName)
+	cmd := exec.Command("az", "vmss", "identity", "assign", "-g", resourceGroup, "-n", vmName, "--identities", identityName)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to assign user assigned identity to VM: %s", string(out))
 	}
 
 	return nil
@@ -205,6 +220,19 @@ func EnableUserAssignedIdentityOnVM(resourceGroup, vmName, identityName string) 
 func EnableSystemAssignedIdentityOnVM(resourceGroup, vmName string) error {
 	fmt.Printf("# Assigning system assigned identity to %s...\n", vmName)
 	cmd := exec.Command("az", "vm", "identity", "assign", "-g", resourceGroup, "-n", vmName)
+	cmdOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("%s\n", cmdOutput)
+		return errors.Wrap(err, "Failed to enable identity to VM")
+	}
+
+	return nil
+}
+
+// EnableSystemAssignedIdentityOnVMSS will enable a system assigned identity to a VM
+func EnableSystemAssignedIdentityOnVMSS(resourceGroup, vmName string) error {
+	fmt.Printf("# Assigning system assigned identity to %s...\n", vmName)
+	cmd := exec.Command("az", "vmss", "identity", "assign", "-g", resourceGroup, "-n", vmName)
 	cmdOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Printf("%s\n", cmdOutput)
@@ -249,15 +277,15 @@ func UserIdentityAssignedToVMSS(resourceGroup, vmssName, identityName string) (b
 	return false, nil
 }
 
-// GetUserAssignedIdentities will return the list of user assigned identity in a given VM
-func GetUserAssignedIdentities(resourceGroup, vmName string) (*map[string]UserAssignedIdentity, error) {
+// GetVMUserAssignedIdentities will return the list of user assigned identity in a given VM
+func GetVMUserAssignedIdentities(resourceGroup, vmName string) (map[string]UserAssignedIdentity, error) {
 	// Sleep for 30 seconds to allow potential changes to propagate to Azure
 	time.Sleep(time.Second * 30)
 
 	cmd := exec.Command("az", "vm", "identity", "show", "-g", resourceGroup, "-n", vmName)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get user assigned identity from VM")
+		return nil, errors.Wrapf(err, "Failed to get user assigned identity from VM: %s", string(out))
 	}
 
 	var vmIdentity VMIdentity
@@ -265,18 +293,48 @@ func GetUserAssignedIdentities(resourceGroup, vmName string) (*map[string]UserAs
 
 	// Return an empty userAssignedIdentities if out slice is empty
 	if len(out) == 0 {
-		return &userAssignedIdentities, nil
+		return userAssignedIdentities, nil
 	} else if err := json.Unmarshal(out, &vmIdentity); err != nil {
 		return nil, errors.Wrap(err, "Failed to unmarshall json")
 	}
 
 	if vmIdentity.Type == "SystemAssigned" {
-		return &userAssignedIdentities, nil
+		return userAssignedIdentities, nil
+	} else if err := json.Unmarshal(*vmIdentity.UserAssignedIdentities, userAssignedIdentities); err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshall json")
+	}
+
+	return userAssignedIdentities, nil
+}
+
+// GetVMSSUserAssignedIdentities will return the list of user assigned identity in a given VM
+func GetVMSSUserAssignedIdentities(resourceGroup, name string) (map[string]UserAssignedIdentity, error) {
+	// Sleep for 30 seconds to allow potential changes to propagate to Azure
+	time.Sleep(time.Second * 30)
+
+	cmd := exec.Command("az", "vmss", "identity", "show", "-g", resourceGroup, "-n", name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get user assigned identity from VMSS: %s", string(out))
+	}
+
+	var vmIdentity VMIdentity
+	var userAssignedIdentities map[string]UserAssignedIdentity
+
+	// Return an empty userAssignedIdentities if out slice is empty
+	if len(out) == 0 {
+		return userAssignedIdentities, nil
+	} else if err := json.Unmarshal(out, &vmIdentity); err != nil {
+		return nil, errors.Wrap(err, "Failed to unmarshall json")
+	}
+
+	if vmIdentity.Type == "SystemAssigned" {
+		return userAssignedIdentities, nil
 	} else if err := json.Unmarshal(*vmIdentity.UserAssignedIdentities, &userAssignedIdentities); err != nil {
 		return nil, errors.Wrap(err, "Failed to unmarshall json")
 	}
 
-	return &userAssignedIdentities, nil
+	return userAssignedIdentities, nil
 }
 
 // RemoveUserAssignedIdentityFromVM will remove a user assigned identity to a VM
@@ -291,12 +349,44 @@ func RemoveUserAssignedIdentityFromVM(resourceGroup, vmName, identityName string
 	return nil
 }
 
-// GetSystemAssignedIdentity will return the principal ID and tenant ID of a system assigned identity
-func GetSystemAssignedIdentity(resourceGroup, vmName string) (string, string, error) {
+// RemoveUserAssignedIdentityFromVMSS will remove a user assigned identity to a VMSS
+func RemoveUserAssignedIdentityFromVMSS(resourceGroup, vmName, identityName string) error {
+	fmt.Printf("# Removing identity '%s' from %s...\n", identityName, vmName)
+	cmd := exec.Command("az", "vmss", "identity", "remove", "-g", resourceGroup, "-n", vmName, "--identities", identityName)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "Failed to remove user assigned identity to VMSS")
+	}
+
+	return nil
+}
+
+// GetVMSystemAssignedIdentity will return the principal ID and tenant ID of a system assigned identity
+func GetVMSystemAssignedIdentity(resourceGroup, vmName string) (string, string, error) {
 	cmd := exec.Command("az", "vm", "identity", "show", "-g", resourceGroup, "-n", vmName)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", "", errors.Wrap(err, "Failed to get system assigned identity from VM")
+	}
+
+	var systemAssignedIdentity VMIdentity
+	if err := json.Unmarshal(out, &systemAssignedIdentity); err != nil {
+		return "", "", errors.Wrap(err, "Failed to unmarshall json")
+	}
+
+	if strings.Contains(systemAssignedIdentity.Type, "SystemAssigned") {
+		return systemAssignedIdentity.PrincipalID, systemAssignedIdentity.TenantID, nil
+	}
+
+	return "", "", nil
+}
+
+// GetVMSSSystemAssignedIdentity will return the principal ID and tenant ID of a system assigned identity
+func GetVMSSSystemAssignedIdentity(resourceGroup, name string) (string, string, error) {
+	cmd := exec.Command("az", "vmss", "identity", "show", "-g", resourceGroup, "-n", name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", "", errors.Wrap(err, "Failed to get system assigned identity from VMSS")
 	}
 
 	var systemAssignedIdentity VMIdentity
@@ -319,6 +409,19 @@ func RemoveSystemAssignedIdentityFromVM(resourceGroup, vmName string) error {
 	if err != nil {
 		fmt.Printf("%s\n", cmdOutput)
 		return errors.Wrap(err, "Failed to remove system assigned identity to VM")
+	}
+
+	return nil
+}
+
+// RemoveSystemAssignedIdentityFromVMSS will remove the system assigned identity to a VMSS
+func RemoveSystemAssignedIdentityFromVMSS(resourceGroup, name string) error {
+	fmt.Printf("# Removing system assigned identity from %s...\n", name)
+	cmd := exec.Command("az", "vmss", "identity", "remove", "-g", resourceGroup, "-n", name)
+	cmdOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("%s\n", cmdOutput)
+		return errors.Wrap(err, "Failed to remove system assigned identity to VMSS")
 	}
 
 	return nil

--- a/test/common/k8s/deploy/deploy.go
+++ b/test/common/k8s/deploy/deploy.go
@@ -43,9 +43,9 @@ type Status struct {
 func Delete(name, templateOutputPath string) error {
 	cmd := exec.Command("kubectl", "delete", "-f", path.Join(templateOutputPath, name+"-deployment.yaml"), "--now", "--ignore-not-found")
 	util.PrintCommand(cmd)
-	_, err := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Wrapf(err, "Failed to delete %v from the Kubernetes cluster", name)
+		return errors.Wrapf(err, "Failed to delete %v from the Kubernetes cluster: %s", name, out)
 	}
 
 	return nil

--- a/test/common/k8s/infra/infra.go
+++ b/test/common/k8s/infra/infra.go
@@ -89,9 +89,9 @@ func CreateIdentityValidator(subscriptionID, resourceGroup, templateOutputPath s
 
 	cmd := exec.Command("kubectl", "apply", "-f", deployFilePath)
 	util.PrintCommand(cmd)
-	_, err = cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, "Failed to deploy AzureIdentityBinding to the Kubernetes cluster")
+		return errors.Wrapf(err, "Failed to deploy AzureIdentityBinding to the Kubernetes cluster: %s", out)
 	}
 
 	return nil

--- a/test/e2e/template/deployment.yaml
+++ b/test/e2e/template/deployment.yaml
@@ -14,6 +14,9 @@ spec:
         app: identity-validator
         aadpodidbinding: {{.IdentityBinding}}
     spec:
+      {{ if ne .NodeName "" -}}
+      nodeName: {{.NodeName}}
+      {{- end }}
       containers:
       - name: {{.Name}}
         image: {{.Registry}}/identityvalidator:{{.IdentityValidatorVersion}}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Adds an e2e test testing deletion of vmss identities.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:

I have not run this test yet and am not particularly familiar with Ginkgo. Be kind 👼 🙇 
Posting this for early input.