### PR TITLE
feat: add finalizer for assigned identity

### DIFF
--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -11,6 +11,7 @@ import (
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	"github.com/Azure/aad-pod-identity/pkg/metrics"
 	"github.com/Azure/aad-pod-identity/pkg/stats"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -22,6 +23,10 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
+)
+
+const (
+	finalizerName = "azureassignedidentity.finalizers.aadpodidentity.k8s.io"
 )
 
 // Client represents all the watchers
@@ -483,7 +488,17 @@ func (c *Client) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 
 	}()
 
-	err = c.rest.Delete().Namespace(assignedIdentity.Namespace).Resource("azureassignedidentities").Name(assignedIdentity.Name).Do().Error()
+	var res aadpodv1.AzureAssignedIdentity
+	err = c.rest.Delete().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Name(assignedIdentity.Name).Do().Into(&res)
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+	if hasFinalizer(&res) {
+		removeFinalizer(&res)
+		// update the assigned identity without finalizer and resource will be garbage collected
+		err = c.rest.Put().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Name(assignedIdentity.Name).Body(&res).Do().Error()
+	}
+
 	klog.V(5).Infof("Deletion %s took: %v", assignedIdentity.Name, time.Since(begin))
 	stats.Update(stats.AssignedIDDel, time.Since(begin))
 	return err
@@ -505,11 +520,12 @@ func (c *Client) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 
 	}()
 
-	// Create a new AzureAssignedIdentity which maps the relationship between id and pod
 	var res aadpodv1.AzureAssignedIdentity
 	v1AssignedID := aadpodv1.ConvertInternalAssignedIdentityToV1AssignedIdentity(*assignedIdentity)
-	// TODO: Ensure that the status reflects the corresponding
-	err = c.rest.Post().Namespace(assignedIdentity.Namespace).Resource("azureassignedidentities").Body(&v1AssignedID).Do().Into(&res)
+	if !hasFinalizer(&v1AssignedID) {
+		v1AssignedID.SetFinalizers(append(v1AssignedID.GetFinalizers(), finalizerName))
+	}
+	err = c.rest.Post().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Body(&v1AssignedID).Do().Into(&res)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -785,7 +801,7 @@ func (c *Client) UpdateAzureAssignedIdentityStatus(assignedIdentity *aadpodid.Az
 	err = c.rest.
 		Patch(types.JSONPatchType).
 		Namespace(assignedIdentity.Namespace).
-		Resource("azureassignedidentities").
+		Resource(aadpodid.AzureAssignedIDResource).
 		Name(assignedIdentity.Name).
 		Body(patchBytes).
 		Do().
@@ -796,4 +812,31 @@ func (c *Client) UpdateAzureAssignedIdentityStatus(assignedIdentity *aadpodid.Az
 
 func getMapKey(ns, name string) string {
 	return strings.Join([]string{ns, name}, "/")
+}
+
+func removeFinalizer(assignedID *aadpodv1.AzureAssignedIdentity) {
+	assignedID.SetFinalizers(removeString(finalizerName, assignedID.GetFinalizers()))
+}
+
+func hasFinalizer(assignedID *aadpodv1.AzureAssignedIdentity) bool {
+	return containsString(finalizerName, assignedID.GetFinalizers())
+}
+
+func containsString(s string, items []string) bool {
+	for _, item := range items {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(s string, items []string) []string {
+	var rval []string
+	for _, item := range items {
+		if item != s {
+			rval = append(rval, item)
+		}
+	}
+	return rval
 }

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -490,7 +490,10 @@ func (c *Client) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 
 	var res aadpodv1.AzureAssignedIdentity
 	err = c.rest.Delete().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Name(assignedIdentity.Name).Do().Into(&res)
-	if !apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
 		return err
 	}
 	if hasFinalizer(&res) {

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -1,6 +1,8 @@
 package crd
 
 import (
+	"testing"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
@@ -101,4 +103,19 @@ func (c *TestCrdClient) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity
 		assignedIDList = append(assignedIDList, *v)
 	}
 	return &assignedIDList, nil
+}
+
+func TestRemoveFinalizer(t *testing.T) {
+	assignedID := aadpodid.AzureAssignedIdentity{
+		ObjectMeta: v1.ObjectMeta{
+			Finalizers: []string{
+				finalizerName,
+			},
+		},
+	}
+
+	removeFinalizer(&assignedID)
+	if len(assignedID.GetFinalizers()) != 0 {
+		t.Fatalf("expected len to be 0, got: %d", len(assignedID.GetFinalizers()))
+	}
 }

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -1080,7 +1080,6 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 		for _, delID := range nodeTrackList.assignedIDsToDelete {
 			id := delID.Spec.AzureIdentityRef
-			removedID := delID.Spec.AzureIdentityRef
 			removedBinding := delID.Spec.AzureBindingRef
 			isUserAssignedMSI := c.checkIfUserAssignedMSI(*id)
 			idExistsOnNode := c.checkIfMSIExistsOnNode(id, delID.Spec.NodeName, idList)
@@ -1101,7 +1100,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 				continue
 			}
 
-			klog.Infof("Updating msis on node %s failed, but identity %s/%s has successfully been removed from node", delID.Spec.NodeName, removedID.Namespace, removedID.Name)
+			klog.Infof("Updating msis on node %s failed, but identity %s/%s has successfully been removed from node", delID.Spec.NodeName, id.Namespace, id.Name)
 
 			// remove assigned identity crd from cluster as the identity has successfully been removed from the node
 			err = c.removeAssignedIdentity(&delID)
@@ -1168,7 +1167,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 				klog.Error(err)
 				return
 			}
-			klog.Infof("deleted assigned identity %s/%s", delID.Namespace, delID.Name)
+			klog.V(1).Infof("deleted assigned identity %s/%s", assignedID.Namespace, assignedID.Name)
 		}(delID)
 	}
 

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -1068,7 +1068,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			c.EventRecorder.Event(binding, corev1.EventTypeNormal, "binding applied",
 				fmt.Sprintf("Binding %s applied on node %s for pod %s", binding.Name, createID.Spec.NodeName, createID.Name))
 
-			klog.Infof("Updating msis on node %s failed, but identity %s has successfully been assigned to node", createID.Spec.NodeName, binding.Name)
+			klog.Infof("Updating msis on node %s failed, but identity %s/%s has successfully been assigned to node", createID.Spec.NodeName, id.Namespace, id.Name)
 
 			// Identity is successfully assigned to node, so update the status of assigned identity to assigned
 			if updateErr := c.updateAssignedIdentityStatus(&createID, aadpodid.AssignedIDAssigned); updateErr != nil {
@@ -1080,6 +1080,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 		for _, delID := range nodeTrackList.assignedIDsToDelete {
 			id := delID.Spec.AzureIdentityRef
+			removedID := delID.Spec.AzureIdentityRef
 			removedBinding := delID.Spec.AzureBindingRef
 			isUserAssignedMSI := c.checkIfUserAssignedMSI(*id)
 			idExistsOnNode := c.checkIfMSIExistsOnNode(id, delID.Spec.NodeName, idList)
@@ -1096,24 +1097,19 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			// the identity still exists on node, which means removing the identity from the node failed
 			if isUserAssignedMSI && !inUse && idExistsOnNode {
 				message := fmt.Sprintf("Binding %s removal from node %s for pod %s resulted in error %v", removedBinding.Name, delID.Spec.NodeName, delID.Spec.Pod, err.Error())
-				c.EventRecorder.Event(removedBinding, corev1.EventTypeWarning, "binding remove error", message)
 				klog.Error(message)
 				continue
 			}
 
-			klog.Infof("Updating msis on node %s failed, but identity %s has successfully been removed from node", delID.Spec.NodeName, removedBinding.Name)
+			klog.Infof("Updating msis on node %s failed, but identity %s/%s has successfully been removed from node", delID.Spec.NodeName, removedID.Namespace, removedID.Name)
 
 			// remove assigned identity crd from cluster as the identity has successfully been removed from the node
 			err = c.removeAssignedIdentity(&delID)
 			if err != nil {
-				c.EventRecorder.Event(removedBinding, corev1.EventTypeWarning, "binding remove error",
-					fmt.Sprintf("Removing assigned identity binding %s node %s for pod %s resulted in error %v", removedBinding.Name, delID.Spec.NodeName, delID.Name, err.Error()))
 				klog.Error(err)
 				continue
 			}
-			// the identity was successfully removed from node
-			c.EventRecorder.Event(removedBinding, corev1.EventTypeNormal, "binding removed",
-				fmt.Sprintf("Binding %s removed from node %s for pod %s", removedBinding.Name, delID.Spec.NodeName, delID.Spec.Pod))
+			klog.Infof("deleted assigned identity %s/%s", delID.Namespace, delID.Name)
 		}
 		stats.Put(stats.TotalCreateOrUpdate, time.Since(beginAdding))
 		return
@@ -1157,7 +1153,6 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 		}
 		go func(assignedID aadpodid.AzureAssignedIdentity) {
 			defer semDel.Release(1)
-			removedBinding := assignedID.Spec.AzureBindingRef
 			// update the status for the assigned identity to Unassigned as the identity has been successfully removed from node.
 			// this will ensure on next sync loop we only try to delete the assigned identity instead of doing everything.
 			err := c.updateAssignedIdentityStatus(&assignedID, aadpodid.AssignedIDUnAssigned)
@@ -1170,14 +1165,10 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			// remove assigned identity crd from cluster as the identity has successfully been removed from the node
 			err = c.removeAssignedIdentity(&assignedID)
 			if err != nil {
-				c.EventRecorder.Event(removedBinding, corev1.EventTypeWarning, "binding remove error",
-					fmt.Sprintf("Removing assigned identity binding %s node %s for pod %s resulted in error %v", removedBinding.Name, assignedID.Spec.NodeName, assignedID.Name, err))
 				klog.Error(err)
 				return
 			}
-			// the identity was successfully removed from node
-			c.EventRecorder.Event(removedBinding, corev1.EventTypeNormal, "binding removed",
-				fmt.Sprintf("Binding %s removed from node %s for pod %s", removedBinding.Name, assignedID.Spec.NodeName, assignedID.Spec.Pod))
+			klog.Infof("deleted assigned identity %s/%s", delID.Namespace, delID.Name)
 		}(delID)
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Adds finalizer to `AzureAssignedIdentity`
  - ensures, the `AzureAssignedIdentity` is only deleted after the identity is successfully un-assigned from the node.
  - ensures identities are cleaned up when namespace is deleted.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/533

**Notes for Reviewers**:
