### PR TITLE
set resource identity type explicitly

### DIFF
--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -32,8 +32,9 @@ func checkIfIDInList(idList []string, desiredID string) bool {
 	return false
 }
 
-// getResourceIdentityType returns resource identity type based on current type
-func getResourceIdentityType(identityType compute.ResourceIdentityType) compute.ResourceIdentityType {
+// getUpdatedResourceIdentityType returns the new resource identity type
+// to be set on the VM/VMSS based on current type
+func getUpdatedResourceIdentityType(identityType compute.ResourceIdentityType) compute.ResourceIdentityType {
 	switch identityType {
 	case "", compute.ResourceIdentityTypeNone, compute.ResourceIdentityTypeUserAssigned:
 		return compute.ResourceIdentityTypeUserAssigned

--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -35,9 +35,9 @@ func checkIfIDInList(idList []string, desiredID string) bool {
 // getResourceIdentityType returns resource identity type based on current type
 func getResourceIdentityType(identityType compute.ResourceIdentityType) compute.ResourceIdentityType {
 	switch identityType {
-	case "", compute.ResourceIdentityTypeNone:
+	case "", compute.ResourceIdentityTypeNone, compute.ResourceIdentityTypeUserAssigned:
 		return compute.ResourceIdentityTypeUserAssigned
-	case compute.ResourceIdentityTypeSystemAssigned:
+	case compute.ResourceIdentityTypeSystemAssigned, compute.ResourceIdentityTypeSystemAssignedUserAssigned:
 		return compute.ResourceIdentityTypeSystemAssignedUserAssigned
 	default:
 		return compute.ResourceIdentityTypeNone

--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -2,6 +2,8 @@ package cloudprovider
 
 import (
 	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 )
 
 // IdentityHolder represents a resource that contains an Identity object
@@ -28,4 +30,16 @@ func checkIfIDInList(idList []string, desiredID string) bool {
 		}
 	}
 	return false
+}
+
+// getResourceIdentityType returns resource identity type based on current type
+func getResourceIdentityType(identityType compute.ResourceIdentityType) compute.ResourceIdentityType {
+	switch identityType {
+	case "", compute.ResourceIdentityTypeNone:
+		return compute.ResourceIdentityTypeUserAssigned
+	case compute.ResourceIdentityTypeSystemAssigned:
+		return compute.ResourceIdentityTypeSystemAssignedUserAssigned
+	default:
+		return compute.ResourceIdentityTypeNone
+	}
 }

--- a/pkg/cloudprovider/identity_test.go
+++ b/pkg/cloudprovider/identity_test.go
@@ -18,7 +18,7 @@ func checkIDList(t *testing.T, expect, actual []string) {
 	}
 }
 
-func TestGetResourceIdentityType(t *testing.T) {
+func TestGetUpdatedResourceIdentityType(t *testing.T) {
 	cases := []struct {
 		current  compute.ResourceIdentityType
 		expected compute.ResourceIdentityType
@@ -46,7 +46,7 @@ func TestGetResourceIdentityType(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual := getResourceIdentityType(tc.current)
+		actual := getUpdatedResourceIdentityType(tc.current)
 		if tc.expected != actual {
 			t.Fatalf("expected: %v, got: %v", tc.expected, actual)
 		}

--- a/pkg/cloudprovider/identity_test.go
+++ b/pkg/cloudprovider/identity_test.go
@@ -2,6 +2,8 @@ package cloudprovider
 
 import (
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 )
 
 func checkIDList(t *testing.T, expect, actual []string) {
@@ -12,6 +14,33 @@ func checkIDList(t *testing.T, expect, actual []string) {
 	for i, v := range expect {
 		if actual[i] != v {
 			t.Fatalf("expected entry %d to be %q, got: %s", i, v, actual[i])
+		}
+	}
+}
+
+func TestGetResourceIdentityType(t *testing.T) {
+	cases := []struct {
+		current  compute.ResourceIdentityType
+		expected compute.ResourceIdentityType
+	}{
+		{
+			current:  "",
+			expected: compute.ResourceIdentityTypeUserAssigned,
+		},
+		{
+			current:  compute.ResourceIdentityTypeNone,
+			expected: compute.ResourceIdentityTypeUserAssigned,
+		},
+		{
+			current:  compute.ResourceIdentityTypeSystemAssigned,
+			expected: compute.ResourceIdentityTypeSystemAssignedUserAssigned,
+		},
+	}
+
+	for _, tc := range cases {
+		actual := getResourceIdentityType(tc.current)
+		if tc.expected != actual {
+			t.Fatalf("expected: %v, got: %v", tc.expected, actual)
 		}
 	}
 }

--- a/pkg/cloudprovider/identity_test.go
+++ b/pkg/cloudprovider/identity_test.go
@@ -32,7 +32,15 @@ func TestGetResourceIdentityType(t *testing.T) {
 			expected: compute.ResourceIdentityTypeUserAssigned,
 		},
 		{
+			current:  compute.ResourceIdentityTypeUserAssigned,
+			expected: compute.ResourceIdentityTypeUserAssigned,
+		},
+		{
 			current:  compute.ResourceIdentityTypeSystemAssigned,
+			expected: compute.ResourceIdentityTypeSystemAssignedUserAssigned,
+		},
+		{
+			current:  compute.ResourceIdentityTypeSystemAssignedUserAssigned,
 			expected: compute.ResourceIdentityTypeSystemAssignedUserAssigned,
 		},
 	}

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -177,7 +177,7 @@ func (i *vmIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 		return true
 	}
 
-	i.info.Type = getResourceIdentityType(i.info.Type)
+	i.info.Type = getUpdatedResourceIdentityType(i.info.Type)
 	i.info.UserAssignedIdentities = userAssignedIdentities
 	return len(i.info.UserAssignedIdentities) > 0
 }

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -177,13 +177,8 @@ func (i *vmIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 		return true
 	}
 
-	if i.info.Type == compute.ResourceIdentityTypeSystemAssigned {
-		i.info.Type = compute.ResourceIdentityTypeSystemAssignedUserAssigned
-	}
-	if i.info.Type == compute.ResourceIdentityTypeNone {
-		i.info.Type = compute.ResourceIdentityTypeUserAssigned
-	}
-
+	i.info.Type = getResourceIdentityType(i.info.Type)
 	i.info.UserAssignedIdentities = userAssignedIdentities
+
 	return len(i.info.UserAssignedIdentities) > 0
 }

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -179,6 +179,5 @@ func (i *vmIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 
 	i.info.Type = getResourceIdentityType(i.info.Type)
 	i.info.UserAssignedIdentities = userAssignedIdentities
-
 	return len(i.info.UserAssignedIdentities) > 0
 }

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -181,6 +181,5 @@ func (i *vmssIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 
 	i.info.Type = getResourceIdentityType(i.info.Type)
 	i.info.UserAssignedIdentities = userAssignedIdentities
-
 	return len(i.info.UserAssignedIdentities) > 0
 }

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -179,7 +179,7 @@ func (i *vmssIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 		return true
 	}
 
-	i.info.Type = getResourceIdentityType(i.info.Type)
+	i.info.Type = getUpdatedResourceIdentityType(i.info.Type)
 	i.info.UserAssignedIdentities = userAssignedIdentities
 	return len(i.info.UserAssignedIdentities) > 0
 }

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -179,13 +179,8 @@ func (i *vmssIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 		return true
 	}
 
-	if i.info.Type == compute.ResourceIdentityTypeSystemAssigned {
-		i.info.Type = compute.ResourceIdentityTypeSystemAssignedUserAssigned
-	}
-	if i.info.Type == compute.ResourceIdentityTypeNone {
-		i.info.Type = compute.ResourceIdentityTypeUserAssigned
-	}
-
+	i.info.Type = getResourceIdentityType(i.info.Type)
 	i.info.UserAssignedIdentities = userAssignedIdentities
+
 	return len(i.info.UserAssignedIdentities) > 0
 }


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
In case of VMSS, if no identities exist the RP assumes the identity type to be `UserAssigned` if not explicitly set. This is not the case for VMAS. So this PR explicitly sets the type based on the current resource identity type.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
