### PR TITLE
Update README.msi.md

### DIFF
--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -48,6 +48,10 @@ Now to ensure that the operations are allowed on individual identity, perform th
 ```bash
 az role assignment create --role "Managed Identity Operator" --assignee <principal id from above command>  --scope /subscriptions/<subscription id>/resourcegroups/<resource group name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity name>
 ```
+Note: If the VNET is located outside of the AKS resource group, the following command will need to be run on the VNET resource group as well.
+```bash
+az role assignment create --role "Virtual Machine Contributor" --assignee <principal id from above command>  --scope /subscriptions/<sub id>/resourcegroups/<resource group name>
+```
 
 
 ## Authentication method

--- a/docs/readmes/README.msi.md
+++ b/docs/readmes/README.msi.md
@@ -52,7 +52,9 @@ Note: If the VNET is located outside of the AKS resource group, the following co
 ```bash
 az role assignment create --role "Virtual Machine Contributor" --assignee <principal id from above command>  --scope /subscriptions/<sub id>/resourcegroups/<resource group name>
 ```
+Optionally, it is possible to grant the managed identity additional role permissions using a custom role as documented below:
 
+https://docs.microsoft.com/en-us/azure/aks/kubernetes-service-principal#networking
 
 ## Authentication method
 In case the azure.json is used, the following keys indicates whether the cluster is configured with system assigned or user assigned identity:


### PR DESCRIPTION
Added a note to ensure that the user assigned identity is also granted the VM Contributor role due to the following error:

Updating msis on node aks-cyclecloud-22900616-vmss, add [1], del [0] failed with error compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure sending request: StatusCode=403 -- Original Error: Code="LinkedAuthorizationFailed" Message="The client 'd101b0e0-f10e-4e17-996f-b7c7cb70c6d9' with object id 'd101b0e0-f10e-4e17-996f-b7c7cb70c6d9' has permission to perform action 'Microsoft.Compute/virtualMachineScaleSets/write' on scope '/subscriptions/72b61f0d-9bea-401f-ba03-2053af77b5e7/resourceGroups/dapolina-aks-s1-nodes/providers/Microsoft.Compute/virtualMachineScaleSets/aks-cyclecloud-22900616-vmss'; however, it does not have permission to perform action 'Microsoft.Network/virtualNetworks/subnets/join/action' on the linked scope(s) '/subscriptions/72b61f0d-9bea-401f-ba03-2053af77b5e7/resourceGroups/AzureHubVNET/providers/Microsoft.Network/virtualNetworks/AzureEUS2VNET1/subnets/AKS-SN2' or the linked scope(s) are invalid."

<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/511

**Notes for Reviewers**:
