### PR TITLE
Update base alpine image to 3.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG DEMO_VERSION=0.0.0-dev
 ARG IDENTITY_VALIDATOR_VERSION=0.0.0-dev
 RUN make build
 
-FROM alpine:3.8 AS base
+FROM alpine:3.10.1 AS base
 RUN apk add --no-cache \
     ca-certificates \
     iptables \

--- a/test/e2e/template/busyboxds.yaml
+++ b/test/e2e/template/busyboxds.yaml
@@ -12,7 +12,7 @@ spec:
       hostNetwork: true
       containers:
       - name: busybox
-        image: alpine:3.8
+        image: alpine:3.10.1
         stdin: true
         securityContext:
           privileged: true


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Update base alpine image to `3.10.1`. That is the latest available tag with no vulnerabilities.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
