### PR TITLE
E2e - collect info on test failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ bld/
 /.gen*
 /vendor
 /test/e2e/template/_output
+/test/e2e/_output
 junit.xml
 junit_*.xml
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ else
 endif
 
 GO_BUILD_OPTIONS := --tags "netgo osusergo"  -ldflags "-s -X $(NMI_VERSION_VAR)=$(NMI_VERSION) -X $(MIC_VERSION_VAR)=$(MIC_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
-E2E_TEST_OPTIONS := -count=1 -v -timeout 24h -ginkgo.failFast $(E2E_TEST_OPTIONS_EXTRA)
+E2E_TEST_OPTIONS := -count=1 -v -timeout 24h -ginkgo.progress $(E2E_TEST_OPTIONS_EXTRA)
 
 # useful for other docker repos
 REGISTRY_NAME ?= upstreamk8sci

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -116,7 +116,6 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		if CurrentGinkgoTestDescription().Failed {
 			fmt.Printf("Test failed. Collecting debugging information.")
 			collectDebuggingInfo()
-			return
 		}
 		// Ensure a clean cluster after the end of each test
 		cmd := exec.Command("kubectl", "delete", "AzureIdentity,AzureIdentityBinding", "--all")
@@ -722,7 +721,7 @@ func collectLogs(podName, dir string) {
 
 func collectPods(dir string) {
 	logFile := path.Join(dir, "pods")
-	cmd := exec.Command("bash", "-c", "kubectl get pods > "+logFile)
+	cmd := exec.Command("bash", "-c", "kubectl get pods -o wide > "+logFile)
 	util.PrintCommand(cmd)
 	_, err := cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred())
@@ -755,7 +754,7 @@ func collectDebuggingInfo() {
 	Expect(err).NotTo(HaveOccurred())
 
 	fd.WriteString("Test name: " + CurrentGinkgoTestDescription().TestText + "\n")
-	fd.WriteString("Collecting diagnosics at: " + tNow.Format(time.UnixDate))
+	fd.WriteString("Collecting diagnostics at: " + tNow.Format(time.UnixDate))
 	fd.Sync()
 	fd.Close()
 

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 	AfterEach(func() {
 		fmt.Println("\nTearing down the test environment...")
 		if CurrentGinkgoTestDescription().Failed {
-			fmt.Printf("Test failed. Collecting diagnostics information.")
+			fmt.Printf("Test failed. Collecting debugging information.")
 			collectDebuggingInfo()
 			return
 		}
@@ -724,8 +724,7 @@ func collectPods(dir string) {
 	logFile := path.Join(dir, "pods")
 	cmd := exec.Command("bash", "-c", "kubectl get pods > "+logFile)
 	util.PrintCommand(cmd)
-	output, err := cmd.CombinedOutput()
-	fmt.Printf("%+v: error: %+v", string(output), err)
+	_, err := cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -745,7 +744,7 @@ func collectLeEndpoint(dir string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func collectDebuggignInfo() {
+func collectDebuggingInfo() {
 	tNow := time.Now()
 	logDirName := path.Join(logsPath, tNow.Format(time.RFC3339))
 	err := os.MkdirAll(logDirName, os.ModePerm)

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -42,8 +42,8 @@ const (
 var (
 	cfg                config.Config
 	templateOutputPath = path.Join("template", "_output")
+	logsPath           = path.Join("_output", "logs")
 	testIndex          = 0
-	noCleanup          = false
 )
 
 var _ = BeforeSuite(func() {
@@ -62,10 +62,6 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	fmt.Println("\nTearing down the test suite environment...")
-	if noCleanup {
-		fmt.Println("Test failed. No cleanup performed")
-		return
-	}
 
 	// Uninstall CRDs and delete MIC and NMI
 	err := deploy.Delete("default", templateOutputPath)
@@ -118,8 +114,8 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 	AfterEach(func() {
 		fmt.Println("\nTearing down the test environment...")
 		if CurrentGinkgoTestDescription().Failed {
-			noCleanup = true
-			fmt.Println("Test failed. No cleanup performed")
+			fmt.Printf("Test failed. Collecting diagnostics information.")
+			collectDebuggingInfo()
 			return
 		}
 		// Ensure a clean cluster after the end of each test
@@ -711,6 +707,69 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		}
 	})
 })
+
+func collectLogs(podName, dir string) {
+	pods, err := pod.GetAllNameByPrefix(podName)
+	Expect(err).NotTo(HaveOccurred())
+	for _, p := range pods {
+		logFile := path.Join(dir, p)
+		cmd := exec.Command("bash", "-c", "kubectl logs "+p+" > "+logFile)
+		util.PrintCommand(cmd)
+		_, err := cmd.Output()
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func collectPods(dir string) {
+	logFile := path.Join(dir, "pods")
+	cmd := exec.Command("bash", "-c", "kubectl get pods > "+logFile)
+	util.PrintCommand(cmd)
+	output, err := cmd.CombinedOutput()
+	fmt.Printf("%+v: error: %+v", string(output), err)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func collectEvents(dir string) {
+	logFile := path.Join(dir, "events")
+	cmd := exec.Command("bash", "-c", "kubectl get  events --sort-by='.metadata.creationTimestamp' >"+logFile)
+	util.PrintCommand(cmd)
+	_, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func collectLeEndpoint(dir string) {
+	logFile := path.Join(dir, "leEndpoint")
+	cmd := exec.Command("bash", "-c", "kubectl get endpoints aad-pod-identity-mic -o yaml >"+logFile)
+	util.PrintCommand(cmd)
+	_, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func collectDebuggignInfo() {
+	tNow := time.Now()
+	logDirName := path.Join(logsPath, tNow.Format(time.RFC3339))
+	err := os.MkdirAll(logDirName, os.ModePerm)
+	Expect(err).NotTo(HaveOccurred())
+
+	infoFile := path.Join(logDirName, "info")
+	fd, err := os.Create(infoFile)
+	Expect(err).NotTo(HaveOccurred())
+
+	fd.WriteString("Test name: " + CurrentGinkgoTestDescription().TestText + "\n")
+	fd.WriteString("Collecting diagnosics at: " + tNow.Format(time.UnixDate))
+	fd.Sync()
+	fd.Close()
+
+	collectPods(logDirName)
+	collectEvents(logDirName)
+	collectLeEndpoint(logDirName)
+
+	collectLogs("mic", logDirName)
+	collectLogs("nmi", logDirName)
+	collectLogs("identityvalidator", logDirName)
+	collectLogs("busybox", logDirName)
+
+}
 
 func getMICLeader() (string, error) {
 	cmd := exec.Command("kubectl", "get", "endpoints", "aad-pod-identity-mic", "-o", "json")


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

- This PR adds the ability to collect the logs, events, endpoint and pod state, in case of a test failure. 
- Also removed is ginkgo fail fast so that tests can continue if one of them fails.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**: