### PR TITLE
feat: re-initialize MIC cloud client when cloud config is updated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.2.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/coreos/go-iptables v0.3.0
-	github.com/fsnotify/fsnotify v1.4.7
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/googleapis/gnostic v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.2.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/coreos/go-iptables v0.3.0
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/googleapis/gnostic v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -257,6 +259,8 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd h1:r7DufRZuZbWB7j439YfAzP8RP
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -42,11 +42,9 @@ func NewCloudProvider(configFile string) (c *Client, e error) {
 	client := &Client{
 		configFile: configFile,
 	}
-
 	if err := client.Init(); err != nil {
 		return nil, err
 	}
-
 	return client, nil
 }
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -27,113 +27,23 @@ type Client struct {
 	VMSSClient VMSSClientInt
 	ExtClient  compute.VirtualMachineExtensionsClient
 	Config     config.AzureConfig
+	configFile string
 }
 
 // ClientInt client interface
 type ClientInt interface {
 	UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs []string, name string, isvmss bool) error
 	GetUserMSIs(name string, isvmss bool) ([]string, error)
+	Init() error
 }
 
 // NewCloudProvider returns a azure cloud provider client
 func NewCloudProvider(configFile string) (c *Client, e error) {
-	azureConfig := config.AzureConfig{}
-	if configFile != "" {
-		klog.V(6).Info("Populate AzureConfig from azure.json")
-		bytes, err := ioutil.ReadFile(configFile)
-		if err != nil {
-			klog.Errorf("Read file (%s) error: %+v", configFile, err)
-			return nil, err
-		}
-		if err = yaml.Unmarshal(bytes, &azureConfig); err != nil {
-			klog.Errorf("Unmarshall error: %v", err)
-			return nil, err
-		}
-	} else {
-		klog.V(6).Info("Populate AzureConfig from secret/environment variables")
-		azureConfig.Cloud = os.Getenv("CLOUD")
-		azureConfig.TenantID = os.Getenv("TENANT_ID")
-		azureConfig.ClientID = os.Getenv("CLIENT_ID")
-		azureConfig.ClientSecret = os.Getenv("CLIENT_SECRET")
-		azureConfig.SubscriptionID = os.Getenv("SUBSCRIPTION_ID")
-		azureConfig.ResourceGroupName = os.Getenv("RESOURCE_GROUP")
-		azureConfig.VMType = os.Getenv("VM_TYPE")
-		azureConfig.UseManagedIdentityExtension = strings.EqualFold(os.Getenv("USE_MSI"), "True")
-		azureConfig.UserAssignedIdentityID = os.Getenv("USER_ASSIGNED_MSI_CLIENT_ID")
-	}
-
-	azureEnv, err := azure.EnvironmentFromName(azureConfig.Cloud)
-	if err != nil {
-		klog.Errorf("Get cloud env error: %+v", err)
-		return nil, err
-	}
-
-	err = adal.AddToUserAgent(version.GetUserAgent("MIC", version.MICVersion))
-	if err != nil {
-		return nil, err
-	}
-
-	oauthConfig, err := adal.NewOAuthConfig(azureEnv.ActiveDirectoryEndpoint, azureConfig.TenantID)
-	if err != nil {
-		klog.Errorf("Create OAuth config error: %+v", err)
-		return nil, err
-	}
-
-	var spt *adal.ServicePrincipalToken
-	if azureConfig.UseManagedIdentityExtension {
-		// MSI endpoint is required for both types of MSI - system assigned and user assigned.
-		msiEndpoint, err := adal.GetMSIVMEndpoint()
-		if err != nil {
-			klog.Errorf("Failed to get MSI endpoint. Error: %+v", err)
-			return nil, err
-		}
-		// UserAssignedIdentityID is empty, so we are going to use system assigned MSI
-		if azureConfig.UserAssignedIdentityID == "" {
-			klog.Infof("MIC using system assigned identity for authentication.")
-			spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, azureEnv.ResourceManagerEndpoint)
-			if err != nil {
-				klog.Errorf("Get token from system assigned MSI error: %+v", err)
-				return nil, err
-			}
-		} else { // User assigned identity usage.
-			klog.Infof("MIC using user assigned identity: %s for authentication.", utils.RedactClientID(azureConfig.UserAssignedIdentityID))
-			spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, azureEnv.ResourceManagerEndpoint, azureConfig.UserAssignedIdentityID)
-			if err != nil {
-				klog.Errorf("Get token from user assigned MSI error: %+v", err)
-				return nil, err
-			}
-		}
-	} else { // This is the default scenario - use service principal to get the token.
-		spt, err = adal.NewServicePrincipalToken(
-			*oauthConfig,
-			azureConfig.ClientID,
-			azureConfig.ClientSecret,
-			azureEnv.ResourceManagerEndpoint,
-		)
-		if err != nil {
-			klog.Errorf("Get service principal token error: %+v", err)
-			return nil, err
-		}
-	}
-
-	extClient := compute.NewVirtualMachineExtensionsClient(azureConfig.SubscriptionID)
-	extClient.BaseURI = azure.PublicCloud.ResourceManagerEndpoint
-	extClient.Authorizer = autorest.NewBearerAuthorizer(spt)
-	extClient.PollingDelay = 5 * time.Second
-
 	client := &Client{
-		Config:    azureConfig,
-		ExtClient: extClient,
+		configFile: configFile,
 	}
 
-	client.VMSSClient, err = NewVMSSClient(azureConfig, spt)
-	if err != nil {
-		klog.Errorf("Create VMSS Client error: %+v", err)
-		return nil, err
-	}
-	client.VMClient, err = NewVirtualMachinesClient(azureConfig, spt)
-	if err != nil {
-		klog.Errorf("Create VM Client error: %+v", err)
+	if err := client.Init(); err != nil {
 		return nil, err
 	}
 
@@ -148,6 +58,108 @@ func withInspection() autorest.PrepareDecorator {
 			return p.Prepare(r)
 		})
 	}
+}
+
+// Init initializes the cloud provider client based
+// on a config path or environment variables
+func (c *Client) Init() error {
+	c.Config = config.AzureConfig{}
+	if c.configFile != "" {
+		klog.V(6).Info("Populate AzureConfig from azure.json")
+		bytes, err := ioutil.ReadFile(c.configFile)
+		if err != nil {
+			klog.Errorf("Read file (%s) error: %+v", c.configFile, err)
+			return err
+		}
+		if err = yaml.Unmarshal(bytes, &c.Config); err != nil {
+			klog.Errorf("Unmarshall error: %v", err)
+			return err
+		}
+	} else {
+		klog.V(6).Info("Populate AzureConfig from secret/environment variables")
+		c.Config.Cloud = os.Getenv("CLOUD")
+		c.Config.TenantID = os.Getenv("TENANT_ID")
+		c.Config.ClientID = os.Getenv("CLIENT_ID")
+		c.Config.ClientSecret = os.Getenv("CLIENT_SECRET")
+		c.Config.SubscriptionID = os.Getenv("SUBSCRIPTION_ID")
+		c.Config.ResourceGroupName = os.Getenv("RESOURCE_GROUP")
+		c.Config.VMType = os.Getenv("VM_TYPE")
+		c.Config.UseManagedIdentityExtension = strings.EqualFold(os.Getenv("USE_MSI"), "True")
+		c.Config.UserAssignedIdentityID = os.Getenv("USER_ASSIGNED_MSI_CLIENT_ID")
+	}
+
+	azureEnv, err := azure.EnvironmentFromName(c.Config.Cloud)
+	if err != nil {
+		klog.Errorf("Get cloud env error: %+v", err)
+		return err
+	}
+
+	err = adal.AddToUserAgent(version.GetUserAgent("MIC", version.MICVersion))
+	if err != nil {
+		klog.Errorf("add to user agent error: %+v", err)
+		return err
+	}
+
+	oauthConfig, err := adal.NewOAuthConfig(azureEnv.ActiveDirectoryEndpoint, c.Config.TenantID)
+	if err != nil {
+		klog.Errorf("Create OAuth config error: %+v", err)
+		return err
+	}
+
+	var spt *adal.ServicePrincipalToken
+	if c.Config.UseManagedIdentityExtension {
+		// MSI endpoint is required for both types of MSI - system assigned and user assigned.
+		msiEndpoint, err := adal.GetMSIVMEndpoint()
+		if err != nil {
+			klog.Errorf("Failed to get MSI endpoint. Error: %+v", err)
+			return err
+		}
+		// UserAssignedIdentityID is empty, so we are going to use system assigned MSI
+		if c.Config.UserAssignedIdentityID == "" {
+			klog.Infof("MIC using system assigned identity for authentication.")
+			spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, azureEnv.ResourceManagerEndpoint)
+			if err != nil {
+				klog.Errorf("Get token from system assigned MSI error: %+v", err)
+				return err
+			}
+		} else { // User assigned identity usage.
+			klog.Infof("MIC using user assigned identity: %s for authentication.", utils.RedactClientID(c.Config.UserAssignedIdentityID))
+			spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, azureEnv.ResourceManagerEndpoint, c.Config.UserAssignedIdentityID)
+			if err != nil {
+				klog.Errorf("Get token from user assigned MSI error: %+v", err)
+				return err
+			}
+		}
+	} else { // This is the default scenario - use service principal to get the token.
+		spt, err = adal.NewServicePrincipalToken(
+			*oauthConfig,
+			c.Config.ClientID,
+			c.Config.ClientSecret,
+			azureEnv.ResourceManagerEndpoint,
+		)
+		if err != nil {
+			klog.Errorf("Get service principal token error: %+v", err)
+			return err
+		}
+	}
+
+	extClient := compute.NewVirtualMachineExtensionsClient(c.Config.SubscriptionID)
+	extClient.BaseURI = azure.PublicCloud.ResourceManagerEndpoint
+	extClient.Authorizer = autorest.NewBearerAuthorizer(spt)
+	extClient.PollingDelay = 5 * time.Second
+
+	c.VMSSClient, err = NewVMSSClient(c.Config, spt)
+	if err != nil {
+		klog.Errorf("Create VMSS Client error: %+v", err)
+		return err
+	}
+	c.VMClient, err = NewVirtualMachinesClient(c.Config, spt)
+	if err != nil {
+		klog.Errorf("Create VM Client error: %+v", err)
+		return err
+	}
+
+	return nil
 }
 
 // GetUserMSIs will return a list of all identities on the node or vmss based on value of isvmss

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -1,0 +1,69 @@
+package filewatcher
+
+import (
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/klog"
+)
+
+// EventHandler is called when a fsnotify event occurs.
+type EventHandler func(fsnotify.Event)
+
+// ErrorHandler is called when a fsnotify error occurs.
+type ErrorHandler func(error)
+
+// ClientInt is a file watcher abstraction based on fsnotify.
+type ClientInt interface {
+	Add(path string) error
+	Start(exit <-chan struct{})
+}
+
+// client is an implementation of ClientInt.
+type client struct {
+	watcher      *fsnotify.Watcher
+	eventHandler EventHandler
+	errorHandler ErrorHandler
+}
+
+var _ ClientInt = &client{}
+
+// NewFileWatcher returns an implementation of ClientInt that continuously listens
+// for fsnotify events and calls the event handler as soon as an event is received.
+func NewFileWatcher(eventHandler EventHandler, errorHandler ErrorHandler) (ClientInt, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{
+		watcher:      watcher,
+		eventHandler: eventHandler,
+		errorHandler: errorHandler,
+	}, nil
+}
+
+// Add adds a file path to watch.
+func (c *client) Add(path string) error {
+	return c.watcher.Add(path)
+}
+
+// Start starts watching all registered files for events.
+func (c *client) Start(exit <-chan struct{}) {
+	go func() {
+		defer c.watcher.Close()
+		for {
+			select {
+			case <-exit:
+				return
+			case event := <-c.watcher.Events:
+				klog.Infof("Detect file modification: %s", event.String())
+				if c.eventHandler != nil {
+					c.eventHandler(event)
+				}
+			case err := <-c.watcher.Errors:
+				if c.errorHandler != nil {
+					c.errorHandler(err)
+				}
+			}
+		}
+	}()
+}

--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -1,0 +1,64 @@
+package filewatcher
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileWatcher(t *testing.T) {
+	tempFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	writeCount := 0
+	removed := false
+	fw, err := NewFileWatcher(func(event fsnotify.Event) {
+		if event.Op&fsnotify.Write == fsnotify.Write {
+			writeCount++
+		} else if event.Op&fsnotify.Remove == fsnotify.Remove {
+			removed = true
+		}
+	}, func(err error) {
+		t.Fatal(err)
+	})
+	assert.NoError(t, err)
+
+	go fw.Start(make(chan struct{}))
+	_, err = tempFile.Write([]byte("test0"))
+	assert.NoError(t, err)
+	// Sleep for 1 second to allow event propagation
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 0, writeCount)
+	assert.Equal(t, false, removed)
+
+	err = fw.Add(tempFile.Name())
+	assert.NoError(t, err)
+
+	_, err = tempFile.Write([]byte("test1"))
+	assert.NoError(t, err)
+	// Sleep for 1 second to allow event propagation
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 1, writeCount)
+	assert.Equal(t, false, removed)
+
+	_, err = tempFile.Write([]byte("test2"))
+	assert.NoError(t, err)
+	time.Sleep(1 * time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, writeCount)
+	assert.Equal(t, false, removed)
+
+	err = os.Remove(tempFile.Name())
+	assert.NoError(t, err)
+	time.Sleep(1 * time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, writeCount)
+	assert.Equal(t, true, removed)
+}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Re-initialize MIC cloud client when cloud config is updated so that it has the latest credentials to perform cloud operations.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #523.

**Notes for Reviewers**:

For aks-engine cluster, ssh into the node to modify `/etc/kubernetes/azure.json`. It's known that vim does not trigger a WRITE event to fsnotify. You can use other text editors like nano to test.

For AKS cluster, use `az aks update-credentials`.