### PR TITLE
Parallelize node cloud calls

### DIFF
--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -627,12 +627,16 @@ func (c *Client) updateAssignedIdentityStatus(assignedID *aadpodid.AzureAssigned
 }
 
 func (c *Client) updateNodeAndDeps(newAssignedIDs []aadpodid.AzureAssignedIdentity, nodeMap map[string]trackUserAssignedMSIIds, nodeRefs map[string]bool) {
+	var wg sync.WaitGroup
 	for nodeName, nodeTrackList := range nodeMap {
-		c.updateUserMSI(newAssignedIDs, nodeName, nodeTrackList, nodeRefs)
+		wg.Add(1)
+		go c.updateUserMSI(newAssignedIDs, nodeName, nodeTrackList, nodeRefs, &wg)
 	}
+	wg.Wait()
 }
 
-func (c *Client) updateUserMSI(newAssignedIDs []aadpodid.AzureAssignedIdentity, nodeName string, nodeTrackList trackUserAssignedMSIIds, nodeRefs map[string]bool) {
+func (c *Client) updateUserMSI(newAssignedIDs []aadpodid.AzureAssignedIdentity, nodeName string, nodeTrackList trackUserAssignedMSIIds, nodeRefs map[string]bool, wg *sync.WaitGroup) {
+	defer wg.Done()
 	beginAdding := time.Now()
 	glog.V(5).Infof("Processing node %s", nodeName)
 

--- a/test/common/azure/azure.go
+++ b/test/common/azure/azure.go
@@ -300,7 +300,7 @@ func GetVMUserAssignedIdentities(resourceGroup, vmName string) (map[string]UserA
 
 	if vmIdentity.Type == "SystemAssigned" {
 		return userAssignedIdentities, nil
-	} else if err := json.Unmarshal(*vmIdentity.UserAssignedIdentities, userAssignedIdentities); err != nil {
+	} else if err := json.Unmarshal(*vmIdentity.UserAssignedIdentities, &userAssignedIdentities); err != nil {
 		return nil, errors.Wrap(err, "Failed to unmarshall json")
 	}
 

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -626,7 +626,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		}
 
 		if vmssID == "" {
-			fmt.Println("skipping test since no there is no vmss with more than 1 node")
+			fmt.Println("skipping test since there is no vmss with more than 1 node")
 			return
 		}
 
@@ -726,7 +726,7 @@ func setUpIdentityAndDeployment(azureIdentityName, suffix, replicas string, tmpl
 	Expect(err).NotTo(HaveOccurred())
 
 	data := infra.IdentityValidatorTemplateData{
-		Name:                     identityValidator,
+		Name:                     identityValidatorName,
 		IdentityBinding:          azureIdentityName,
 		Registry:                 cfg.Registry,
 		IdentityValidatorVersion: cfg.IdentityValidatorVersion,


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
This feature is to parallel process cloud API calls to node for identity assignment and removal.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
e2e tests in master branch are broken. This PR fixes the e2e tests.

**Notes for Reviewers**:
