### PR TITLE
remove pod name label

### DIFF
--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -723,8 +723,6 @@ func (c *Client) makeAssignedIDs(azID aadpodid.AzureIdentity, azBinding aadpodid
 
 	labels := make(map[string]string)
 	labels["nodename"] = nodeName
-	labels["podnamespace"] = podNameSpace
-	labels["podname"] = podName
 
 	oMeta := v1.ObjectMeta{
 		Name:   c.getAssignedIDName(podName, podNameSpace, azID.Name),


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Removes the `podname` and `podnamespace` label in the `AzureAssignedIdentity` which are redundant (podname and podnamespace already exist in spec). This fixes the issue where pod name is > 63 chars. `metadata.Labels` have a [63 char limit](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) which results in failure while creating `AzureAssignedIdentity` for pod names > 63 chars

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/508

**Notes for Reviewers**:
