### PR TITLE
add user agent to kube-api calls

### DIFF
--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -61,6 +61,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Could not read config properly. Check the k8s config file, %+v", err)
 	}
+	config.UserAgent = version.GetUserAgent("MIC", version.MICVersion)
 
 	forceNamespaced = forceNamespaced || "true" == os.Getenv("FORCENAMESPACED")
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -15,6 +15,7 @@ import (
 
 	aadpodid "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	crd "github.com/Azure/aad-pod-identity/pkg/crd"
+	"github.com/Azure/aad-pod-identity/version"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -62,6 +63,7 @@ func NewKubeClient() (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	config.UserAgent = version.GetUserAgent("NMI", version.NMIVersion)
 	clientset, err := getkubeclient(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Add user-agent to kube-api calls. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes https://github.com/Azure/aad-pod-identity/issues/352

**Notes for Reviewers**:
Sample output from grafana -

```
{client="aad-pod-identity/MIC/0.0.0-dev/6f597c3/2019-08-21-06:53",resource="azureassignedidentities",verb="CREATE"}
{client="aad-pod-identity/MIC/0.0.0-dev/6f597c3/2019-08-21-06:53",resource="azureidentities",verb="LIST"}
{client="aad-pod-identity/NMI/0.0.0-dev/6f597c3/2019-08-21-06:52",resource="azureassignedidentities",verb="LIST"}
```