### PR TITLE
Set Content-Type on token response

### DIFF
--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -452,6 +452,7 @@ func (s *Server) defaultPathHandler(logger *log.Entry, w http.ResponseWriter, r 
 		logger.Errorf("failed io operation of reading response body, %+v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+	w.Header().Set("Content-Type", "application/json")
 	w.Write(body)
 }
 


### PR DESCRIPTION
Proposed fix for https://github.com/Azure/aad-pod-identity/issues/340

<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
Rest Clients expects the content type to be application/json
https://github.com/Azure/aad-pod-identity/issues/340

**Issue Fixed**:
Fixes
https://github.com/Azure/aad-pod-identity/issues/340
https://github.com/Azure/aad-pod-identity/issues/368

**Notes for Reviewers**:
