### PR TITLE
Node filtered listing for pod/AzureAssignedIdentity, enable pprof, and misc cache sync fixes

### DIFF
--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"time"
 
@@ -14,13 +16,16 @@ import (
 )
 
 var (
-	kubeconfig        string
-	cloudconfig       string
-	forceNamespaced   bool
-	versionInfo       bool
-	syncRetryDuration time.Duration
-	leaderElectionCfg mic.LeaderElectionConfig
-	httpProbePort     string
+	kubeconfig          string
+	cloudconfig         string
+	forceNamespaced     bool
+	versionInfo         bool
+	syncRetryDuration   time.Duration
+	leaderElectionCfg   mic.LeaderElectionConfig
+	httpProbePort       string
+	enableProfile       bool
+	enableScaleFeatures bool
+	createDeleteBatch   int64
 )
 
 func main() {
@@ -44,6 +49,15 @@ func main() {
 	//Probe port
 	flag.StringVar(&httpProbePort, "http-probe-port", "8080", "http liveliness probe port")
 
+	// Profile
+	flag.BoolVar(&enableProfile, "enableProfile", false, "Enable/Disable pprof profiling")
+
+	// Profile
+	flag.BoolVar(&enableScaleFeatures, "enableScaleFeatures", false, "Enable/Disable new features used for clusters at scale")
+
+	// Profile
+	flag.Int64Var(&createDeleteBatch, "createDeleteBatch", 200, "Per node/VMSS create/delete batches")
+
 	flag.Parse()
 	if versionInfo {
 		version.PrintVersionAndExit()
@@ -55,6 +69,17 @@ func main() {
 	if kubeconfig == "" {
 		glog.Warningf("--kubeconfig not passed will use InClusterConfig")
 	}
+	if enableProfile {
+		profilePort := "6060"
+		glog.Infof("Starting profiling on port %s", profilePort)
+		go func() {
+			glog.Error(http.ListenAndServe("localhost:"+profilePort, nil))
+		}()
+	}
+
+	if enableScaleFeatures {
+		glog.Infof("Enabling features for scale clusters")
+	}
 
 	glog.Infof("kubeconfig (%s) cloudconfig (%s)", kubeconfig, cloudconfig)
 	config, err := buildConfig(kubeconfig)
@@ -65,7 +90,7 @@ func main() {
 
 	forceNamespaced = forceNamespaced || "true" == os.Getenv("FORCENAMESPACED")
 
-	micClient, err := mic.NewMICClient(cloudconfig, config, forceNamespaced, syncRetryDuration, &leaderElectionCfg)
+	micClient, err := mic.NewMICClient(cloudconfig, config, forceNamespaced, syncRetryDuration, &leaderElectionCfg, enableScaleFeatures, createDeleteBatch)
 	if err != nil {
 		glog.Fatalf("Could not get the MIC client: %+v", err)
 	}

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -53,14 +53,14 @@ func main() {
 	// Profile
 	flag.BoolVar(&enableProfile, "enableProfile", false, "Enable/Disable pprof profiling")
 
-	// Profile
+	// Enable scale features handles the label based azureassignedidentity.
 	flag.BoolVar(&enableScaleFeatures, "enableScaleFeatures", false, "Enable/Disable new features used for clusters at scale")
 
-	// Profile
+	// createDeleteBatch can be used for tuning the number of outstanding api server operations we do per node/VMSS.
 	flag.Int64Var(&createDeleteBatch, "createDeleteBatch", 200, "Per node/VMSS create/delete batches")
 
-	// Profile
-	flag.Float64Var(&clientQPS, "clientQps", 70, "Client QPS used for throttling of calls to server")
+	// Client QPS is used to configure the client-go QPS throttling and bursting.
+	flag.Float64Var(&clientQPS, "clientQps", 10, "Client QPS used for throttling of calls to server")
 
 	flag.Parse()
 	if versionInfo {

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -26,6 +26,7 @@ var (
 	enableProfile       bool
 	enableScaleFeatures bool
 	createDeleteBatch   int64
+	clientQPS           float64
 )
 
 func main() {
@@ -58,6 +59,9 @@ func main() {
 	// Profile
 	flag.Int64Var(&createDeleteBatch, "createDeleteBatch", 200, "Per node/VMSS create/delete batches")
 
+	// Profile
+	flag.Float64Var(&clientQPS, "clientQps", 70, "Client QPS used for throttling of calls to server")
+
 	flag.Parse()
 	if versionInfo {
 		version.PrintVersionAndExit()
@@ -89,6 +93,10 @@ func main() {
 	config.UserAgent = version.GetUserAgent("MIC", version.MICVersion)
 
 	forceNamespaced = forceNamespaced || "true" == os.Getenv("FORCENAMESPACED")
+
+	config.QPS = float32(clientQPS)
+	config.Burst = int(clientQPS)
+	glog.Infof("Client QPS set to: %v. Burst to: %v", config.QPS, config.Burst)
 
 	micClient, err := mic.NewMICClient(cloudconfig, config, forceNamespaced, syncRetryDuration, &leaderElectionCfg, enableScaleFeatures, createDeleteBatch)
 	if err != nil {

--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -51,7 +51,7 @@ func main() {
 	log.Infof("Starting nmi process. Version: %v. Build date: %v. Log level: %s.", version.NMIVersion, version.BuildDate, log.GetLevel())
 	logger := &server.Log{}
 
-	client, err := k8s.NewKubeClient(logger)
+	client, err := k8s.NewKubeClient(logger, *nodename)
 	if err != nil {
 		log.Fatalf("%+v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/pflag v1.0.1
 	go.opencensus.io v0.22.0 // indirect
+	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -12,7 +12,6 @@ import (
 	inlog "github.com/Azure/aad-pod-identity/pkg/logger"
 	"github.com/Azure/aad-pod-identity/pkg/stats"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -216,9 +215,9 @@ func newIDInformer(r *rest.RESTClient, eventCh chan aadpodid.EventType, lw *cach
 // apply labels with node name and then later use the NodeNameFilter to tweak
 // options to filter using nodename label.
 func NodeNameFilter(nodeName string) internalinterfaces.TweakListOptionsFunc {
-	return func(l *metav1.ListOptions) {
+	return func(l *v1.ListOptions) {
 		if l == nil {
-			l = &metav1.ListOptions{}
+			l = &v1.ListOptions{}
 		}
 		l.LabelSelector = l.LabelSelector + "nodename=" + nodeName
 		return

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -87,7 +87,7 @@ func NewKubeClient(log inlog.Logger, nodeName string) (Client, error) {
 func (c *KubeClient) Start(exit <-chan struct{}) {
 	go c.PodInformer.Run(exit)
 	c.CrdClient.StartLite(exit)
-	c.CrdClient.SyncCache(exit, true)
+	c.CrdClient.SyncCacheLite(exit)
 }
 
 func (c *KubeClient) getReplicasetName(pod v1.Pod) string {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -85,7 +85,7 @@ func NewKubeClient(log inlog.Logger, nodeName string, scale bool) (Client, error
 
 func (c *KubeClient) Sync(exit <-chan struct{}) {
 	if !cache.WaitForCacheSync(exit, c.PodInformer.HasSynced) {
-		c.log.Errorf("Cache could not be synchronized")
+		c.log.Errorf("Pod cache could not be synchronized")
 	}
 	c.CrdClient.SyncCacheLite(exit)
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -54,7 +54,7 @@ type KubeClient struct {
 }
 
 // NewKubeClient new kubernetes api client
-func NewKubeClient(log inlog.Logger, nodeName string) (Client, error) {
+func NewKubeClient(log inlog.Logger, nodeName string, scale bool) (Client, error) {
 	config, err := buildConfig()
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func NewKubeClient(log inlog.Logger, nodeName string) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	crdclient, err := crd.NewCRDClientLite(config, log)
+	crdclient, err := crd.NewCRDClientLite(config, log, nodeName, scale)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -71,7 +71,7 @@ func NewKubeClient(log inlog.Logger, nodeName string, scale bool) (Client, error
 
 	podInformer := informersv1.NewFilteredPodInformer(clientset, v1.NamespaceAll, 10*time.Minute,
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-		TweakOptionFunc(nodeName))
+		NodeNameFilter(nodeName))
 
 	kubeClient := &KubeClient{
 		CrdClient:   crdclient,
@@ -106,7 +106,9 @@ func (c *KubeClient) getReplicasetName(pod v1.Pod) string {
 	return ""
 }
 
-func TweakOptionFunc(nodeName string) internalinterfaces.TweakListOptionsFunc {
+// NodeNameFilter will tweak the options to include the node name as field
+// selector.
+func NodeNameFilter(nodeName string) internalinterfaces.TweakListOptionsFunc {
 	return func(l *metav1.ListOptions) {
 		if l == nil {
 			l = &metav1.ListOptions{}

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -893,7 +893,7 @@ func (c *Client) updateUserMSI(newAssignedIDs []aadpodid.AzureAssignedIdentity, 
 			defer semUpdate.Release(1)
 			binding := assignedID.Spec.AzureBindingRef
 			// update the status to assigned for assigned identity as identity was successfully assigned to node.
-			err = c.updateAssignedIdentityStatus(&assignedID, aadpodid.AssignedIDAssigned)
+			err := c.updateAssignedIdentityStatus(&assignedID, aadpodid.AssignedIDAssigned)
 			if err != nil {
 				message := fmt.Sprintf("Updating assigned identity %s status to %s for pod %s failed with error %v", assignedID.Name, aadpodid.AssignedIDAssigned, assignedID.Spec.Pod, err.Error())
 				c.EventRecorder.Event(&assignedID, corev1.EventTypeWarning, "status update error", message)
@@ -923,7 +923,7 @@ func (c *Client) updateUserMSI(newAssignedIDs []aadpodid.AzureAssignedIdentity, 
 			removedBinding := assignedID.Spec.AzureBindingRef
 			// update the status for the assigned identity to Unassigned as the identity has been successfully removed from node.
 			// this will ensure on next sync loop we only try to delete the assigned identity instead of doing everything.
-			err = c.updateAssignedIdentityStatus(&assignedID, aadpodid.AssignedIDUnAssigned)
+			err := c.updateAssignedIdentityStatus(&assignedID, aadpodid.AssignedIDUnAssigned)
 			if err != nil {
 				message := fmt.Sprintf("Updating assigned identity %s status to %s for pod %s failed with error %v", assignedID.Name, aadpodid.AssignedIDUnAssigned, assignedID.Spec.Pod, err.Error())
 				c.EventRecorder.Event(&assignedID, corev1.EventTypeWarning, "status update error", message)

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -590,7 +590,8 @@ func NewMICTestClient(eventCh chan aadpodid.EventType,
 	crdClient *TestCrdClient,
 	podClient *TestPodClient,
 	nodeClient *TestNodeClient,
-	eventRecorder *TestEventRecorder, isNamespaced bool) *TestMICClient {
+	eventRecorder *TestEventRecorder, isNamespaced bool,
+	createDeleteBatch int64) *TestMICClient {
 
 	realMICClient := &Client{
 		CloudClient:       cpClient,
@@ -601,6 +602,7 @@ func NewMICTestClient(eventCh chan aadpodid.EventType,
 		NodeClient:        nodeClient,
 		syncRetryInterval: 120 * time.Second,
 		IsNamespaced:      isNamespaced,
+		createDeleteBatch: createDeleteBatch,
 	}
 
 	return &TestMICClient{
@@ -707,7 +709,7 @@ func TestSimpleMICClient(t *testing.T) {
 	evtRecorder.lastEvent = new(LastEvent)
 	evtRecorder.eventChannel = make(chan bool, 100)
 
-	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false)
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false, 4)
 
 	crdClient.CreateID("test-id", "default", aadpodid.UserAssignedMSI, "test-user-msi-resourceid", "test-user-msi-clientid", nil, "", "", "", "")
 	crdClient.CreateBinding("testbinding", "default", "test-id", "test-select", "")
@@ -828,7 +830,7 @@ func TestAddDelMICClient(t *testing.T) {
 	evtRecorder.lastEvent = new(LastEvent)
 	evtRecorder.eventChannel = make(chan bool, 100)
 
-	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false)
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false, 4)
 
 	// Test to add and delete at the same time.
 	// Add a pod, identity and binding.
@@ -920,7 +922,7 @@ func TestMicAddDelVMSS(t *testing.T) {
 	evtRecorder.lastEvent = new(LastEvent)
 	evtRecorder.eventChannel = make(chan bool, 100)
 
-	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false)
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false, 4)
 
 	// Test to add and delete at the same time.
 	// Add a pod, identity and binding.
@@ -1023,7 +1025,7 @@ func TestMICStateFlow(t *testing.T) {
 	evtRecorder.lastEvent = new(LastEvent)
 	evtRecorder.eventChannel = make(chan bool, 100)
 
-	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false)
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false, 4)
 
 	// Add a pod, identity and binding.
 	crdClient.CreateID("test-id1", "default", aadpodid.UserAssignedMSI, "test-user-msi-resourceid", "test-user-msi-clientid", nil, "", "", "", "")
@@ -1137,7 +1139,7 @@ func TestForceNamespaced(t *testing.T) {
 	evtRecorder.lastEvent = new(LastEvent)
 	evtRecorder.eventChannel = make(chan bool, 100)
 
-	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, true)
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, true, 4)
 
 	crdClient.CreateID("test-id1", "default", aadpodid.UserAssignedMSI, "test-user-msi-resourceid", "test-user-msi-clientid", nil, "", "", "", "idrv1")
 	crdClient.CreateBinding("testbinding1", "default", "test-id1", "test-select1", "bindingrv1")
@@ -1201,7 +1203,7 @@ func TestSyncRetryLoop(t *testing.T) {
 	evtRecorder.lastEvent = new(LastEvent)
 	evtRecorder.eventChannel = make(chan bool, 100)
 
-	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false)
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false, 4)
 	syncRetryInterval, err := time.ParseDuration("10s")
 	if err != nil {
 		t.Errorf("error parsing duration: %v", err)
@@ -1280,7 +1282,7 @@ func TestSyncNodeNotFound(t *testing.T) {
 	evtRecorder.lastEvent = new(LastEvent)
 	evtRecorder.eventChannel = make(chan bool, 100)
 
-	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false)
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false, 4)
 
 	// Add a pod, identity and binding.
 	crdClient.CreateID("test-id1", "default", aadpodid.UserAssignedMSI, "test-user-msi-resourceid", "test-user-msi-clientid", nil, "", "", "", "")
@@ -1352,7 +1354,7 @@ func TestSyncExit(t *testing.T) {
 	evtRecorder.lastEvent = new(LastEvent)
 	evtRecorder.eventChannel = make(chan bool)
 
-	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false)
+	micClient := NewMICTestClient(eventCh, cloudClient, crdClient, podClient, nodeClient, &evtRecorder, false, 4)
 
 	micClient.testRunSync()(t)
 }

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -345,7 +345,11 @@ func NewTestCrdClient(config *rest.Config) *TestCrdClient {
 func (c *TestCrdClient) Start(exit <-chan struct{}) {
 }
 
-func (c *TestCrdClient) SyncCache(exit <-chan struct{}, initial bool) {
+func (c *TestCrdClient) SyncCache(exit <-chan struct{}) {
+
+}
+
+func (c *TestCrdClient) SyncCacheLite(exit <-chan struct{}) {
 
 }
 

--- a/test/common/k8s/infra/infra.go
+++ b/test/common/k8s/infra/infra.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CreateInfra will deploy all the infrastructure components (nmi and mic) on a Kubernetes cluster
-func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath string, old bool) error {
+func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath string, old, enableScaleFeatures bool) error {
 	var err error
 	var t *template.Template
 	if !old {
@@ -37,12 +37,13 @@ func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath
 	nmiArg = nmiVersion == "1.4"
 
 	deployData := struct {
-		Namespace  string
-		Registry   string
-		NMIVersion string
-		MICVersion string
-		MICArg     bool
-		NMIArg     bool
+		Namespace           string
+		Registry            string
+		NMIVersion          string
+		MICVersion          string
+		MICArg              bool
+		NMIArg              bool
+		EnableScaleFeatures bool
 	}{
 		namespace,
 		registry,
@@ -50,6 +51,7 @@ func CreateInfra(namespace, registry, nmiVersion, micVersion, templateOutputPath
 		micVersion,
 		micArg,
 		nmiArg,
+		enableScaleFeatures,
 	}
 	if err := t.Execute(deployFile, deployData); err != nil {
 		return errors.Wrap(err, "Failed to create a deployment file from deployment-rbac.yaml")

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	cfg = *c
 	fmt.Printf("System MSI enabled: %v\n", cfg.SystemMSICluster)
-	setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion)
+	setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion, cfg.EnableScaleFeatures)
 })
 
 var _ = AfterSuite(func() {
@@ -498,7 +498,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		}
 
 		// reset the infra to previous state
-		setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion)
+		setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion, cfg.EnableScaleFeatures)
 	})
 
 	It("should not alter the system assigned identity after creating and deleting pod identity", func() {
@@ -603,7 +603,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		Expect(ok).To(Equal(true))
 
 		// update the infra to use latest mic and nmi images
-		setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion)
+		setupInfra(cfg.Registry, cfg.NMIVersion, cfg.MICVersion, cfg.EnableScaleFeatures)
 
 		ok, err = daemonset.WaitOnReady(nmiDaemonSet)
 		Expect(err).NotTo(HaveOccurred())
@@ -1167,15 +1167,15 @@ func checkInfra() {
 // setupInfra creates the crds, mic, nmi and blocks until iptable entries exist
 func setupInfraOld(registry, nmiVersion, micVersion string) {
 	// Install CRDs and deploy MIC and NMI
-	err := infra.CreateInfra("default", registry, nmiVersion, micVersion, templateOutputPath, true)
+	err := infra.CreateInfra("default", registry, nmiVersion, micVersion, templateOutputPath, true, false)
 	Expect(err).NotTo(HaveOccurred())
 	checkInfra()
 }
 
 // setupInfra creates the crds, mic, nmi and blocks until iptable entries exist
-func setupInfra(registry, nmiVersion, micVersion string) {
+func setupInfra(registry, nmiVersion, micVersion string, enableScaleFeatures bool) {
 	// Install CRDs and deploy MIC and NMI
-	err := infra.CreateInfra("default", registry, nmiVersion, micVersion, templateOutputPath, false)
+	err := infra.CreateInfra("default", registry, nmiVersion, micVersion, templateOutputPath, false, enableScaleFeatures)
 	Expect(err).NotTo(HaveOccurred())
 	checkInfra()
 }

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Registry                 string `envconfig:"REGISTRY" default:"mcr.microsoft.com/k8s/aad-pod-identity"`
 	IdentityValidatorVersion string `envconfig:"IDENTITY_VALIDATOR_VERSION" default:"1.5.2"`
 	SystemMSICluster         bool   `envconfig:"SYSTEM_MSI_CLUSTER" default:"false"`
+	EnableScaleFeatures      bool   `envconfig:"ENABLE_SCALE_FEATURES" default:"false"`
 }
 
 // ParseConfig will parse needed environment variables for running the tests

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -116,6 +116,7 @@ spec:
           {{if .NMIArg}}- nmi {{ end }}
           - "--host-ip=$(HOST_IP)"
           - "--node=$(NODE_NAME)"
+          {{if .EnableScaleFeatures}}- "--enableScaleFeatures=true" {{end}}
         env:
           - name: HOST_IP
             valueFrom:
@@ -215,6 +216,7 @@ spec:
           {{if .MICArg}}- mic {{ end }}
           - "--cloudconfig=/etc/kubernetes/azure.json"
           - "--logtostderr"
+          {{if .EnableScaleFeatures}}- "--enableScaleFeatures=true" {{end}}
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

- Add ability to enable pprof profiling.
-  Add labels to AzureAssignedIdentity which indicates the nodename, pod name and pod namespace. This is used to tune the list/watches in NMI. NMI in 'enableScaleFeatures' mode will list/watch based on nodename in the lable. This reduces the payload passed between the etcd, api-server and NMI. With this we can scale to large number of nodes.     
-  Create/Delete operations for each node/VMSS based on the parallelism set by 'createDeleteBatch' parameter.
-  Parallelize the create/delete of AzureAssignedIdentity operations for individual VMSS. 
- Cache sync fixes.
- Fix to not call CacheSync in every cycle to avoid go-client thread leak issue.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
