### PR TITLE
Add selectors as separate include

### DIFF
--- a/charts/aad-pod-identity/templates/_helper.tpl
+++ b/charts/aad-pod-identity/templates/_helper.tpl
@@ -56,11 +56,18 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common selectors.
+*/}}
+{{- define "aad-pod-identity.selectors" -}}
+app.kubernetes.io/name: {{ template "aad-pod-identity.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
 Common labels.
 */}}
 {{- define "aad-pod-identity.labels" -}}
-app.kubernetes.io/name: {{ template "aad-pod-identity.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "aad-pod-identity.selectors" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ template "aad-pod-identity.chart" . }}
 {{- end -}}

--- a/charts/aad-pod-identity/templates/mic-deployment.yaml
+++ b/charts/aad-pod-identity/templates/mic-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: 2
   selector:
     matchLabels:
-      {{- include "aad-pod-identity.labels" . | nindent 6 }}
+      {{- include "aad-pod-identity.selectors" . | nindent 6 }}
       app.kubernetes.io/component: mic
   template:
     metadata:
@@ -54,13 +54,13 @@ spec:
           {{- end }}
           {{- if .Values.mic.clientQps }}
           - --clientQps={{ .Values.mic.clientQps }}
-          {{- end }}          
+          {{- end }}
           {{- if .Values.mic.immutableUserMSIs }}
           - "--immutable-user-msis={{- join "," .Values.mic.immutableUserMSIs}}"
           {{- end }}
           {{- if .Values.mic.prometheusPort }}
           - --prometheus-port={{ .Values.mic.prometheusPort }}
-          {{- end }}  
+          {{- end }}
         env:
           - name: FORCENAMESPACED
             value: "{{ .Values.forceNameSpaced }}"

--- a/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "aad-pod-identity.labels" . | nindent 6 }}
+      {{- include "aad-pod-identity.selectors" . | nindent 6 }}
       app.kubernetes.io/component: nmi
   template:
     metadata:
@@ -62,7 +62,7 @@ spec:
           {{- end }}
           {{- if .Values.nmi.blockInstanceMetadata }}
           - --block-instance-metadata={{ .Values.nmi.blockInstanceMetadata }}
-          {{- end }}  
+          {{- end }}
         env:
           - name: HOST_IP
             valueFrom:
@@ -89,7 +89,7 @@ spec:
             port: {{ .Values.nmi.probePort }}
             {{- else }}
             port: 8080
-            {{- end }}            
+            {{- end }}
           initialDelaySeconds: 10
           periodSeconds: 5
 {{- with .Values.nmi.resources }}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
The helm chart is currently broken when upgrading as it includes the helm chart value in the resource standard labels and these are used in deployment and daemonset `selector`.  Selectors are now immutable.

As suggested by twendt in #502, this separates the variable labels from static ones that are used in selectors.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #502 
Fixes #507

**Notes for Reviewers**:
Users who have already deployed a 1.5.x chart will have to uninstall aad-pod-identity before applying this chart as they will already have the `helm.sh/chart` label in the selectors. This is a one-off requirement and as a permanent forward-fix this PR is good.
