### PR TITLE
validate resource param exists

### DIFF
--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -191,7 +191,7 @@ func (s *Server) hostHandler(logger *log.Entry, w http.ResponseWriter, r *http.R
 		return
 	}
 	if !validateResourceParamExists(rqResource) {
-		logger.Error("parameter resource cannot be empty")
+		logger.Warning("parameter resource cannot be empty")
 		http.Error(w, "parameter resource cannot be empty", http.StatusBadRequest)
 		return
 	}
@@ -321,7 +321,7 @@ func (s *Server) msiHandler(logger *log.Entry, w http.ResponseWriter, r *http.Re
 		return
 	}
 	if !validateResourceParamExists(rqResource) {
-		logger.Error("parameter resource cannot be empty")
+		logger.Warning("parameter resource cannot be empty")
 		http.Error(w, "parameter resource cannot be empty", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Validates if the `resource` parameter exists in the token request. This validation is currently done in the sdk and we are introducing the change in order to mimic the exact same error response code that IMDS would send for such a scenario.

Request without `resource` param while talking directly also returns an error and `400` response code -
```
body {"error":"invalid_request","error_description":"Required query variable 'resource' is missing"}
Response status: 400 Bad Request
```

With this change we will be more aligned with what a user would typically see while taking to IMDS without pod-identity.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
