### PR TITLE
remove cluster service label

### DIFF
--- a/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: nmi
-    kubernetes.io/cluster-service: "true"
     tier: node
   annotations:
     description: {{ .Chart.Description }}

--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -94,7 +94,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/cluster-service: "true"
     component: nmi
     tier: node
     k8s-app: aad-pod-id

--- a/deploy/infra/deployment.yaml
+++ b/deploy/infra/deployment.yaml
@@ -52,7 +52,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/cluster-service: "true"
     component: nmi
     tier: node
   name: nmi

--- a/deploy/infra/noazurejson/deployment-rbac.yaml
+++ b/deploy/infra/noazurejson/deployment-rbac.yaml
@@ -94,7 +94,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/cluster-service: "true"
     component: nmi
     tier: node
     k8s-app: aad-pod-id

--- a/deploy/infra/noazurejson/deployment.yaml
+++ b/deploy/infra/noazurejson/deployment.yaml
@@ -52,7 +52,6 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/cluster-service: "true"
     component: nmi
     tier: node
   name: nmi

--- a/deploy/infra/rc/deployment-rbac.yaml
+++ b/deploy/infra/rc/deployment-rbac.yaml
@@ -94,7 +94,6 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/cluster-service: "true"
     component: nmi
     tier: node
     k8s-app: aad-pod-id

--- a/deploy/infra/rc/deployment.yaml
+++ b/deploy/infra/rc/deployment.yaml
@@ -52,7 +52,6 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/cluster-service: "true"
     component: nmi
     tier: node
   name: nmi

--- a/test/e2e/template/deployment-rbac-old.yaml
+++ b/test/e2e/template/deployment-rbac-old.yaml
@@ -78,7 +78,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/cluster-service: "true"
     component: nmi
     tier: node
     k8s-app: aad-pod-id

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -91,7 +91,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    kubernetes.io/cluster-service: "true"
     component: nmi
     tier: node
     k8s-app: aad-pod-id


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Remove `kubernetes.io/cluster-service: "true"` label which is typically used for addons and has been deprecated since 1.11

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
partially resolves https://github.com/Azure/aad-pod-identity/issues/471

**Notes for Reviewers**:
