### PR TITLE
Fix assigned id deletion when no identity exists

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -113,7 +113,7 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 			azureEnv.ResourceManagerEndpoint,
 		)
 		if err != nil {
-			glog.Errorf("Get service principle token error: %+v", err)
+			glog.Errorf("Get service principal token error: %+v", err)
 			return nil, err
 		}
 	}

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -105,6 +105,10 @@ func (i *vmIdentityInfo) RemoveUserIdentity(id string) error {
 	if i.info.Type == compute.ResourceIdentityTypeNone || i.info.Type == compute.ResourceIdentityTypeSystemAssigned {
 		i.info.IdentityIds = nil
 	}
+	// if the identityids is nil and identity type is not set, then set it to ResourceIdentityTypeNone
+	if i.info.IdentityIds == nil && i.info.Type == "" {
+		i.info.Type = compute.ResourceIdentityTypeNone
+	}
 	return nil
 }
 

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -113,6 +113,10 @@ func (i *vmssIdentityInfo) RemoveUserIdentity(id string) error {
 	if i.info.Type == compute.ResourceIdentityTypeNone || i.info.Type == compute.ResourceIdentityTypeSystemAssigned {
 		i.info.IdentityIds = nil
 	}
+	// if the identityids is nil and identity type is not set, then set it to ResourceIdentityTypeNone
+	if i.info.IdentityIds == nil && i.info.Type == "" {
+		i.info.Type = compute.ResourceIdentityTypeNone
+	}
 	return nil
 }
 

--- a/test/common/azure/azure.go
+++ b/test/common/azure/azure.go
@@ -343,6 +343,10 @@ func RemoveUserAssignedIdentityFromVM(resourceGroup, vmName, identityName string
 	cmd := exec.Command("az", "vm", "identity", "remove", "-g", resourceGroup, "-n", vmName, "--identities", identityName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if strings.Contains(string(output), "are not associated with") {
+			fmt.Printf("Warning: the cluster identity: %s was not associated with %s.\n", identityName, vmName)
+			return nil
+		}
 		return errors.Wrap(err, "Failed to remove user assigned identity to VM. Error output: "+string(output))
 	}
 

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -646,7 +646,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		}
 
 		if vmssID == "" {
-			fmt.Println("skipping test since there is no vmss with more than 1 node")
+			Skip("Skipping test since there is no vmss with more than 1 node")
 			return
 		}
 
@@ -808,6 +808,12 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 
 		cmdOutput, err = validateUserAssignedIdentityOnPod(podName2, identityClientID)
 		Expect(errors.Wrap(err, string(cmdOutput))).NotTo(HaveOccurred())
+
+		removeUserAssignedIdentityFromCluster(nodeList, fmt.Sprintf("%s-%d", keyvaultIdentity, 1))
+		removeUserAssignedIdentityFromCluster(nodeList, fmt.Sprintf("%s-%d", keyvaultIdentity, 2))
+		if !cfg.SystemMSICluster {
+			removeSystemAssignedIdentityOnCluster(nodeList)
+		}
 	})
 
 	It("should pass identity validation with correct identity and fail with wrong identity", func() {

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -844,6 +844,29 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		cmdOutput, err = validateUserAssignedIdentityOnPod(podName, identityClientID)
 		Expect(errors.Wrap(err, string(cmdOutput))).NotTo(HaveOccurred())
 	})
+
+	It("should delete assigned identity when identity no longer exists on underlying node", func() {
+		setUpIdentityAndDeployment(keyvaultIdentity, "", "1")
+
+		ok, err := azureassignedidentity.WaitOnLengthMatched(1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
+		Expect(err).NotTo(HaveOccurred())
+
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+
+		nodeList, err := node.GetAll()
+		Expect(err).NotTo(HaveOccurred())
+		// remove the assigned identity manually from the underlying node
+		removeUserAssignedIdentityFromCluster(nodeList, keyvaultIdentity)
+
+		waitForDeployDeletion(identityValidator)
+		ok, err = azureassignedidentity.WaitOnLengthMatched(0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+	})
 })
 
 func collectLogs(podName, dir string) {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
When the last underlying identity is deleted from the node, the deletion of assigned identity fails because the resource type is not set during the `CreateOrUpdate` call. This PR ensures when the identity list is nil, the resource type is set to None.

Adds e2e test to valid the scenario.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes https://github.com/Azure/aad-pod-identity/issues/313

**Notes for Reviewers**:
