### PR TITLE
Add e2e for init containers

### DIFF
--- a/test/common/k8s/infra/infra.go
+++ b/test/common/k8s/infra/infra.go
@@ -74,6 +74,7 @@ type IdentityValidatorTemplateData struct {
 	NodeName                 string
 	Replicas                 string
 	DeploymentLabels         map[string]string
+	InitContainer            bool
 }
 
 // CreateIdentityValidator will create an identity validator deployment on a Kubernetes cluster

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -10,11 +10,11 @@ type Config struct {
 	KeyvaultName             string `envconfig:"KEYVAULT_NAME"`
 	KeyvaultSecretName       string `envconfig:"KEYVAULT_SECRET_NAME"`
 	KeyvaultSecretVersion    string `envconfig:"KEYVAULT_SECRET_VERSION"`
-	MICVersion               string `envconfig:"MIC_VERSION" default:"1.5"`
-	NMIVersion               string `envconfig:"NMI_VERSION" default:"1.5"`
+	MICVersion               string `envconfig:"MIC_VERSION" default:"1.5.2"`
+	NMIVersion               string `envconfig:"NMI_VERSION" default:"1.5.2"`
 	Registry                 string `envconfig:"REGISTRY" default:"mcr.microsoft.com/k8s/aad-pod-identity"`
-	IdentityValidatorVersion string `envconfig:"IDENTITY_VALIDATOR_VERSION" default:"1.5"`
-	SystemMSICluster         bool   `envconfig:"SYSTEM_MSI_CLUSTER" default:false`
+	IdentityValidatorVersion string `envconfig:"IDENTITY_VALIDATOR_VERSION" default:"1.5.2"`
+	SystemMSICluster         bool   `envconfig:"SYSTEM_MSI_CLUSTER" default:"false"`
 }
 
 // ParseConfig will parse needed environment variables for running the tests

--- a/test/e2e/template/deployment.yaml
+++ b/test/e2e/template/deployment.yaml
@@ -23,6 +23,12 @@ spec:
       {{ if ne .NodeName "" -}}
       nodeName: {{.NodeName}}
       {{- end }}
+      {{- if .InitContainer -}}
+      initContainers:
+        - name: init-myservice
+          image: microsoft/azure-cli:latest
+          command: ["sh", "-c", "az login --identity"]
+      {{- end }}
       containers:
       - name: {{.Name}}
         image: {{.Registry}}/identityvalidator:{{.IdentityValidatorVersion}}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Add e2e tests for init containers

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes https://github.com/Azure/aad-pod-identity/issues/357

**Notes for Reviewers**:
