### PR TITLE
update identity in vmss only once

### DIFF
--- a/deploy/infra/rc/deployment-rbac.yaml
+++ b/deploy/infra/rc/deployment-rbac.yaml
@@ -118,7 +118,7 @@ spec:
         name: iptableslock
       containers:
       - name: nmi
-        image: "aramase/nmi:1.5.4"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.5.3-rc2"
         imagePullPolicy: Always
         args:
           - "--host-ip=$(HOST_IP)"
@@ -220,7 +220,7 @@ spec:
       serviceAccountName: aad-pod-id-mic-service-account
       containers:
       - name: mic
-        image: "aramase/mic:1.5.4"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.5.3-rc2"
         imagePullPolicy: Always
         args:
           - "--cloudconfig=/etc/kubernetes/azure.json"

--- a/deploy/infra/rc/deployment-rbac.yaml
+++ b/deploy/infra/rc/deployment-rbac.yaml
@@ -118,7 +118,7 @@ spec:
         name: iptableslock
       containers:
       - name: nmi
-        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.5.3-rc2"
+        image: "aramase/nmi:1.5.4"
         imagePullPolicy: Always
         args:
           - "--host-ip=$(HOST_IP)"
@@ -220,7 +220,7 @@ spec:
       serviceAccountName: aad-pod-id-mic-service-account
       containers:
       - name: mic
-        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.5.3-rc2"
+        image: "aramase/mic:1.5.4"
         imagePullPolicy: Always
         args:
           - "--cloudconfig=/etc/kubernetes/azure.json"

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/glog"
 	yaml "gopkg.in/yaml.v2"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // Client is a cloud provider client
@@ -31,10 +30,10 @@ type Client struct {
 
 // ClientInt client interface
 type ClientInt interface {
-	RemoveUserMSI(userAssignedMSIID string, node *corev1.Node) error
-	AssignUserMSI(userAssignedMSIID string, node *corev1.Node) error
-	UpdateUserMSI(addUserAssignedMSIIDs []string, removeUserAssignedMSIIDs []string, node *corev1.Node) error
-	GetUserMSIs(node *corev1.Node) ([]string, error)
+	RemoveUserMSI(userAssignedMSIID, name string, isvmss bool) error
+	AssignUserMSI(userAssignedMSIID, name string, isvmss bool) error
+	UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs []string, name string, isvmss bool) error
+	GetUserMSIs(name string, isvmss bool) ([]string, error)
 }
 
 // NewCloudProvider returns a azure cloud provider client
@@ -153,8 +152,8 @@ func withInspection() autorest.PrepareDecorator {
 }
 
 // GetUserMSIs will return a list of all identities on the node
-func (c *Client) GetUserMSIs(node *corev1.Node) ([]string, error) {
-	idH, _, err := c.getIdentityResource(node)
+func (c *Client) GetUserMSIs(name string, isvmss bool) ([]string, error) {
+	idH, _, err := c.getIdentityResource(name, isvmss)
 	if err != nil {
 		glog.Errorf("GetUserMSIs: get identity resource failed with error %v", err)
 		return nil, err
@@ -168,8 +167,8 @@ func (c *Client) GetUserMSIs(node *corev1.Node) ([]string, error) {
 }
 
 // UpdateUserMSI will batch process the removal and addition of ids
-func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs []string, removeUserAssignedMSIIDs []string, node *corev1.Node) error {
-	idH, updateFunc, err := c.getIdentityResource(node)
+func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs []string, name string, isvmss bool) error {
+	idH, updateFunc, err := c.getIdentityResource(name, isvmss)
 	if err != nil {
 		return err
 	}
@@ -184,43 +183,43 @@ func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs []string, removeUserAssigne
 	for _, userAssignedMSIID := range removeUserAssignedMSIIDs {
 		requiresUpdate = true
 		if err := info.RemoveUserIdentity(userAssignedMSIID); err != nil {
-			return fmt.Errorf("could not remove identity from node %s: %v", node.Name, err)
+			return fmt.Errorf("could not remove identity from node %s: %v", name, err)
 		}
 	}
 	// add new ids to the list
 	for _, userAssignedMSIID := range addUserAssignedMSIIDs {
 		addedToList := info.AppendUserIdentity(userAssignedMSIID)
 		if !addedToList {
-			glog.V(6).Infof("Identity %s already assigned to node %s. Skipping assignment.", userAssignedMSIID, node.Name)
+			glog.V(6).Infof("Identity %s already assigned to node %s. Skipping assignment.", userAssignedMSIID, name)
 		}
 		requiresUpdate = requiresUpdate || addedToList
 	}
 	if requiresUpdate {
-		glog.Infof("Updating user assigned MSIs on %s", node.Name)
+		glog.Infof("Updating user assigned MSIs on %s", name)
 		timeStarted := time.Now()
 		if err := updateFunc(); err != nil {
 			return err
 		}
-		glog.V(6).Infof("UpdateUserMSI of %s completed in %s", node.Name, time.Since(timeStarted))
+		glog.V(6).Infof("UpdateUserMSI of %s completed in %s", name, time.Since(timeStarted))
 	}
 	return nil
 }
 
 //RemoveUserMSI - Use the underlying cloud api calls and remove the given user assigned MSI from the vm.
-func (c *Client) RemoveUserMSI(userAssignedMSIID string, node *corev1.Node) error {
-	idH, updateFunc, err := c.getIdentityResource(node)
+func (c *Client) RemoveUserMSI(userAssignedMSIID, name string, isvmss bool) error {
+	idH, updateFunc, err := c.getIdentityResource(name, isvmss)
 	if err != nil {
 		return err
 	}
 
 	info := idH.IdentityInfo()
 	if info == nil {
-		glog.Errorf("Identity null for vm: %s ", node.Name)
-		return fmt.Errorf("identity null for vm: %s ", node.Name)
+		glog.Errorf("Identity null for vm: %s ", name)
+		return fmt.Errorf("identity null for vm: %s ", name)
 	}
 
 	if err := info.RemoveUserIdentity(userAssignedMSIID); err != nil {
-		return fmt.Errorf("could not remove identity from node %s: %v", node.Name, err)
+		return fmt.Errorf("could not remove identity from node %s: %v", name, err)
 	}
 
 	if err := updateFunc(); err != nil {
@@ -232,18 +231,18 @@ func (c *Client) RemoveUserMSI(userAssignedMSIID string, node *corev1.Node) erro
 }
 
 // AssignUserMSI - Use the underlying cloud api call and add the given user assigned MSI to the vm
-func (c *Client) AssignUserMSI(userAssignedMSIID string, node *corev1.Node) error {
+func (c *Client) AssignUserMSI(userAssignedMSIID, name string, isvmss bool) error {
 	// Get the vm using the VmClient
 	// Update the assigned identity into the VM using the CreateOrUpdate
 
-	glog.Infof("Find %s in resource group: %s", node.Name, c.Config.ResourceGroupName)
+	glog.Infof("Find %s in resource group: %s", name, c.Config.ResourceGroupName)
 	timeStarted := time.Now()
 
-	idH, updateFunc, err := c.getIdentityResource(node)
+	idH, updateFunc, err := c.getIdentityResource(name, isvmss)
 	if err != nil {
 		return err
 	}
-	glog.V(6).Infof("Get of %s completed in %s", node.Name, time.Since(timeStarted))
+	glog.V(6).Infof("Get of %s completed in %s", name, time.Since(timeStarted))
 
 	info := idH.IdentityInfo()
 	if info == nil {
@@ -255,34 +254,17 @@ func (c *Client) AssignUserMSI(userAssignedMSIID string, node *corev1.Node) erro
 		if err := updateFunc(); err != nil {
 			return err
 		}
-		glog.V(6).Infof("CreateOrUpdate of %s completed in %s", node.Name, time.Since(timeStarted))
+		glog.V(6).Infof("CreateOrUpdate of %s completed in %s", name, time.Since(timeStarted))
 	} else {
-		glog.V(6).Infof("Identity %s already assigned to node %s. Skipping assignment.", userAssignedMSIID, node.Name)
+		glog.V(6).Infof("Identity %s already assigned to node %s. Skipping assignment.", userAssignedMSIID, name)
 	}
 	return nil
 }
 
-func (c *Client) getIdentityResource(node *corev1.Node) (idH IdentityHolder, update func() error, retErr error) {
-	name := node.Name // fallback in case parsing the provider spec fails
+func (c *Client) getIdentityResource(name string, isvmss bool) (idH IdentityHolder, update func() error, retErr error) {
 	rg := c.Config.ResourceGroupName
-	r, err := ParseResourceID(node.Spec.ProviderID)
-	if err != nil {
-		glog.Warningf("Could not parse Azure node resource ID: %v", err)
-	}
 
-	rt := vmTypeOrDefault(&r, c.Config.VMType)
-	glog.V(6).Infof("Using resource type %s for node %s", rt, name)
-
-	if r.ResourceGroup != "" {
-		rg = r.ResourceGroup
-	}
-
-	if r.ResourceName != "" {
-		name = r.ResourceName
-	}
-
-	switch rt {
-	case "vmss":
+	if isvmss {
 		vmss, err := c.VMSSClient.Get(rg, name)
 		if err != nil {
 			return nil, nil, err
@@ -292,16 +274,17 @@ func (c *Client) getIdentityResource(node *corev1.Node) (idH IdentityHolder, upd
 			return c.VMSSClient.CreateOrUpdate(rg, name, vmss)
 		}
 		idH = &vmssIdentityHolder{&vmss}
-	default:
-		vm, err := c.VMClient.Get(rg, name)
-		if err != nil {
-			return nil, nil, err
-		}
-		update = func() error {
-			return c.VMClient.CreateOrUpdate(rg, name, vm)
-		}
-		idH = &vmIdentityHolder{&vm}
+		return idH, update, nil
 	}
+
+	vm, err := c.VMClient.Get(rg, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	update = func() error {
+		return c.VMClient.CreateOrUpdate(rg, name, vm)
+	}
+	idH = &vmIdentityHolder{&vm}
 
 	return idH, update, nil
 }
@@ -315,7 +298,9 @@ var (
 )
 
 const (
-	VMResourceType   = "virtualMachines"
+	// VMResourceType virtual machine resource type
+	VMResourceType = "virtualMachines"
+	// VMSSResourceType virtual machine scale sets resource type
 	VMSSResourceType = "virtualMachineScaleSets"
 )
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -151,7 +151,7 @@ func withInspection() autorest.PrepareDecorator {
 	}
 }
 
-// GetUserMSIs will return a list of all identities on the node
+// GetUserMSIs will return a list of all identities on the node or vmss based on value of isvmss
 func (c *Client) GetUserMSIs(name string, isvmss bool) ([]string, error) {
 	idH, _, err := c.getIdentityResource(name, isvmss)
 	if err != nil {

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -708,6 +708,11 @@ func (c *Client) updateNodeAndDeps(newAssignedIDs []aadpodid.AzureAssignedIdenti
 
 	vmssMap := make(map[string][]string)
 
+	fmt.Println("NODE NAME BEFORE ##############")
+	for nodeName := range nodeMap {
+		fmt.Println(nodeName)
+	}
+
 	for nodeName, nodeTrackList := range nodeMap {
 		node, err := c.NodeClient.Get(nodeName)
 		if err != nil && !strings.Contains(err.Error(), "not found") {
@@ -756,6 +761,11 @@ func (c *Client) updateNodeAndDeps(newAssignedIDs []aadpodid.AzureAssignedIdenti
 
 			nodeMap[vmssNodes[0]] = firstNodeTrackList
 		}
+	}
+
+	fmt.Println("NODE NAME AFTER ##############")
+	for nodeName := range nodeMap {
+		fmt.Println(nodeName)
 	}
 
 	for nodeName, nodeTrackList := range nodeMap {

--- a/pkg/mic/vmss.go
+++ b/pkg/mic/vmss.go
@@ -96,6 +96,11 @@ func makeVMSSID(r azure.Resource) string {
 	return path.Join(r.SubscriptionID, r.ResourceGroup, r.ResourceName)
 }
 
+func getVMSSName(vmssID string) string {
+	_, resourceName := path.Split(vmssID)
+	return resourceName
+}
+
 // Either get a vmss group by node reference or lookup the vmss ID from the node's provider ID.
 // The reason for this is we may have request to delete an identity from a node and it is the last identity, so
 // the node will not be referenced by any pods and will be absent from the group list

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -609,6 +609,9 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(Equal(true))
 
+		// TODO (aramase) make this deterministic by ensuring pods with desired image are running
+		time.Sleep(30 * time.Second)
+
 		ok, err = waitForIPTableRulesToExist("busybox")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(Equal(true))


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Update identity in vmss only once as identity is across all nodes in vmss and not just single node.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes https://github.com/Azure/aad-pod-identity/issues/361

**Notes for Reviewers**: