### PR TITLE
Add namespace metadata

### DIFF
--- a/charts/aad-pod-identity/templates/_helper.tpl
+++ b/charts/aad-pod-identity/templates/_helper.tpl
@@ -39,6 +39,9 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Component namespaces. Defaults to release namespace for all.
+*/}}
 {{- define "aad-pod-identity.azureidentity.namespace" -}}
 {{- if .Values.azureIdentity.namespace -}}
 {{ .Values.azureIdentity.namespace }}
@@ -50,6 +53,22 @@ Create chart name and version as used by the chart label.
 {{- define "aad-pod-identity.azureidentitybinding.namespace" -}}
 {{- if .Values.azureIdentity.namespace -}}
 {{ .Values.azureIdentity.namespace }}
+{{- else -}}
+{{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}
+
+{{- define "aad-pod-identity.mic.namespace" -}}
+{{- if .Values.mic.namespace -}}
+{{ .Values.mic.namespace }}
+{{- else -}}
+{{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}
+
+{{- define "aad-pod-identity.nmi.namespace" -}}
+{{- if .Values.nmi.namespace -}}
+{{ .Values.nmi.namespace }}
 {{- else -}}
 {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/aad-pod-identity/templates/mic-deployment.yaml
+++ b/charts/aad-pod-identity/templates/mic-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}
+  namespace: {{ template "aad-pod-identity.mic.namespace" . }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: mic
@@ -54,13 +55,13 @@ spec:
           {{- end }}
           {{- if .Values.mic.clientQps }}
           - --clientQps={{ .Values.mic.clientQps }}
-          {{- end }}          
+          {{- end }}
           {{- if .Values.mic.immutableUserMSIs }}
           - "--immutable-user-msis={{- join "," .Values.mic.immutableUserMSIs}}"
           {{- end }}
           {{- if .Values.mic.prometheusPort }}
           - --prometheus-port={{ .Values.mic.prometheusPort }}
-          {{- end }}  
+          {{- end }}
         env:
           - name: FORCENAMESPACED
             value: "{{ .Values.forceNameSpaced }}"

--- a/charts/aad-pod-identity/templates/mic-secret.yaml
+++ b/charts/aad-pod-identity/templates/mic-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}
+  namespace: {{ template "aad-pod-identity.mic.namespace" . }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: mic

--- a/charts/aad-pod-identity/templates/mic-serviceaccount.yaml
+++ b/charts/aad-pod-identity/templates/mic-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}
+  namespace: {{ template "aad-pod-identity.mic.namespace" . }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: mic

--- a/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "aad-pod-identity.nmi.fullname" . }}
+  namespace: {{ template "aad-pod-identity.nmi.namespace" . }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: nmi
@@ -63,7 +64,7 @@ spec:
           {{- end }}
           {{- if .Values.nmi.blockInstanceMetadata }}
           - --block-instance-metadata={{ .Values.nmi.blockInstanceMetadata }}
-          {{- end }}  
+          {{- end }}
         env:
           - name: HOST_IP
             valueFrom:
@@ -90,7 +91,7 @@ spec:
             port: {{ .Values.nmi.probePort }}
             {{- else }}
             port: 8080
-            {{- end }}            
+            {{- end }}
           initialDelaySeconds: 10
           periodSeconds: 5
 {{- with .Values.nmi.resources }}

--- a/charts/aad-pod-identity/templates/nmi-serviceaccount.yaml
+++ b/charts/aad-pod-identity/templates/nmi-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aad-pod-identity.nmi.fullname" . }}
+  namespace: {{ template "aad-pod-identity.nmi.namespace" . }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: nmi


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
As per https://github.com/Azure/aad-pod-identity/issues/462 it makes it possible to deploy to a specified namespace without having to use tiller.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://github.com/Azure/aad-pod-identity/issues/462

**Notes for Reviewers**:
