### PR TITLE
Moving to latest Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG DEMO_VERSION=0.0.0-dev
 ARG IDENTITY_VALIDATOR_VERSION=0.0.0-dev
 RUN make build
 
-FROM alpine:3.10.1 AS base
+FROM alpine:3.10.3 AS base
 RUN apk add --no-cache \
     ca-certificates \
     iptables \


### PR DESCRIPTION
**Reason for Change**:

3.10.1 has a high severity vulnerability being raised on our CSP. it's good to be on latest anyway.

https://github.com/alpinelinux/docker-alpine/issues/34

**Issue Fixed**:
NA

**Notes for Reviewers**:
