### PR TITLE
Change 'updateStrategy' for nmi DaemonSet to `RollingUpdate`

### DIFF
--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -101,6 +101,8 @@ metadata:
   name: nmi
   namespace: default
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/deploy/infra/deployment.yaml
+++ b/deploy/infra/deployment.yaml
@@ -58,6 +58,8 @@ metadata:
   name: nmi
   namespace: default
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Without explicit strategy set, it defaults to `OnDelete` which means
`nmi` pods will be updated only when they are terminated, which doesn't
happen often obviously and it's quite unpredictable.

**Reason for Change**:

With this change, `kubectl apply` correctly upgrades and restarts all
the components when new verison is applied.

**Issue Fixed**:

none

**Notes for Reviewers**:
