### PR TITLE
Fix namespaced multiple binding/identity handling and verbose logs

### DIFF
--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -598,42 +598,51 @@ func TestMapMICClient(t *testing.T) {
 	idList := make([]aadpodid.AzureIdentity, 0)
 
 	id := new(aadpodid.AzureIdentity)
+	id.Namespace = "default"
 	id.Name = "test-azure-identity"
 
 	idList = append(idList, *id)
 
+	id.Namespace = "newns"
 	id.Name = "test-akssvcrg-id"
+
 	idList = append(idList, *id)
 
 	idMap, _ := micClient.convertIDListToMap(idList)
 
+	namespace := "default"
 	name := "test-azure-identity"
 	count := 3
-	if azureID, idPresent := idMap[name]; idPresent {
+	if azureID, idPresent := idMap[getIDKey(namespace, name)]; idPresent {
 		if azureID.Name != name {
-			t.Errorf("id map id value mismatch")
+			t.Fatalf("id map id value mismatch")
 		}
 		count = count - 1
+	} else {
+		t.Fatalf("id %s not found", name)
 	}
 
+	namespace = "newns"
 	name = "test-akssvcrg-id"
-	if azureID, idPresent := idMap[name]; idPresent {
+	if azureID, idPresent := idMap[getIDKey(namespace, name)]; idPresent {
 		if azureID.Name != name {
-			t.Errorf("id map id value mismatch")
+			t.Fatalf("id map id value mismatch")
 		}
 		count = count - 1
+	} else {
+		t.Fatalf("id %s not found", name)
 	}
 
+	namespace = "default"
 	name = "test not there"
-	if _, idPresent := idMap[name]; idPresent {
-		t.Errorf("not present found")
+	if _, idPresent := idMap[getIDKey(namespace, name)]; idPresent {
+		t.Fatalf("not present found")
 	} else {
 		count = count - 1
 	}
 	if count != 0 {
-		t.Errorf("Test count mismatch")
+		t.Fatalf("Test count mismatch - count %d", count)
 	}
-
 }
 
 func (c *TestMICClient) testRunSync() func(t *testing.T) {

--- a/pkg/stats/stats_test.go
+++ b/pkg/stats/stats_test.go
@@ -1,7 +1,6 @@
 package stats_test
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -49,14 +48,14 @@ func TestConcurrency(t *testing.T) {
 		go func(c int) {
 			defer wg.Done()
 			startWg.Wait()
-			fmt.Printf("Updating %d \n", c)
+			//fmt.Printf("Updating %d \n", c)
 			stats.Update(stats.AssignedIDList, duration)
 		}(i)
 		wg.Add(1)
 		go func(c int) {
 			defer wg.Done()
 			startWg.Wait()
-			fmt.Printf("Getting %d\n", c)
+			//fmt.Printf("Getting %d\n", c)
 			stats.Get(stats.AssignedIDList)
 		}(i)
 	}


### PR DESCRIPTION
In forcenamespaced configuration multiple bindings or identities could exists with the same name in different namespaces. The last binding which matched was used to create the assigned identity representing current state. This PR fixes the issue by using the right bindings and identities.

The map used for handling of identities did not consider the namespace. This PR changes the key of the map to a combination of namespace and name of the identity.

<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
