### PR TITLE
fix updating assigned identity when azure identity updated

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -191,7 +191,7 @@ func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs [
 	requiresUpdate := info.SetUserIdentities(ids)
 
 	if requiresUpdate {
-		klog.Infof("Updating user assigned MSIs on %s", name)
+		klog.Infof("Updating user assigned MSIs on %s, assign [%d], unassign [%d]", name, len(addUserAssignedMSIIDs), len(removeUserAssignedMSIIDs))
 		timeStarted := time.Now()
 		if err := updateFunc(); err != nil {
 			return err

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -144,7 +144,7 @@ func (i *vmIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 
 	nodeList := make(map[string]bool)
 	// add all current existing ids
-	for id, _ := range i.info.UserAssignedIdentities {
+	for id := range i.info.UserAssignedIdentities {
 		nodeList[id] = true
 	}
 

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -146,7 +146,7 @@ func (i *vmssIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 
 	nodeList := make(map[string]bool)
 	// add all current existing ids
-	for id, _ := range i.info.UserAssignedIdentities {
+	for id := range i.info.UserAssignedIdentities {
 		nodeList[id] = true
 	}
 

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -41,6 +41,7 @@ type ClientInt interface {
 	SyncCacheAll(exit <-chan struct{}, initial bool)
 	RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) error
 	CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) error
+	UpdateAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) error
 	UpdateAzureAssignedIdentityStatus(assignedIdentity *aadpodid.AzureAssignedIdentity, status string) error
 	UpgradeAll() error
 	ListBindings() (res *[]aadpodid.AzureIdentityBinding, err error)
@@ -515,6 +516,32 @@ func (c *Client) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 	}
 
 	klog.V(5).Infof("Time take to create %s: %v", assignedIdentity.Name, time.Since(begin))
+	stats.Update(stats.AssignedIDAdd, time.Since(begin))
+	return nil
+}
+
+func (c *Client) UpdateAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) (err error) {
+	klog.Infof("Got assigned id %s/%s to update", assignedIdentity.Namespace, assignedIdentity.Name)
+	begin := time.Now()
+
+	defer func() {
+		if err != nil {
+			c.reporter.ReportKubernetesAPIOperationError(metrics.AssignedIdentityAdditionOperationName)
+			return
+		}
+		c.reporter.Report(
+			metrics.AssignedIdentityAdditionCountM.M(1),
+			metrics.AssignedIdentityAdditionDurationM.M(metrics.SinceInSeconds(begin)))
+
+	}()
+
+	v1AssignedID := aadpodv1.ConvertInternalAssignedIdentityToV1AssignedIdentity(*assignedIdentity)
+	err = c.rest.Put().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Name(assignedIdentity.Name).Body(&v1AssignedID).Do().Error()
+	if err != nil {
+		return fmt.Errorf("failed to update assigned identity: %v", err)
+	}
+
+	klog.V(5).Infof("Time take to update %s/%s: %v", assignedIdentity.Namespace, assignedIdentity.Name, time.Since(begin))
 	stats.Update(stats.AssignedIDAdd, time.Since(begin))
 	return nil
 }

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -526,12 +526,12 @@ func (c *Client) UpdateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 
 	defer func() {
 		if err != nil {
-			c.reporter.ReportKubernetesAPIOperationError(metrics.AssignedIdentityAdditionOperationName)
+			c.reporter.ReportKubernetesAPIOperationError(metrics.AssignedIdentityUpdateOperationName)
 			return
 		}
 		c.reporter.Report(
-			metrics.AssignedIdentityAdditionCountM.M(1),
-			metrics.AssignedIdentityAdditionDurationM.M(metrics.SinceInSeconds(begin)))
+			metrics.AssignedIdentityUpdateCountM.M(1),
+			metrics.AssignedIdentityUpdateDurationM.M(metrics.SinceInSeconds(begin)))
 
 	}()
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -18,6 +18,8 @@ const (
 	assignedIdentityAdditionCountName      = "assigned_identity_addition_count"
 	assignedIdentityDeletionDurationName   = "assigned_identity_deletion_duration_seconds"
 	assignedIdentityDeletionCountName      = "assigned_identity_deletion_count"
+	assignedIdentityUpdateDurationName     = "assigned_identity_update_duration_seconds"
+	assignedIdentityUpdateCountName        = "assigned_identity_update_count"
 	nmiOperationsDurationName              = "nmi_operations_duration_seconds"
 	micCycleDurationName                   = "mic_cycle_duration_seconds"
 	micCycleCountName                      = "mic_cycle_count"
@@ -46,6 +48,8 @@ const (
 	AssignedIdentityDeletionOperationName = "assigned_identity_deletion"
 	// AssignedIdentityAdditionOperationName ...
 	AssignedIdentityAdditionOperationName = "assigned_identity_addition"
+	// AssignedIdentityUpdateOperationName ...
+	AssignedIdentityUpdateOperationName = "assigned_identity_update"
 	// UpdateAzureAssignedIdentityStatusOperationName ...
 	UpdateAzureAssignedIdentityStatusOperationName = "update_azure_assigned_identity_status"
 	// GetPodListOperationName
@@ -132,6 +136,18 @@ var (
 		imdsOperationsDurationName,
 		"Duration in seconds of imds token operations",
 		stats.UnitMilliseconds)
+
+	// AssignedIdentityUpdateDurationM is a measure that tracks the duration in seconds of assigned_identity_update operations.
+	AssignedIdentityUpdateDurationM = stats.Float64(
+		assignedIdentityUpdateDurationName,
+		"Duration in seconds of assigned identity update operations",
+		stats.UnitMilliseconds)
+
+	// AssignedIdentityUpdateCountM is a measure that tracks the cumulative number of assigned identity update operations.
+	AssignedIdentityUpdateCountM = stats.Int64(
+		assignedIdentityUpdateCountName,
+		"Total number of assigned identity update operations",
+		stats.UnitDimensionless)
 )
 
 var (
@@ -221,6 +237,16 @@ func registerViews() error {
 			Measure:     ImdsOperationsDurationM,
 			Aggregation: view.Distribution(0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 4, 5, 10),
 			TagKeys:     []tag.Key{operationTypeKey},
+		},
+		&view.View{
+			Description: AssignedIdentityUpdateDurationM.Description(),
+			Measure:     AssignedIdentityUpdateDurationM,
+			Aggregation: view.Distribution(0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 4, 5, 10),
+		},
+		&view.View{
+			Description: AssignedIdentityUpdateCountM.Description(),
+			Measure:     AssignedIdentityUpdateCountM,
+			Aggregation: view.Count(),
 		},
 	}
 	err := view.Register(views...)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -16,6 +16,7 @@ func TestBasicAndDurationReport(t *testing.T) {
 
 	testCounterMetric(t, reporter, AssignedIdentityAdditionCountM)
 	testCounterMetric(t, reporter, AssignedIdentityDeletionCountM)
+	testCounterMetric(t, reporter, AssignedIdentityUpdateCountM)
 	testCounterMetric(t, reporter, MICCycleCountM)
 	testCounterMetric(t, reporter, MICNewLeaderElectionCountM)
 	testCounterMetric(t, reporter, CloudProviderOperationsErrorsCountM)

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -436,7 +436,7 @@ func (c *Client) Sync(exit <-chan struct{}) {
 		// for each node or vmss
 		nodeMap := make(map[string]trackUserAssignedMSIIds)
 
-		// seperate the add and delete list per node
+		// separate the add, delete and update list per node
 		c.convertAssignedIDListToMap(addList, deleteList, afterUpdateList, nodeMap)
 
 		// process the delete and add list
@@ -1009,7 +1009,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	for _, updateID := range nodeTrackList.assignedIDsToUpdate {
 		if err := semCreateOrUpdate.Acquire(ctx, 1); err != nil {
-			klog.Errorf("Failed to acquire semaphore in the create loop: %v", err)
+			klog.Errorf("Failed to acquire semaphore in the update loop: %v", err)
 			return
 		}
 		go func(assignedID aadpodid.AzureAssignedIdentity) {

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -29,6 +29,7 @@ const (
 	TotalPutCalls           StatsType = "Number of cloud provider PUT"
 	TotalGetCalls           StatsType = "Number of cloud provider GET"
 	TotalAssignedIDsCreated StatsType = "Number of assigned ids created in this sync cycle"
+	TotalAssignedIDsUpdated StatsType = "Number of assigned ids updated in this sync cycle"
 	TotalAssignedIDsDeleted StatsType = "Number of assigned ids deleted in this sync cycle"
 	K8sGet                  StatsType = "K8s get"
 	K8sPut                  StatsType = "K8s put"
@@ -114,6 +115,7 @@ func PrintSync() {
 		PrintCount(TotalGetCalls)
 
 		PrintCount(TotalAssignedIDsCreated)
+		PrintCount(TotalAssignedIDsUpdated)
 		PrintCount(TotalAssignedIDsDeleted)
 
 		Print(FindAssignedIDCreate)

--- a/test/common/k8s/azureidentity/azureidentity.go
+++ b/test/common/k8s/azureidentity/azureidentity.go
@@ -18,17 +18,17 @@ import (
 
 // CreateOnClusterOld will create an Azure Identity on a Kubernetes cluster
 func CreateOnClusterOld(subscriptionID, resourceGroup, name, templateOutputPath string) error {
-	return CreateOnClusterInternal(subscriptionID, resourceGroup, name, "aadpodidentity-old.yaml", templateOutputPath)
+	return CreateOnClusterInternal(subscriptionID, resourceGroup, name, name, "aadpodidentity-old.yaml", templateOutputPath)
 }
 
 // CreateOnCluster will create an Azure Identity on a Kubernetes cluster
-func CreateOnCluster(subscriptionID, resourceGroup, name, templateOutputPath string) error {
-	return CreateOnClusterInternal(subscriptionID, resourceGroup, name, "aadpodidentity.yaml", templateOutputPath)
+func CreateOnCluster(subscriptionID, resourceGroup, identity, name, templateOutputPath string) error {
+	return CreateOnClusterInternal(subscriptionID, resourceGroup, identity, name, "aadpodidentity.yaml", templateOutputPath)
 }
 
 // CreateOnClusterInternal will create an Azure Identity on a Kubernetes cluster
-func CreateOnClusterInternal(subscriptionID, resourceGroup, name, templateInputFile, templateOutputPath string) error {
-	clientID, err := GetClientID(resourceGroup, name)
+func CreateOnClusterInternal(subscriptionID, resourceGroup, identity, name, templateInputFile, templateOutputPath string) error {
+	clientID, err := GetClientID(resourceGroup, identity)
 	if err != nil {
 		return err
 	}
@@ -51,11 +51,13 @@ func CreateOnClusterInternal(subscriptionID, resourceGroup, name, templateInputF
 		ResourceGroup  string
 		ClientID       string
 		Name           string
+		Identity       string
 	}{
 		subscriptionID,
 		resourceGroup,
 		clientID,
 		name,
+		identity,
 	}
 	if err := t.Execute(deployFile, deployData); err != nil {
 		return errors.Wrap(err, "Failed to create a deployment file from aadpodidentity.yaml")

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
 		Expect(err).NotTo(HaveOccurred())
 
-		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
 	})
 
 	It("should not pass the identity validating test if the AzureIdentity is deleted", func() {
@@ -226,7 +226,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Make sure the AzureAssignedIdentity is updated along with the new pod
-		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
 
 		node.Uncordon(nodeName)
 	})
@@ -256,7 +256,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 			azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidatorName)
 			Expect(err).NotTo(HaveOccurred())
 
-			validateAzureAssignedIdentity(azureAssignedIdentity, identityName)
+			validateAzureAssignedIdentity(azureAssignedIdentity, identityName, identityName)
 
 			testData[i] = struct {
 				identityName          string
@@ -293,7 +293,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 
 			// Make sure that the existing identities are still functioning
 			for j := i + 1; j < 5; j++ {
-				validateAzureAssignedIdentity(testData[j].azureAssignedIdentity, testData[j].identityName)
+				validateAzureAssignedIdentity(testData[j].azureAssignedIdentity, testData[j].identityName, testData[j].identityName)
 			}
 		}
 	})
@@ -342,7 +342,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 
 		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
 		Expect(err).NotTo(HaveOccurred())
-		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
 
 		// Delete pod identity to verify that the VM identity did not get deleted
 		waitForDeployDeletion(identityValidator)
@@ -430,7 +430,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 
 		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
 		Expect(err).NotTo(HaveOccurred())
-		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
 
 		waitForDeployDeletion(identityValidator)
 		ok, err := azureassignedidentity.WaitOnLengthMatched(0, false)
@@ -472,7 +472,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, azureAssignedIdentity := range azureAssignedIdentities {
-				validateAzureAssignedIdentity(azureAssignedIdentity, identityName)
+				validateAzureAssignedIdentity(azureAssignedIdentity, identityName, identityName)
 			}
 		}
 	})
@@ -523,7 +523,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
 		Expect(err).NotTo(HaveOccurred())
 
-		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
 	})
 
 	It("should not delete an in use identity from a vmss", func() {
@@ -603,7 +603,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Ensure that the identity validator is able to get the token
-		validateAzureAssignedIdentity(azureAssignedIdentity, immutableIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, immutableIdentity, immutableIdentity)
 
 		waitForDeployDeletion(identityValidator)
 
@@ -753,7 +753,8 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 
 		setUpIdentityAndDeployment(keyvaultIdentity, "", "1")
 
-		err := azureidentity.CreateOnCluster(cfg.SubscriptionID, cfg.ResourceGroup, fmt.Sprintf("%s-%d", keyvaultIdentity, 5), templateOutputPath)
+		azureIdentity := fmt.Sprintf("%s-%d", keyvaultIdentity, 5)
+		err := azureidentity.CreateOnCluster(cfg.SubscriptionID, cfg.ResourceGroup, azureIdentity, azureIdentity, templateOutputPath)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = azureidentitybinding.Create(fmt.Sprintf("%s-%d", keyvaultIdentity, 5), keyvaultIdentity, templateOutputPath)
@@ -790,7 +791,7 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
 		Expect(err).NotTo(HaveOccurred())
 
-		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
 
 		nodeList, err := node.GetAll()
 		Expect(err).NotTo(HaveOccurred())
@@ -842,11 +843,10 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
 		Expect(err).NotTo(HaveOccurred())
 
-		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
 	})
 
 	It("should pass the identity format validation with gatekeeper constraint", func() {
-
 		// setup the required infra
 		setupIdentityFormatValidationInfra()
 
@@ -866,6 +866,31 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		output, err = cmd.CombinedOutput()
 		fmt.Printf("%s", output)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should assign new identity and remove old when AzureIdentity updated", func() {
+		setUpIdentityAndDeployment(keyvaultIdentity, "", "1")
+		ok, err := azureassignedidentity.WaitOnLengthMatched(1, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
+		Expect(err).NotTo(HaveOccurred())
+
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
+
+		identity := fmt.Sprintf("%s-%d", keyvaultIdentity, 0)
+		err = azureidentity.CreateOnCluster(cfg.SubscriptionID, cfg.ResourceGroup, identity, keyvaultIdentity, templateOutputPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		ok, err = azureassignedidentity.WaitOnLengthMatched(1, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		azureAssignedIdentity, err = azureassignedidentity.GetByPrefix(identityValidator)
+		Expect(err).NotTo(HaveOccurred())
+
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, identity)
 	})
 })
 
@@ -925,7 +950,7 @@ func runValidatorTest(iterations int) {
 
 		azureAssignedIdentity, err := azureassignedidentity.GetByPrefix(identityValidator)
 		Expect(err).NotTo(HaveOccurred())
-		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity)
+		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, keyvaultIdentity)
 
 		deleteAllIdentityValidator()
 
@@ -1151,7 +1176,7 @@ func setUpIdentityAndDeploymentInternal(azureIdentityName, suffix, replicas stri
 	if old {
 		err = azureidentity.CreateOnClusterOld(cfg.SubscriptionID, cfg.ResourceGroup, azureIdentityName, templateOutputPath)
 	} else {
-		err = azureidentity.CreateOnCluster(cfg.SubscriptionID, cfg.ResourceGroup, azureIdentityName, templateOutputPath)
+		err = azureidentity.CreateOnCluster(cfg.SubscriptionID, cfg.ResourceGroup, azureIdentityName, azureIdentityName, templateOutputPath)
 	}
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1190,7 +1215,7 @@ func setUpIdentityAndDeploymentInternal(azureIdentityName, suffix, replicas stri
 }
 
 // validateAzureAssignedIdentity will make sure a given AzureAssignedIdentity has the correct properties
-func validateAzureAssignedIdentity(azureAssignedIdentity aadpodid.AzureAssignedIdentity, identityName string) {
+func validateAzureAssignedIdentity(azureAssignedIdentity aadpodid.AzureAssignedIdentity, identityName, identity string) {
 	identityClientID := azureAssignedIdentity.Spec.AzureIdentityRef.Spec.ClientID
 	Expect(identityClientID).NotTo(Equal(""))
 	podName := azureAssignedIdentity.Spec.Pod
@@ -1209,7 +1234,7 @@ func validateAzureAssignedIdentity(azureAssignedIdentity aadpodid.AzureAssignedI
 	Expect(azureAssignedIdentity.Spec.AzureIdentityRef.ObjectMeta.Name).To(Equal(identityName))
 	Expect(azureAssignedIdentity.Spec.AzureIdentityRef.ObjectMeta.Namespace).To(Equal("default"))
 
-	if strings.HasPrefix(identityName, clusterIdentity) {
+	if strings.HasPrefix(identity, clusterIdentity) {
 		cmdOutput, err := validateClusterWideUserAssignedIdentity(podName, identityClientID)
 		Expect(errors.Wrap(err, string(cmdOutput))).NotTo(HaveOccurred())
 	} else {
@@ -1218,7 +1243,7 @@ func validateAzureAssignedIdentity(azureAssignedIdentity aadpodid.AzureAssignedI
 		Expect(errors.Wrap(err, string(cmdOutput))).NotTo(HaveOccurred())
 	}
 
-	fmt.Printf("# %s validated!\n", identityName)
+	fmt.Printf("# %s validated!\n", identity)
 }
 
 // waitForDeployDeletion will block until a give deploy and its pods are completed deleted

--- a/test/e2e/template/aadpodidentity.yaml
+++ b/test/e2e/template/aadpodidentity.yaml
@@ -4,5 +4,5 @@ metadata:
   name: {{.Name}}
 spec:
   type: 0
-  resourceID: /subscriptions/{{.SubscriptionID}}/resourceGroups/{{.ResourceGroup}}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{.Name}}
+  resourceID: /subscriptions/{{.SubscriptionID}}/resourceGroups/{{.ResourceGroup}}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{{.Identity}}
   clientID: {{.ClientID}}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Adds code path to update azure assigned identity when azure identity is updated in place
- Ensures old identity is deleted and new updated identity is assigned
- Adds e2e test to test update path

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/510, fixes https://github.com/Azure/aad-pod-identity/issues/504

**Notes for Reviewers**:
