### PR TITLE
Remove deprecated API version usages

### DIFF
--- a/charts/aad-pod-identity/templates/mic-deployment.yaml
+++ b/charts/aad-pod-identity/templates/mic-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}

--- a/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "aad-pod-identity.nmi.fullname" . }}


### PR DESCRIPTION
**Reason for Change**:

Kubernetes 1.16 [removes](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) API version `extensions/v1beta1` for `Deployment` and `DaemonSet` (in addition to other resources as well).

This PR fixes the existing usages.

**Issue Fixed**:
N/A