### PR TITLE
Stats locks and tests

### DIFF
--- a/pkg/stats/stats_test.go
+++ b/pkg/stats/stats_test.go
@@ -1,7 +1,9 @@
 package stats_test
 
 import (
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,5 +31,41 @@ func TestBasics(t *testing.T) {
 	getAllStats := stats.GetAll()
 	if reflect.DeepEqual(getAllStats, validateMap) != true {
 		panic("Stats added did not come back")
+	}
+}
+
+func TestConcurrency(t *testing.T) {
+	glog.Infof("Concurrency test starting")
+	stats.Init()
+	var wg sync.WaitGroup
+	var startWg sync.WaitGroup
+
+	// Make sure all of them start at the same time so that there are more chances of sync issues.
+	startWg.Add(1)
+	count := 100
+	duration := time.Second * 10
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(c int) {
+			defer wg.Done()
+			startWg.Wait()
+			fmt.Printf("Updating %d \n", c)
+			stats.Update(stats.AssignedIDList, duration)
+		}(i)
+		wg.Add(1)
+		go func(c int) {
+			defer wg.Done()
+			startWg.Wait()
+			fmt.Printf("Getting %d\n", c)
+			stats.Get(stats.AssignedIDList)
+		}(i)
+	}
+
+	// All of them should start together.
+	startWg.Done()
+	wg.Wait()
+
+	if stats.Get(stats.AssignedIDList) != duration*time.Duration(count) {
+		panic("Stats did not get incremented.")
 	}
 }


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
With parallel node updates there are code paths which updates these stats concurrently.
These changes add lock around stats and UT corresponding to that.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**: