### PR TITLE
add finalizer for azure assigned identity

### DIFF
--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -1,6 +1,8 @@
 package crd
 
 import (
+	"testing"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
@@ -101,4 +103,19 @@ func (c *TestCrdClient) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity
 		assignedIDList = append(assignedIDList, *v)
 	}
 	return &assignedIDList, nil
+}
+
+func TestRemoveFinalizer(t *testing.T) {
+	assignedID := aadpodid.AzureAssignedIdentity{
+		ObjectMeta: v1.ObjectMeta{
+			Finalizers: []string{
+				finalizerName,
+			},
+		},
+	}
+
+	RemoveFinalizer(&assignedID.ObjectMeta)
+	if len(assignedID.ObjectMeta.GetFinalizers()) != 0 {
+		t.Fatalf("expected len to be 0, got: %d", len(assignedID.GetObjectMeta().GetFinalizers()))
+	}
 }

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -629,7 +629,7 @@ func (c *Client) getListOfIdsToAssign(addList map[string]aadpodid.AzureAssignedI
 	}
 }
 
-func (c *Client) matchAssignedID(x aadpodid.AzureAssignedIdentity, y aadpodid.AzureAssignedIdentity) (ret bool) {
+func (c *Client) matchAssignedID(x aadpodid.AzureAssignedIdentity, y aadpodid.AzureAssignedIdentity) bool {
 	bindingX := x.Spec.AzureBindingRef
 	bindingY := y.Spec.AzureBindingRef
 
@@ -700,14 +700,10 @@ func (c *Client) getAzureAssignedIDsToDelete(old, new map[string]aadpodid.AzureA
 
 	begin := time.Now()
 	for assignedIDName, oldAssignedID := range old {
-		newAssignedID, exists := new[assignedIDName]
-		idMatch := false
-		if exists {
-			idMatch = c.matchAssignedID(oldAssignedID, newAssignedID)
-		}
+		_, exists := new[assignedIDName]
 		// assigned identity exists in the desired list too which means
 		// it should not be deleted
-		if exists && idMatch {
+		if exists {
 			continue
 		}
 		// We are done checking that this old id is not present in the new

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -679,6 +679,7 @@ func (c *Client) getAzureAssignedIDsToCreate(old, new map[string]aadpodid.AzureA
 		if !idMatch {
 			// We are done checking that this new id is not present in the old
 			// list. So we will add it to the create list.
+			newAssignedID.ObjectMeta = oldAssignedID.ObjectMeta
 			klog.V(5).Infof("ok: %v, Create added: %s", idMatch, assignedIDName)
 			create[assignedIDName] = newAssignedID
 		}

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -677,9 +677,11 @@ func (c *Client) getAzureAssignedIDsToCreate(old, new map[string]aadpodid.AzureA
 			create[assignedIDName] = oldAssignedID
 		}
 		if !idMatch {
-			// We are done checking that this new id is not present in the old
-			// list. So we will add it to the create list.
-			newAssignedID.ObjectMeta = oldAssignedID.ObjectMeta
+			// if the assigned identity exists in the new list but doesn't match the desired, then
+			// we need to update it
+			if exists {
+				newAssignedID.ObjectMeta = oldAssignedID.ObjectMeta
+			}
 			klog.V(5).Infof("ok: %v, Create added: %s", idMatch, assignedIDName)
 			create[assignedIDName] = newAssignedID
 		}

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -447,8 +447,6 @@ func (c *TestCrdClient) RemoveAssignedIdentity(assignedIdentity *internalaadpodi
 	return nil
 }
 
-// This function is not used currently
-// TODO: consider remove
 func (c *TestCrdClient) CreateAssignedIdentity(assignedIdentity *internalaadpodid.AzureAssignedIdentity) error {
 	assignedIdentityToStore := *assignedIdentity //Make a copy to store in the map.
 	c.mu.Lock()
@@ -873,8 +871,7 @@ func TestSimpleMICClient(t *testing.T) {
 	testPass := false
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 
 	if listAssignedIDs != nil {
@@ -901,10 +898,8 @@ func TestSimpleMICClient(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Fatalf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
-
 	if len(*listAssignedIDs) != 0 {
 		t.Fatalf("Assigned id not deleted")
 	}
@@ -929,10 +924,8 @@ func TestSimpleMICClient(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Fatalf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
-
 	if (*listAssignedIDs)[0].Status.Status != aadpodid.AssignedIDCreated {
 		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDCreated, (*listAssignedIDs)[0].Status.Status)
 	}
@@ -1009,11 +1002,8 @@ func TestAddDelMICClient(t *testing.T) {
 	}
 	expectedLen := 2
 	gotLen := len(*listAssignedIDs)
-
-	//One id should be left around. Rest should be removed
 	if gotLen != expectedLen {
-		klog.Errorf("Expected len: %d. Got: %d", expectedLen, gotLen)
-		t.Fatalf("Add and delete id at same time mismatch")
+		t.Fatalf("expected len: %d. Got: %d", expectedLen, gotLen)
 	}
 
 	// Delete the pod
@@ -1039,22 +1029,18 @@ func TestAddDelMICClient(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Fatalf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 
 	expectedLen = 1
 	gotLen = len(*listAssignedIDs)
-	//One id should be left around. Rest should be removed
 	if gotLen != expectedLen {
-		klog.Errorf("Expected len: %d. Got: %d", expectedLen, gotLen)
-		t.Fatalf("Add and delete id at same time mismatch")
+		t.Fatalf("expected len: %d. Got: %d", expectedLen, gotLen)
 	} else {
 		gotID := (*listAssignedIDs)[0].Name
 		expectedID := "test-pod3-default-test-id3"
 		if gotID != expectedID {
-			klog.Errorf("Expected %s. Got: %s", expectedID, gotID)
-			t.Fatalf("Add and delete id at same time. Found wrong id")
+			t.Fatalf("expected %s. Got: %s", expectedID, gotID)
 		}
 	}
 }
@@ -1102,8 +1088,7 @@ func TestMicAddDelVMSS(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 3) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 3, len(*listAssignedIDs))
@@ -1124,8 +1109,7 @@ func TestMicAddDelVMSS(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 2) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 2, len(*listAssignedIDs))
@@ -1147,8 +1131,7 @@ func TestMicAddDelVMSS(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
@@ -1190,8 +1173,7 @@ func TestMICStateFlow(t *testing.T) {
 
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
@@ -1217,8 +1199,7 @@ func TestMICStateFlow(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
@@ -1244,8 +1225,7 @@ func TestMICStateFlow(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 2) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 2, len(*listAssignedIDs))
@@ -1272,8 +1252,7 @@ func TestMICStateFlow(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 0) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 0, len(*listAssignedIDs))
@@ -1306,8 +1285,7 @@ func TestForceNamespaced(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
@@ -1330,8 +1308,7 @@ func TestForceNamespaced(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 2) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
@@ -1376,8 +1353,7 @@ func TestSyncRetryLoop(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
@@ -1402,8 +1378,7 @@ func TestSyncRetryLoop(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))
@@ -1419,8 +1394,7 @@ func TestSyncRetryLoop(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 0) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 0, len(*listAssignedIDs))
@@ -1457,8 +1431,7 @@ func TestSyncNodeNotFound(t *testing.T) {
 
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 10) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 10, len(*listAssignedIDs))
@@ -1486,8 +1459,7 @@ func TestSyncNodeNotFound(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 6) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 6, len(*listAssignedIDs))
@@ -1529,8 +1501,7 @@ func TestProcessingTimeForScale(t *testing.T) {
 
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 20000) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 20000, len(*listAssignedIDs))
@@ -1546,8 +1517,7 @@ func TestProcessingTimeForScale(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 10000) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 10000, len(*listAssignedIDs))
@@ -1616,8 +1586,7 @@ func TestMicAddDelVMSSwithImmutableIdentities(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 3) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 3, len(*listAssignedIDs))
@@ -1638,8 +1607,7 @@ func TestMicAddDelVMSSwithImmutableIdentities(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 2) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 2, len(*listAssignedIDs))
@@ -1661,8 +1629,7 @@ func TestMicAddDelVMSSwithImmutableIdentities(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Error(err)
-		t.Errorf("list assigned failed")
+		t.Fatalf("list assigned failed, err: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 1) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 1, len(*listAssignedIDs))


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Add finalizer to prevent manual deletion of `AzureAssignedIdentity` before the identities are removed from underlying vm/vmss.
- `PUT` first to update existing `AzureAssignedIdentity`. If not exists, then `POST`.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/533, fixes https://github.com/Azure/aad-pod-identity/issues/504

**Notes for Reviewers**:
