### PR TITLE
Liveness probe

### DIFF
--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -25,7 +25,6 @@ var (
 
 func main() {
 	defer glog.Flush()
-	startTime := time.Now()
 	hostName, err := os.Hostname()
 	if err != nil {
 		glog.Fatalf("Get hostname failure. Error: %+v", err)
@@ -71,9 +70,9 @@ func main() {
 	}
 
 	// Health probe will always report success once its started.
-	// MIC instance will report ready only once its elected the leader
+	// MIC instance will report the contents as "Active" only once its elected the leader
 	// and starts the sync loop.
-	probes.InitAndStart(httpProbePort, startTime, &micClient.SyncLoopStarted)
+	probes.InitAndStart(httpProbePort, &micClient.SyncLoopStarted)
 
 	// Starts the leader election loop
 	micClient.Run()

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.DurationVar(&leaderElectionCfg.Duration, "leader-election-duration", time.Second*15, "leader election duration")
 
 	//Probe port
-	flag.StringVar(&httpProbePort, "http-probe-port", "8080", "http health and ready probe port")
+	flag.StringVar(&httpProbePort, "http-probe-port", "8080", "http liveliness probe port")
 
 	flag.Parse()
 	if versionInfo {

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Azure/aad-pod-identity/pkg/mic"
+	"github.com/Azure/aad-pod-identity/pkg/probes"
 	"github.com/Azure/aad-pod-identity/version"
 	"github.com/golang/glog"
 	"k8s.io/client-go/rest"
@@ -19,10 +20,12 @@ var (
 	versionInfo       bool
 	syncRetryDuration time.Duration
 	leaderElectionCfg mic.LeaderElectionConfig
+	httpProbePort     string
 )
 
 func main() {
 	defer glog.Flush()
+	startTime := time.Now()
 	hostName, err := os.Hostname()
 	if err != nil {
 		glog.Fatalf("Get hostname failure. Error: %+v", err)
@@ -38,6 +41,9 @@ func main() {
 	flag.StringVar(&leaderElectionCfg.Namespace, "leader-election-namespace", "default", "namespace to create leader election objects")
 	flag.StringVar(&leaderElectionCfg.Name, "leader-election-name", "aad-pod-identity-mic", "leader election name")
 	flag.DurationVar(&leaderElectionCfg.Duration, "leader-election-duration", time.Second*15, "leader election duration")
+
+	//Probe port
+	flag.StringVar(&httpProbePort, "http-probe-port", "8080", "http health and ready probe port")
 
 	flag.Parse()
 	if versionInfo {
@@ -63,6 +69,12 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Could not get the MIC client: %+v", err)
 	}
+
+	// Health probe will always report success once its started.
+	// MIC instance will report ready only once its elected the leader
+	// and starts the sync loop.
+	probes.InitAndStart(httpProbePort, startTime, &micClient.SyncLoopStarted)
+
 	// Starts the leader election loop
 	micClient.Run()
 	glog.Info("AAD Pod identity controller initialized!!")

--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"time"
 
 	"github.com/Azure/aad-pod-identity/pkg/k8s"
 	server "github.com/Azure/aad-pod-identity/pkg/nmi/server"
@@ -34,7 +33,6 @@ var (
 )
 
 func main() {
-	startTime := time.Now()
 	pflag.Parse()
 	if *versionInfo {
 		version.PrintVersionAndExit()
@@ -57,9 +55,9 @@ func main() {
 	s.NodeName = *nodename
 	s.IPTableUpdateTimeIntervalInSeconds = *ipTableUpdateTimeIntervalInSeconds
 
-	// Health probe will always report success once its started.
-	// NMI instance will report ready only once the iptable rules are set
-	probes.InitAndStart(*httpProbePort, startTime, &s.Initialized)
+	// Health probe will always report success once its started. The contents
+	// will report "Active" once the iptables rules are set
+	probes.InitAndStart(*httpProbePort, &s.Initialized)
 
 	if err := s.Run(); err != nil {
 		log.Fatalf("%s", err)

--- a/deploy/infra/master/replicaset/deployment-rbac.yaml
+++ b/deploy/infra/master/replicaset/deployment-rbac.yaml
@@ -103,7 +103,7 @@ spec:
         name: iptableslock
       containers:
       - name: nmi
-        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.5-rc1"
+        image: "testle5.azurecr.io/nmi:le"
         imagePullPolicy: Always
         args:
           - "--host-ip=$(HOST_IP)"
@@ -129,13 +129,13 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
         readinessProbe:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -203,7 +203,7 @@ spec:
       serviceAccountName: aad-pod-id-mic-service-account
       containers:
       - name: mic
-        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.5-rc1"
+        image: "testle5.azurecr.io/mic:le"
         imagePullPolicy: Always
         args:
           - "--cloudconfig=/etc/kubernetes/azure.json"
@@ -212,18 +212,18 @@ spec:
         - name: k8s-azure-file
           mountPath: /etc/kubernetes/azure.json
           readOnly: true
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
       volumes:
       - name: k8s-azure-file
         hostPath:

--- a/deploy/infra/master/replicaset/deployment-rbac.yaml
+++ b/deploy/infra/master/replicaset/deployment-rbac.yaml
@@ -125,6 +125,18 @@ spec:
         volumeMounts:
         - mountPath: /run/xtables.lock
           name: iptableslock
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
 ---
@@ -200,6 +212,18 @@ spec:
         - name: k8s-azure-file
           mountPath: /etc/kubernetes/azure.json
           readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
       - name: k8s-azure-file
         hostPath:

--- a/deploy/infra/master/replicaset/deployment-rbac.yaml
+++ b/deploy/infra/master/replicaset/deployment-rbac.yaml
@@ -103,7 +103,7 @@ spec:
         name: iptableslock
       containers:
       - name: nmi
-        image: "testle5.azurecr.io/nmi:le"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.5-rc1"
         imagePullPolicy: Always
         args:
           - "--host-ip=$(HOST_IP)"
@@ -128,12 +128,6 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /ready
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
@@ -203,7 +197,7 @@ spec:
       serviceAccountName: aad-pod-id-mic-service-account
       containers:
       - name: mic
-        image: "testle5.azurecr.io/mic:le"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.5-rc1"
         imagePullPolicy: Always
         args:
           - "--cloudconfig=/etc/kubernetes/azure.json"
@@ -215,12 +209,6 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /ready
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5

--- a/deploy/infra/master/replicaset/deployment.yaml
+++ b/deploy/infra/master/replicaset/deployment.yaml
@@ -81,6 +81,18 @@ spec:
         volumeMounts:
         - mountPath: /run/xtables.lock
           name: iptableslock
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
 ---
@@ -116,6 +128,18 @@ spec:
           - name: k8s-azure-file
             mountPath: /etc/kubernetes/azure.json
             readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
       - name: kubeconfig
         hostPath:

--- a/deploy/infra/master/replicaset/deployment.yaml
+++ b/deploy/infra/master/replicaset/deployment.yaml
@@ -85,13 +85,13 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
         readinessProbe:
           httpGet:
             path: /ready
             port: 8080
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -128,18 +128,18 @@ spec:
           - name: k8s-azure-file
             mountPath: /etc/kubernetes/azure.json
             readOnly: true
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
       volumes:
       - name: kubeconfig
         hostPath:

--- a/deploy/infra/master/replicaset/deployment.yaml
+++ b/deploy/infra/master/replicaset/deployment.yaml
@@ -87,12 +87,6 @@ spec:
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
 ---
@@ -131,12 +125,6 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /ready
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -55,6 +55,7 @@ type Client struct {
 	EventChannel      chan aadpodid.EventType
 	NodeClient        NodeGetter
 	IsNamespaced      bool
+	SyncLoopStarted   bool
 	syncRetryInterval time.Duration
 
 	syncing       int32 // protect against conucrrent sync's
@@ -217,6 +218,7 @@ func (c *Client) Sync(exit <-chan struct{}) {
 	defer ticker.Stop()
 
 	glog.Info("Sync thread started.")
+	c.SyncLoopStarted = true
 	var event aadpodid.EventType
 	for {
 		select {

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -126,7 +126,7 @@ func NewMICClient(cloudconfig string, config *rest.Config, isNamespaced bool, sy
 
 // Run - Initiates the leader election run call to find if its leader and run it
 func (c *Client) Run() {
-	glog.Infof("MIC Leader election initiated")
+	glog.Infof("Initiating MIC Leader election")
 	c.leaderElector.Run()
 }
 

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -46,6 +46,7 @@ type Server struct {
 	IPTableUpdateTimeIntervalInSeconds int
 	IsNamespaced                       bool
 	MICNamespace                       string
+	Initialized                        bool
 }
 
 // NMIResponse is the response returned to caller
@@ -100,6 +101,7 @@ loop:
 
 		case <-ticker.C:
 			log.Infof("node(%s) hostip(%s) metadataaddress(%s:%s) nmiport(%s)", s.NodeName, s.HostIP, s.MetadataIP, s.MetadataPort, s.NMIPort)
+			s.Initialized = true
 			if err := iptables.AddCustomChain(s.MetadataIP, s.MetadataPort, s.HostIP, s.NMIPort); err != nil {
 				log.Fatalf("%s", err)
 			}

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -103,7 +103,7 @@ func (s *Server) updateIPTableRules() {
 	ticker := time.NewTicker(time.Second * time.Duration(s.IPTableUpdateTimeIntervalInSeconds))
 	defer ticker.Stop()
 
-	// Run once before the waiting on ticket for the rules to take effect
+	// Run once before the waiting on ticker for the rules to take effect
 	// immediately.
 	s.updateIPTableRulesInternal()
 	s.Initialized = true

--- a/pkg/probes/probes.go
+++ b/pkg/probes/probes.go
@@ -2,25 +2,16 @@ package probes
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/golang/glog"
 )
 
-// InitHealthProbe - sets up a health probe which responds with success (200 - OK) all the time once its called.
-func InitHealthProbe() {
+// InitHealthProbe - sets up a health probe which responds with success (200 - OK) once its initialized.
+// The contents of the healthz endpoint will be the string "Active" if the condition is satisfied.
+// The condition is set to true when the sync cycle has become active in case of MIC and the iptables
+// rules set in case of NMI.
+func InitHealthProbe(condition *bool) {
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-	})
-}
-
-// InitReadyProbe - sets up a ready probe which returns success (200-OK) if the condition variable is set, else
-// return an error (500). Also returned in the ready probe is the amount of time from the start of this container.
-func InitReadyProbe(startTime time.Time, condition *bool) {
-	http.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
-		// Readiness probe being 500 causes too many events to be produced.
-		// Hence we post the real status as result of the readiness probe instead of
-		// marking the state as not ready.
 		w.WriteHeader(200)
 		if *condition {
 			w.Write([]byte("Active"))
@@ -45,12 +36,10 @@ func Start(port string) {
 }
 
 // InitAndStart - Initialize the default probes and starts the http listening port.
-func InitAndStart(port string, startTime time.Time, condition *bool) {
-	InitHealthProbe()
+func InitAndStart(port string, condition *bool) {
+	InitHealthProbe(condition)
 	glog.V(1).Infof("Initialized health probe")
-	InitReadyProbe(startTime, condition)
-	glog.V(1).Infof("Initialized readiness probe")
-	// start the probes.
+	// start the probe.
 	Start(port)
-	glog.Infof("Initialized and started health and readiness probe")
+	glog.Infof("Initialized and started health probe")
 }

--- a/pkg/probes/probes.go
+++ b/pkg/probes/probes.go
@@ -18,25 +18,39 @@ func InitHealthProbe() {
 // return an error (500). Also returned in the ready probe is the amount of time from the start of this container.
 func InitReadyProbe(startTime time.Time, condition *bool) {
 	http.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		// Readiness probe being 500 causes too many events to be produced.
+		// Hence we post the real status as result of the readiness probe instead of
+		// marking the state as not ready.
+		w.WriteHeader(200)
 		if *condition {
-			w.WriteHeader(200)
+			w.Write([]byte("Active"))
 		} else {
-			w.WriteHeader(500)
+			w.Write([]byte("Not Active"))
 		}
-		data := (time.Since(startTime)).String()
-		w.Write([]byte(data))
 	})
+}
+
+func startAsync(port string) {
+	err := http.ListenAndServe(":"+port, nil)
+	if err != nil {
+		glog.Fatalf("Http listen and serve error: %+v", err)
+	} else {
+		glog.V(1).Infof("Http listen and serve started !")
+	}
 }
 
 //Start - Starts the required http server to start the probe to respond.
 func Start(port string) {
-	glog.Fatal(http.ListenAndServe(":"+port, nil))
+	go startAsync(port)
 }
 
 // InitAndStart - Initialize the default probes and starts the http listening port.
 func InitAndStart(port string, startTime time.Time, condition *bool) {
 	InitHealthProbe()
+	glog.V(1).Infof("Initialized health probe")
 	InitReadyProbe(startTime, condition)
+	glog.V(1).Infof("Initialized readiness probe")
 	// start the probes.
 	Start(port)
+	glog.Infof("Initialized and started health and readiness probe")
 }

--- a/pkg/probes/probes.go
+++ b/pkg/probes/probes.go
@@ -1,0 +1,42 @@
+package probes
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// InitHealthProbe - sets up a health probe which responds with success (200 - OK) all the time once its called.
+func InitHealthProbe() {
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+}
+
+// InitReadyProbe - sets up a ready probe which returns success (200-OK) if the condition variable is set, else
+// return an error (500). Also returned in the ready probe is the amount of time from the start of this container.
+func InitReadyProbe(startTime time.Time, condition *bool) {
+	http.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		if *condition {
+			w.WriteHeader(200)
+		} else {
+			w.WriteHeader(500)
+		}
+		data := (time.Since(startTime)).String()
+		w.Write([]byte(data))
+	})
+}
+
+//Start - Starts the required http server to start the probe to respond.
+func Start(port string) {
+	glog.Fatal(http.ListenAndServe(":"+port, nil))
+}
+
+// InitAndStart - Initialize the default probes and starts the http listening port.
+func InitAndStart(port string, startTime time.Time, condition *bool) {
+	InitHealthProbe()
+	InitReadyProbe(startTime, condition)
+	// start the probes.
+	Start(port)
+}

--- a/test/common/k8s/infra/infra.go
+++ b/test/common/k8s/infra/infra.go
@@ -11,8 +11,14 @@ import (
 )
 
 // CreateInfra will deploy all the infrastructure components (nmi and mic) on a Kubernetes cluster
-func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath string) error {
-	t, err := template.New("deployment-rbac.yaml").ParseFiles(path.Join("template", "deployment-rbac.yaml"))
+func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath string, old bool) error {
+	var err error
+	var t *template.Template
+	if !old {
+		t, err = template.New("deployment-rbac.yaml").ParseFiles(path.Join("template", "deployment-rbac.yaml"))
+	} else {
+		t, err = template.New("deployment-rbac-old.yaml").ParseFiles(path.Join("template", "deployment-rbac-old.yaml"))
+	}
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse deployment-rbac.yaml")
 	}
@@ -20,7 +26,7 @@ func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath
 	deployFilePath := path.Join(templateOutputPath, namespace+"-deployment.yaml")
 	deployFile, err := os.Create(deployFilePath)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create a deployment file from deployment-rbac.yaml")
+		return errors.Wrap(err, "Failed to create a deployment file")
 	}
 	defer deployFile.Close()
 

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -685,8 +685,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		Expect(exists).To(Equal(true))
 	})
 
-	It("readiness and liveness probe test", func() {
-
+	It("liveness probe test", func() {
 		pods, err := pod.GetAllNameByPrefix("mic")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pods).NotTo(BeNil())
@@ -696,12 +695,11 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		fmt.Printf("MIC leader: %s\n", leader)
 
 		for _, p := range pods {
-			checkHealthProbe(p, "")
 			// Leader MIC will show as active and other as Not Active
 			if strings.EqualFold(p, leader) {
-				checkReadinessProbe(p, "Active")
+				checkHealthProbe(p, "Active")
 			} else {
-				checkReadinessProbe(p, "Not Active")
+				checkHealthProbe(p, "Not Active")
 			}
 		}
 
@@ -709,8 +707,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pods).NotTo(BeNil())
 		for _, p := range pods {
-			checkHealthProbe(p, "")
-			checkReadinessProbe(p, "Active")
+			checkHealthProbe(p, "Active")
 		}
 	})
 })
@@ -745,11 +742,7 @@ func checkProbe(p string, endpoint string) string {
 }
 
 func checkHealthProbe(p string, state string) {
-	Expect(checkProbe(p, "healthz")).To(BeEmpty())
-}
-
-func checkReadinessProbe(p string, state string) {
-	Expect(strings.EqualFold(state, checkProbe(p, "ready"))).To(BeTrue())
+	Expect(strings.EqualFold(state, checkProbe(p, "healthz"))).To(BeTrue())
 }
 
 func checkInfra() {

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -112,7 +112,7 @@ var _ = AfterSuite(func() {
 var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 	BeforeEach(func() {
 		testIndex++
-		fmt.Printf("\n\n%d) %s\n", testIndex, CurrentGinkgoTestDescription().TestText)
+		fmt.Printf("\n\n[%d] %s\n", testIndex, CurrentGinkgoTestDescription().TestText)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/template/deployment-rbac-old.yaml
+++ b/test/e2e/template/deployment-rbac-old.yaml
@@ -1,0 +1,195 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-id-nmi-service-account
+  namespace: {{.Namespace}}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureassignedidentities.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureAssignedIdentity
+    plural: azureassignedidentities
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentitybindings.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentityBinding
+    plural: azureidentitybindings
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureidentities.aadpodidentity.k8s.io
+spec:
+  group: aadpodidentity.k8s.io
+  version: v1
+  names:
+    kind: AzureIdentity
+    singular: azureidentity
+    plural: azureidentities
+  scope: Namespaced
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-id-nmi-role
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-id-nmi-binding
+  labels:
+    k8s-app: aad-pod-id-nmi-binding
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-id-nmi-service-account
+  namespace: {{.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-id-nmi-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    component: nmi
+    tier: node
+    k8s-app: aad-pod-id
+  name: nmi
+  namespace: {{.Namespace}}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        component: nmi
+        tier: node
+    spec:
+      serviceAccountName: aad-pod-id-nmi-service-account
+      hostNetwork: true
+      containers:
+      - name: nmi
+        image: "{{.Registry}}/nmi:{{.NMIVersion}}"
+        imagePullPolicy: Always
+        args:
+          {{if .NMIArg}}- nmi {{ end }}
+          - "--host-ip=$(HOST_IP)"
+          - "--node=$(NODE_NAME)"
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aad-pod-id-mic-service-account
+  namespace: {{.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aad-pod-id-mic-role
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: [ "list", "watch" ]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureidentitybindings", "azureidentities"]
+  verbs: ["get", "list", "watch", "post"]
+- apiGroups: ["aadpodidentity.k8s.io"]
+  resources: ["azureassignedidentities"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aad-pod-id-mic-binding
+  labels:
+    k8s-app: aad-pod-id-mic-binding
+subjects:
+- kind: ServiceAccount
+  name: aad-pod-id-mic-service-account
+  namespace: {{.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: aad-pod-id-mic-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: mic
+    k8s-app: aad-pod-id
+  name: mic
+  namespace: {{.Namespace}}
+spec:
+  template:
+    metadata:
+      labels:
+        component: mic
+    spec:
+      serviceAccountName: aad-pod-id-mic-service-account
+      containers:
+      - name: mic
+        image: "{{.Registry}}/mic:{{.MICVersion}}"
+        imagePullPolicy: Always
+        args:
+          {{if .MICArg}}- mic {{ end }}
+          - "--cloudconfig=/etc/kubernetes/azure.json"
+          - "--logtostderr"
+        volumeMounts:
+          - name: k8s-azure-file
+            mountPath: /etc/kubernetes/azure.json
+            readOnly: true
+      volumes:
+      - name: k8s-azure-file
+        hostPath:
+          path: /etc/kubernetes/azure.json

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -123,12 +123,6 @@ spec:
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
 ---
@@ -208,12 +202,6 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /ready
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -117,6 +117,18 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
 ---
@@ -193,6 +205,18 @@ spec:
           - name: k8s-azure-file
             mountPath: /etc/kubernetes/azure.json
             readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
       volumes:
       - name: k8s-azure-file
         hostPath:


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Add liveliness at /healthz endpoint for MIC and NMI at 8080 by default.
~~- Add readiness at /ready endpoint for MIC and NMI at 8080 by default.~~
~~- Both liveness and readiness probe return back 200 okay as soon as they are activated from the current run.~~
- The liveliness probe provides "Active" or "Not Active" status as per the state of the component. In case of MIC if the given instance is the elected leader then "Active" string is presented in the /healthz endpoint. For NMI it would show "Active" as soon as the iptables are put in place. 
- Fix the NMI iptables to run instantly instead of waiting for the first ticker instance.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#288 

**Notes for Reviewers**: