### PR TITLE
Append NMI version to the `User-Agent` for adal only once

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -48,11 +48,6 @@ func GetServicePrincipalTokenFromMSIWithUserAssignedID(clientID, resource string
 		return nil, fmt.Errorf("Failed to acquire a token using the MSI VM extension. Error: %v", err)
 	}
 
-	err = adal.AddToUserAgent(version.GetUserAgent("NMI", version.NMIVersion))
-	if err != nil {
-		return nil, err
-	}
-
 	// Effectively acquire the token
 	err = spt.Refresh()
 	if err != nil {
@@ -86,4 +81,12 @@ func GetServicePrincipalToken(tenantID, clientID, secret, resource string) (*ada
 	token := spt.Token()
 
 	return &token, nil
+}
+
+func init() {
+	err := adal.AddToUserAgent(version.GetUserAgent("NMI", version.NMIVersion))
+	if err != nil {
+		// shouldn't fail ever
+		panic(err)
+	}
 }


### PR DESCRIPTION

Before the fix, append happened each time
`GetServicePrincipalTokenFromMSIWithUserAssignedID` was called, which
was blowing up HTTP header size (or header value size).

This also updates adal UserAgent for any call from this library, not
only for the one mentioned above.

**Reason for Change**:

Fixes a bug, makes UA header consistent.

**Issue Fixed**:

Fixes: #332

(not tested yet)

**Notes for Reviewers**:
