### PR TITLE
Fix the token backward compat in host based token fetching

### DIFF
--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -52,8 +52,8 @@ type Server struct {
 
 // NMIResponse is the response returned to caller
 type NMIResponse struct {
-	Token    adal.Token `json:"token"`
-	ClientID string     `json:"clientid"`
+	Token    msiResponse `json:"token"`
+	ClientID string      `json:"clientid"`
 }
 
 // NewServer will create a new Server with default values.
@@ -220,7 +220,7 @@ func (s *Server) hostHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 	nmiResp := NMIResponse{
-		Token:    *token,
+		Token:    newMSIResponse(*token),
 		ClientID: clientID,
 	}
 	response, err := json.Marshal(nmiResp)


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

As aad-pod-identity moved to new adal libraries, the usage of older libraries had become incompatible (due to backward combat issues introduced with https://github.com/Azure/go-autorest/pull/326). With the PR #306 backward compatibility was added in paths where applications fetch tokens. The host handler path which is used by kevvault flex volume also needs similar fixes. This PR fixes that path. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
#336 

**Notes for Reviewers**:
Ran 15 of 17 Specs in 3684.931 seconds
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2 Skipped
--- PASS: TestAADPodIdentity (3684.93s)
PASS
ok      github.com/Azure/aad-pod-identity/test/e2e      3684.958s