### PR TITLE
VMSS e2e changes and System MSI cluster support

### DIFF
--- a/test/common/azure/azure.go
+++ b/test/common/azure/azure.go
@@ -341,9 +341,9 @@ func GetVMSSUserAssignedIdentities(resourceGroup, name string) (map[string]UserA
 func RemoveUserAssignedIdentityFromVM(resourceGroup, vmName, identityName string) error {
 	fmt.Printf("# Removing identity '%s' from %s...\n", identityName, vmName)
 	cmd := exec.Command("az", "vm", "identity", "remove", "-g", resourceGroup, "-n", vmName, "--identities", identityName)
-	_, err := cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, "Failed to remove user assigned identity to VM")
+		return errors.Wrap(err, "Failed to remove user assigned identity to VM. Error output: "+string(output))
 	}
 
 	return nil
@@ -353,9 +353,16 @@ func RemoveUserAssignedIdentityFromVM(resourceGroup, vmName, identityName string
 func RemoveUserAssignedIdentityFromVMSS(resourceGroup, vmName, identityName string) error {
 	fmt.Printf("# Removing identity '%s' from %s...\n", identityName, vmName)
 	cmd := exec.Command("az", "vmss", "identity", "remove", "-g", resourceGroup, "-n", vmName, "--identities", identityName)
-	_, err := cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, "Failed to remove user assigned identity to VMSS")
+		// If the failure is because there is no identity assigned(which can happen in case of VMSS with system assigneed identity)
+		// then we can ignore that error since its a legitimate situation.
+		// TODO: The full fledged fix for this would be ensure that the VMSS removal never gets called twice. Keeping that as TODO for now.
+		if strings.Contains(string(output), "are not associated with") {
+			fmt.Printf("Warning: the cluster identity: %s was not associated with %s.\n", identityName, vmName)
+			return nil
+		}
+		return errors.Wrap(err, "Failed to remove user assigned identity to VMSS. Error output: "+string(output))
 	}
 
 	return nil

