### PR TITLE
Update rules len check for iptables

### DIFF
--- a/pkg/nmi/iptables/iptables.go
+++ b/pkg/nmi/iptables/iptables.go
@@ -80,7 +80,16 @@ func ensureCustomChain(ipt *iptables.IPTables, destIP, destPort, targetip, targe
 			return err
 		}
 	}
-	if len(rules) == 2 {
+
+	/*
+		iptables -t nat -S aad-metadata returns 3 rules
+			-N aad-metadata
+			-A aad-metadata ! -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 10.240.3.134:2579
+			-A aad-metadata -j RETURN
+
+		For this reason we check if the length of rules is 3. If not 3, then we flush and create chain again.
+	*/
+	if len(rules) == 3 {
 		return nil
 	}
 	if err := flushCreateCustomChainrules(ipt, destIP, destPort,
@@ -92,6 +101,7 @@ func ensureCustomChain(ipt *iptables.IPTables, destIP, destPort, targetip, targe
 }
 
 func flushCreateCustomChainrules(ipt *iptables.IPTables, destIP, destPort, targetip, targetport string) error {
+	log.Warn("Flushing iptables to add aad-metadata custom chains")
 	if err := ipt.ClearChain(tablename, customchainname); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Fixes an issues where len of rules returned from `iptables -t nat -S aad-metadata` is 3 instead of 2.

```
root@k8s-agentpool1-24487553-vmss00000Y:/# iptables -t nat -S aad-metadata
-N aad-metadata
-A aad-metadata ! -s 127.0.0.1/32 -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 10.240.3.134:2579
-A aad-metadata -j RETURN
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
