### PR TITLE
update nmi retry interval

### DIFF
--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -16,6 +16,9 @@ const (
 	defaultMetadataPort                       = "80"
 	defaultNmiPort                            = "2579"
 	defaultIPTableUpdateTimeIntervalInSeconds = 60
+	defaultlistPodIDsRetryAttemptsForCreated  = 16
+	defaultlistPodIDsRetryAttemptsForAssigned = 4
+	defaultlistPodIDsRetryIntervalInSeconds   = 5
 )
 
 var (
@@ -30,6 +33,9 @@ var (
 	forceNamespaced                    = pflag.Bool("forceNamespaced", false, "Forces mic to namespace identities, binding, and assignment")
 	micNamespace                       = pflag.String("MICNamespace", "default", "MIC namespace to short circuit MIC token requests")
 	httpProbePort                      = pflag.String("http-probe-port", "8080", "Http health and liveness probe port")
+	retryAttemptsForCreated            = pflag.Int("retry-attempts-for-created", defaultlistPodIDsRetryAttemptsForCreated, "Number of retries in NMI to find assigned identity in CREATED state")
+	retryAttemptsForAssigned           = pflag.Int("retry-attempts-for-assigned", defaultlistPodIDsRetryAttemptsForAssigned, "Number of retries in NMI to find assigned identity in ASSIGNED state")
+	findIdentityRetryIntervalInSeconds = pflag.Int("find-identity-retry-interval", defaultlistPodIDsRetryIntervalInSeconds, "Retry interval to find assigned identities in seconds")
 )
 
 func main() {
@@ -54,6 +60,9 @@ func main() {
 	s.HostIP = *hostIP
 	s.NodeName = *nodename
 	s.IPTableUpdateTimeIntervalInSeconds = *ipTableUpdateTimeIntervalInSeconds
+	s.ListPodIDsRetryAttemptsForCreated = *retryAttemptsForCreated
+	s.ListPodIDsRetryAttemptsForAssigned = *retryAttemptsForAssigned
+	s.ListPodIDsRetryIntervalInSeconds = *findIdentityRetryIntervalInSeconds
 
 	// Health probe will always report success once its started. The contents
 	// will report "Active" once the iptables rules are set

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -30,8 +30,8 @@ import (
 const (
 	iptableUpdateTimeIntervalInSeconds = 60
 	localhost                          = "127.0.0.1"
-	listPodIDsRetryAttemptsForCreated  = 9
-	listPodIDsRetryAttemptsForAssigned = 3
+	listPodIDsRetryAttemptsForCreated  = 16
+	listPodIDsRetryAttemptsForAssigned = 4
 	listPodIDsRetryIntervalInSeconds   = 5
 )
 
@@ -487,8 +487,9 @@ func listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log
 	var err error
 	var idStateMap map[string][]aadpodid.AzureIdentity
 
-	// this loop will run to ensure we have assigned identities before we return. If there are no assigned identities in created state within 45s (9 retries * 5s wait) then we return an error.
-	// If we get an assigned identity in created state within 45s, then loop will continue for another 15s to find assigned identity in assigned state.
+	// this loop will run to ensure we have assigned identities before we return. If there are no assigned identities in created state within 80s (16 retries * 5s wait) then we return an error.
+	// If we get an assigned identity in created state within 80s, then loop will continue until 100s to find assigned identity in assigned state.
+	// Retry interval for CREATED state is set to 80s because avg time for identity to be assigned to the node is 35-37s.
 	for attempt < maxAttemptsForCreated+maxAttemptsForAssigned {
 		idStateMap, err = kubeClient.ListPodIds(podns, podname)
 		if err == nil {

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -28,11 +28,7 @@ import (
 )
 
 const (
-	iptableUpdateTimeIntervalInSeconds = 60
-	localhost                          = "127.0.0.1"
-	listPodIDsRetryAttemptsForCreated  = 16
-	listPodIDsRetryAttemptsForAssigned = 4
-	listPodIDsRetryIntervalInSeconds   = 5
+	localhost = "127.0.0.1"
 )
 
 // Server encapsulates all of the parameters necessary for starting up
@@ -48,6 +44,10 @@ type Server struct {
 	IsNamespaced                       bool
 	MICNamespace                       string
 	Initialized                        bool
+
+	ListPodIDsRetryAttemptsForCreated  int
+	ListPodIDsRetryAttemptsForAssigned int
+	ListPodIDsRetryIntervalInSeconds   int
 }
 
 // NMIResponse is the response returned to caller
@@ -187,7 +187,7 @@ func (s *Server) hostHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		http.Error(w, "missing 'podname' and 'podns' from request header", http.StatusBadRequest)
 		return
 	}
-	podIDs, identityInCreatedStateFound, err := listPodIDsWithRetry(r.Context(), s.KubeClient, logger, podns, podname, rqClientID, listPodIDsRetryAttemptsForCreated, listPodIDsRetryAttemptsForAssigned)
+	podIDs, identityInCreatedStateFound, err := s.listPodIDsWithRetry(r.Context(), s.KubeClient, logger, podns, podname, rqClientID)
 	if err != nil {
 		msg := fmt.Sprintf("no AzureAssignedIdentity found for pod:%s/%s in assigned state", podns, podname)
 		logger.Errorf("%s, %+v", msg, err)
@@ -332,7 +332,7 @@ func (s *Server) msiHandler(logger *log.Entry, w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	podIDs, identityInCreatedStateFound, err := listPodIDsWithRetry(r.Context(), s.KubeClient, logger, podns, podname, rqClientID, listPodIDsRetryAttemptsForCreated, listPodIDsRetryAttemptsForAssigned)
+	podIDs, identityInCreatedStateFound, err := s.listPodIDsWithRetry(r.Context(), s.KubeClient, logger, podns, podname, rqClientID)
 	if err != nil {
 		msg := fmt.Sprintf("no AzureAssignedIdentity found for pod:%s/%s in assigned state", podns, podname)
 		logger.Errorf("%s, %+v", msg, err)
@@ -482,7 +482,7 @@ func handleTermination() {
 }
 
 // listPodIDsWithRetry returns a list of matched identities in Assigned state, boolean indicating if at least an identity was found in Created state and error if any
-func listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log.Entry, podns, podname, rqClientID string, maxAttemptsForCreated, maxAttemptsForAssigned int) ([]aadpodid.AzureIdentity, bool, error) {
+func (s *Server) listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log.Entry, podns, podname, rqClientID string) ([]aadpodid.AzureIdentity, bool, error) {
 	attempt := 0
 	var err error
 	var idStateMap map[string][]aadpodid.AzureIdentity
@@ -490,7 +490,7 @@ func listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log
 	// this loop will run to ensure we have assigned identities before we return. If there are no assigned identities in created state within 80s (16 retries * 5s wait) then we return an error.
 	// If we get an assigned identity in created state within 80s, then loop will continue until 100s to find assigned identity in assigned state.
 	// Retry interval for CREATED state is set to 80s because avg time for identity to be assigned to the node is 35-37s.
-	for attempt < maxAttemptsForCreated+maxAttemptsForAssigned {
+	for attempt < s.ListPodIDsRetryAttemptsForCreated+s.ListPodIDsRetryAttemptsForAssigned {
 		idStateMap, err = kubeClient.ListPodIds(podns, podname)
 		if err == nil {
 			if len(rqClientID) == 0 {
@@ -504,9 +504,9 @@ func listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log
 				if len(idStateMap[aadpodid.AssignedIDAssigned]) != 0 {
 					return idStateMap[aadpodid.AssignedIDAssigned], true, nil
 				}
-				if len(idStateMap[aadpodid.AssignedIDCreated]) == 0 && attempt >= maxAttemptsForCreated {
+				if len(idStateMap[aadpodid.AssignedIDCreated]) == 0 && attempt >= s.ListPodIDsRetryAttemptsForCreated {
 					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s. Error: %v",
-						podns, podname, maxAttemptsForCreated, listPodIDsRetryIntervalInSeconds, err)
+						podns, podname, s.ListPodIDsRetryAttemptsForCreated, s.ListPodIDsRetryIntervalInSeconds, err)
 				}
 			} else {
 				// if client id exists in request, we need to ensure the identity with this client
@@ -530,16 +530,16 @@ func listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log
 						break
 					}
 				}
-				if !foundMatch && attempt >= maxAttemptsForCreated {
+				if !foundMatch && attempt >= s.ListPodIDsRetryAttemptsForCreated {
 					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s. Error: %v",
-						podns, podname, maxAttemptsForCreated, listPodIDsRetryIntervalInSeconds, err)
+						podns, podname, s.ListPodIDsRetryAttemptsForCreated, s.ListPodIDsRetryIntervalInSeconds, err)
 				}
 			}
 		}
 		attempt++
 
 		select {
-		case <-time.After(listPodIDsRetryIntervalInSeconds * time.Second):
+		case <-time.After(time.Duration(s.ListPodIDsRetryIntervalInSeconds) * time.Second):
 		case <-ctx.Done():
 			err = ctx.Err()
 			return nil, true, err
@@ -547,7 +547,7 @@ func listPodIDsWithRetry(ctx context.Context, kubeClient k8s.Client, logger *log
 		logger.Warningf("failed to get assigned ids for pod:%s/%s in ASSIGNED state, retrying attempt: %d", podns, podname, attempt)
 	}
 	return nil, true, fmt.Errorf("getting assigned identities for pod %s/%s in ASSIGNED state failed after %d attempts, retry duration [%d]s. Error: %v",
-		podns, podname, maxAttemptsForCreated+maxAttemptsForAssigned, listPodIDsRetryIntervalInSeconds, err)
+		podns, podname, s.ListPodIDsRetryAttemptsForCreated+s.ListPodIDsRetryAttemptsForAssigned, s.ListPodIDsRetryIntervalInSeconds, err)
 }
 
 func getErrorResponseStatusCode(identityFound bool) int {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Update the NMI retry interval to 80s for CREATED state and additional 20s for ASSIGNED state. This done because identity assignment on VMSS takes ~35-37s on average.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