--- a/test/common/azure/azure.go
+++ b/test/common/azure/azure.go
@@ -355,7 +355,7 @@ func RemoveUserAssignedIdentityFromVMSS(resourceGroup, vmName, identityName stri
 	cmd := exec.Command("az", "vmss", "identity", "remove", "-g", resourceGroup, "-n", vmName, "--identities", identityName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		// If the failure is because there is no identity assigned(which can happen in case of VMSS with system assigneed identity)
+		// If the failure is because there is no identity assigned(which can happen in case of VMSS with system assigned identity)
 		// then we can ignore that error since its a legitimate situation.
 		// TODO: The full fledged fix for this would be ensure that the VMSS removal never gets called twice. Keeping that as TODO for now.
 		if strings.Contains(string(output), "are not associated with") {

--- a/test/common/k8s/azureassignedidentity/azureassignedidentity.go
+++ b/test/common/k8s/azureassignedidentity/azureassignedidentity.go
@@ -70,8 +70,8 @@ func GetAllByPrefix(prefix string) ([]aadpodid.AzureAssignedIdentity, error) {
 // WaitOnLengthMatched will block until the number of Azure Assigned Identity matches the target
 func WaitOnLengthMatched(target int) (bool, error) {
 	successChannel, errorChannel := make(chan bool, 1), make(chan error)
-	// defining ~2 mins as an acceptable timeframe for ids to be assigned to node
-	duration, sleep := 120*time.Second, 10*time.Second
+	// defining ~2 mins 30 seconds as an acceptable timeframe for ids to be assigned to node
+	duration, sleep := 150*time.Second, 10*time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 

--- a/test/common/k8s/daemonset/daemonset.go
+++ b/test/common/k8s/daemonset/daemonset.go
@@ -71,7 +71,7 @@ func isAvailableReplicasMatchDesired(name string) (bool, error) {
 // WaitOnReady will block until the number of replicas of a daemonset is equal to the specified amount
 func WaitOnReady(name string) (bool, error) {
 	successChannel, errorChannel := make(chan bool, 1), make(chan error)
-	duration, sleep := 30*time.Second, 3*time.Second
+	duration, sleep := 40*time.Second, 3*time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 

--- a/test/common/k8s/deploy/deploy.go
+++ b/test/common/k8s/deploy/deploy.go
@@ -88,7 +88,7 @@ func isAvailableReplicasMatchDesired(name string) (bool, error) {
 // WaitOnReady will block until the number of replicas of a deployment is equal to the specified amount
 func WaitOnReady(name string) (bool, error) {
 	successChannel, errorChannel := make(chan bool, 1), make(chan error)
-	duration, sleep := 30*time.Second, 3*time.Second
+	duration, sleep := 60*time.Second, 3*time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -58,6 +58,7 @@ var _ = BeforeSuite(func() {
 	c, err := config.ParseConfig()
 	Expect(err).NotTo(HaveOccurred())
 	cfg = *c
+	fmt.Printf("System MSI enabled: %v\n", cfg.SystemMSICluster)
 	setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion)
 })
 
@@ -500,6 +501,9 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 	})
 
 	It("should not alter the system assigned identity after creating and deleting pod identity", func() {
+		if cfg.SystemMSICluster {
+			Skip("Test running on system assigned MSI cluster. Skip specific system MSI tests")
+		}
 		// Assign system assigned identity to every node
 		nodeList, err := node.GetAll()
 		Expect(err).NotTo(HaveOccurred())
@@ -547,14 +551,14 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		removeSystemAssignedIdentityOnCluster(nodeList)
 	})
 
-	It("should create azureassignedidentities for 40 pods within ~2mins", func() {
+	It("should create azureassignedidentities for 40 pods within ~2mins 30seconds", func() {
 		// setup all the 40 pods in a loop to ensure mic handles
 		// scale out efficiently
 		for i := 0; i < 5; i++ {
 			setUpIdentityAndDeployment(keyvaultIdentity, fmt.Sprintf("%d", i), "8")
 		}
 
-		// WaitOnLengthMatched waits for 2 mins, so this will ensure we are performant at high scale
+		// WaitOnLengthMatched waits for 2 mins 30 seconds, so this will ensure we are performant at high scale
 		ok, err := azureassignedidentity.WaitOnLengthMatched(40)
 		Expect(ok).To(Equal(true))
 		Expect(err).NotTo(HaveOccurred())
@@ -1293,8 +1297,10 @@ func (m vmManager) RemoveAllIdentities() error {
 			errs = append(errs, err)
 		}
 	}
-	if err := m.RemoveSystemAssignedIdentity(); err != nil {
-		errs = append(errs, err)
+	if !cfg.SystemMSICluster {
+		if err := m.RemoveSystemAssignedIdentity(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return errs
 }
@@ -1341,8 +1347,10 @@ func (m vmssManager) RemoveAllIdentities() error {
 			errs = append(errs, err)
 		}
 	}
-	if err := m.RemoveSystemAssignedIdentity(); err != nil {
-		errs = append(errs, err)
+	if !cfg.SystemMSICluster {
+		if err := m.RemoveSystemAssignedIdentity(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return errs
 }

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	NMIVersion               string `envconfig:"NMI_VERSION" default:"1.4"`
 	Registry                 string `envconfig:"REGISTRY" default:"mcr.microsoft.com/k8s/aad-pod-identity"`
 	IdentityValidatorVersion string `envconfig:"IDENTITY_VALIDATOR_VERSION" default:"1.4"`
+	SystemMSICluster         bool   `envconfig:"SYSTEM_MSI_CLUSTER" default:false`
 }
 
 // ParseConfig will parse needed environment variables for running the tests

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -5,17 +5,17 @@ set -euo pipefail
 # Check pre-requisites
 [[ ! -z "${SUBSCRIPTION_ID:-}" ]]         || (echo 'Must specify SUBSCRIPTION_ID' && exit -1)
 [[ ! -z "${RESOURCE_GROUP:-}" ]]          || (echo 'Must specify RESOURCE_GROUP' && exit -1)
-[[ ! -z "${AZURE_CLIENT_ID:-}" ]]         || (echo 'Must specify AZURE_CLIENT_ID' && exit -1)
 [[ ! -z "${KEYVAULT_NAME:-}" ]]           || (echo 'Must specify KEYVAULT_NAME' && exit -1)
 [[ ! -z "${KEYVAULT_SECRET_NAME:-}" ]]    || (echo 'Must specify KEYVAULT_SECRET_NAME' && exit -1)
 [[ -z "$(hash az)" ]]                     || (echo 'Azure CLI not found' && exit -1)
 [[ -z "$(hash kubectl)" ]]                || (echo 'kubectl not found' && exit -1)
 
-role_assignment_retry() {
+
+retry_cmd() {
     set +e
     local retval=0
     for i in {0..10}; do
-        out=$(eval $* 2>&1)
+        out=$(eval $1 2>&1)
         retval=$?
         [[ "${out}" == *"already exists"* ]] && retval=0
         [ $retval -eq 0 ] && break
@@ -23,10 +23,36 @@ role_assignment_retry() {
     done
     set -e
     if [ $retval -ne  0 ]; then
-      >&2 echo "role assignment failed"
+      >&2 echo $2
       return 1
     fi
 }
+
+# TODO: Handle multiple pools.
+# TODO: Handle system msi and VMA clusters.
+if [ ! -z ${SYSTEM_MSI_CLUSTER:-} ]; then
+  if "$SYSTEM_MSI_CLUSTER" == "true" ]; then
+    echo "System MSI cluster flag enabled"
+    full_resourceid=$(az group show -n $RESOURCE_GROUP -o json | jq '.id' | sed 's/"//g')
+    echo "Resource id for the group: $full_resourceid"
+    vmss_name=$(az vmss list -g $RESOURCE_GROUP -o json | jq '.[0].name' | sed 's/"//g')
+    if [ "$vmss_name" == "" ]; then
+      echo "Could not find VMSS node pool. Currently e2e support is only for single VMSS pool + System MSI"
+      exit 1
+    fi
+    echo "Found VMSS: " $vmss_name
+    vmss_sys_id=$(az vmss identity show -g $RESOURCE_GROUP -n $vmss_name -o json | jq '.principalId' | sed 's/"//g')
+    echo "System MSI principal id: " $vmss_sys_id
+    echo "Assigning system assigned MSI 'Contributor' role to the resource group $RESOURCE_GROUP for MIC assignments"
+    az role assignment create --role "Contributor" --assignee $vmss_sys_id --scope $full_resourceid
+    # set the AZURE_CLIENT_ID to be the system assigned identity of the vmss pool
+    unset AZURE_CLIENT_ID
+    echo "Setting the $vmss_sys_id as the AZURE_CLIENT_ID"
+    AZURE_CLIENT_ID=$vmss_sys_id
+  fi
+fi
+
+[[ ! -z "${AZURE_CLIENT_ID:-}" ]]         || (echo 'Must specify AZURE_CLIENT_ID' && exit -1)
 
 # Create a keyvault
 az keyvault create -g "$RESOURCE_GROUP" -n "$KEYVAULT_NAME"
@@ -37,9 +63,9 @@ az identity create -g "$RESOURCE_GROUP" -n keyvault-identity
 IDENTITY_CLIENT_ID=$(az identity show -g "$RESOURCE_GROUP" -n keyvault-identity  --query 'clientId' -otsv)
 IDENTITY_PRINCIPAL_ID=$(az identity show -g "$RESOURCE_GROUP" -n keyvault-identity --query 'principalId' -otsv)
 az role assignment create --role 'Managed Identity Operator' --assignee "$AZURE_CLIENT_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourcegroups/$RESOURCE_GROUP/providers/Microsoft.ManagedIdentity/userAssignedIdentities/keyvault-identity" || true
-az keyvault set-policy -n "$KEYVAULT_NAME" --secret-permissions get list --spn "$IDENTITY_CLIENT_ID" || true
+retry_cmd "az keyvault set-policy -n "$KEYVAULT_NAME" --secret-permissions get list --spn "$IDENTITY_CLIENT_ID"" "set policy failed"
 # The following command might need a couple of retries to succeed
-role_assignment_retry "az role assignment create --role Reader --assignee "$IDENTITY_PRINCIPAL_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEYVAULT_NAME""
+retry_cmd "az role assignment create --role Reader --assignee "$IDENTITY_PRINCIPAL_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEYVAULT_NAME"" "role assignment failed"
 
 echo 'Creating a cluster-identity and assign appropriate roles...'
 az identity create -g "$RESOURCE_GROUP" -n cluster-identity
@@ -47,7 +73,7 @@ IDENTITY_CLIENT_ID=$(az identity show -g "$RESOURCE_GROUP" -n cluster-identity  
 IDENTITY_PRINCIPAL_ID=$(az identity show -g "$RESOURCE_GROUP" -n cluster-identity --query 'principalId' -otsv)
 az role assignment create --role 'Managed Identity Operator' --assignee "$AZURE_CLIENT_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourcegroups/$RESOURCE_GROUP/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-identity" || true
 # The following command might need a couple of retries to succeed
-role_assignment_retry "az role assignment create --role Reader --assignee "$IDENTITY_PRINCIPAL_ID" -g "$RESOURCE_GROUP""
+retry_cmd "az role assignment create --role Reader --assignee "$IDENTITY_PRINCIPAL_ID" -g "$RESOURCE_GROUP""
 
 # Create 5 keyvault identities for test #6
 for i in {0..4}; do
@@ -57,9 +83,9 @@ for i in {0..4}; do
     IDENTITY_CLIENT_ID=$(az identity show -g "$RESOURCE_GROUP" -n "$IDENTITY_NAME"  --query 'clientId' -otsv)
     IDENTITY_PRINCIPAL_ID=$(az identity show -g "$RESOURCE_GROUP" -n "$IDENTITY_NAME" --query 'principalId' -otsv)
     az role assignment create --role 'Managed Identity Operator' --assignee "$AZURE_CLIENT_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourcegroups/$RESOURCE_GROUP/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$IDENTITY_NAME" || true
-    az keyvault set-policy -n "$KEYVAULT_NAME" --secret-permissions get list --spn "$IDENTITY_CLIENT_ID" || true
+    retry_cmd "az keyvault set-policy -n "$KEYVAULT_NAME" --secret-permissions get list --spn "$IDENTITY_CLIENT_ID"" "set policy failed"
     # The following command might need a couple of retries to succeed
-    role_assignment_retry "az role assignment create --role Reader --assignee "$IDENTITY_PRINCIPAL_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEYVAULT_NAME""
+    retry_cmd "az role assignment create --role Reader --assignee "$IDENTITY_PRINCIPAL_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEYVAULT_NAME""
 done
 
 # Create identity with not enough permissions to test failure path
@@ -68,6 +94,6 @@ az identity create -g "$RESOURCE_GROUP" -n keyvault-identity-5
 IDENTITY_CLIENT_ID=$(az identity show -g "$RESOURCE_GROUP" -n keyvault-identity-5  --query 'clientId' -otsv)
 IDENTITY_PRINCIPAL_ID=$(az identity show -g "$RESOURCE_GROUP" -n keyvault-identity-5 --query 'principalId' -otsv)
 az role assignment create --role 'Managed Identity Operator' --assignee "$AZURE_CLIENT_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourcegroups/$RESOURCE_GROUP/providers/Microsoft.ManagedIdentity/userAssignedIdentities/keyvault-identity-5" || true
-az keyvault set-policy -n "$KEYVAULT_NAME" --secret-permissions list --spn "$IDENTITY_CLIENT_ID" || true
+retry_cmd "az keyvault set-policy -n "$KEYVAULT_NAME" --secret-permissions list --spn "$IDENTITY_CLIENT_ID"" "set policy failed"
 # The following command might need a couple of retries to succeed
-role_assignment_retry "az role assignment create --role Reader --assignee "$IDENTITY_PRINCIPAL_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEYVAULT_NAME""
+retry_cmd "az role assignment create --role Reader --assignee "$IDENTITY_PRINCIPAL_ID" --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEYVAULT_NAME""


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

- Enable e2e on System assigned MSI+VMSS single nodepool cluster
- Increase timeout for VMSS
- Make retry generic and support it for set-policy in setup.sh

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:

TODO: Add the SYSTEM_MSI_CLUSTER setting step in e2e README