### PR TITLE
fix: fix e2e test regression caused by #579

### DIFF
--- a/test/common/azure/azure.go
+++ b/test/common/azure/azure.go
@@ -315,7 +315,7 @@ func GetVMUserAssignedIdentities(resourceGroup, vmName string) (map[string]UserA
 		return nil, errors.Wrap(err, "Failed to unmarshall json")
 	}
 
-	return userAssignedIdentities, nil
+	return convertKeysToLower(userAssignedIdentities), nil
 }
 
 // GetVMSSUserAssignedIdentities will return the list of user assigned identity in a given VM
@@ -345,7 +345,7 @@ func GetVMSSUserAssignedIdentities(resourceGroup, name string) (map[string]UserA
 		return nil, errors.Wrap(err, "Failed to unmarshall json")
 	}
 
-	return userAssignedIdentities, nil
+	return convertKeysToLower(userAssignedIdentities), nil
 }
 
 // RemoveUserAssignedIdentityFromVM will remove a user assigned identity to a VM
@@ -447,4 +447,12 @@ func RemoveSystemAssignedIdentityFromVMSS(resourceGroup, name string) error {
 	}
 
 	return nil
+}
+
+func convertKeysToLower(m map[string]UserAssignedIdentity) map[string]UserAssignedIdentity {
+	mLower := make(map[string]UserAssignedIdentity)
+	for k, v := range m {
+		mLower[strings.ToLower(k)] = v
+	}
+	return mLower
 }

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -298,10 +298,10 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 		}
 	})
 
-	It("should not alter the user assigned identity on VM after AAD pod identity is created and deleted", func() {
+	It("should not alter the user assigned identity on VM after AAD pod identity is created and deleted [PR]", func() {
 		azureIdentityResource := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s"
-		clusterIdentityResource := fmt.Sprintf(azureIdentityResource, cfg.SubscriptionID, cfg.IdentityResourceGroup, clusterIdentity)
-		keyvaultIdentityResource := fmt.Sprintf(azureIdentityResource, cfg.SubscriptionID, cfg.IdentityResourceGroup, keyvaultIdentity)
+		clusterIdentityResource := strings.ToLower(fmt.Sprintf(azureIdentityResource, cfg.SubscriptionID, cfg.IdentityResourceGroup, clusterIdentity))
+		keyvaultIdentityResource := strings.ToLower(fmt.Sprintf(azureIdentityResource, cfg.SubscriptionID, cfg.IdentityResourceGroup, keyvaultIdentity))
 
 		// Assign user assigned identity to every node
 		nodeList, err := node.GetAll()


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

#579 introduced `IDENTITY_RESOURCE_GROUP` and `CLUSTER_RESOURCE_GROUP` as part of the envconfig for e2e test, so we can no longer assume that the user-assigned identity is within the same resource group as the cluster. Instead of using the name of the user-assigned identity to identify them, we started using the resource ID obtained from `az identity show -g <IdentityResourceGroup> -n <IdentityName>`.

The resource ID obtained from `az identity show` has a `resourcegroup` part of it instead of `resourceGroup` for some unknown reasons. It caused `should not alter the user assigned identity on VM after AAD pod identity is created and deleted` test case to fail since it constructs on a map of user-assigned identity where the key is the resource ID of the identity and the test case assumes that `resourceGroup` is part of the resource ID. This PR converts all keys in the map to lower cases to mitigate the issue.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

https://upstream.jenkins.azure-containers.io/view/aad-pod-identity/job/aad-pod-identity-e2e-daily/

**Notes for Reviewers**:
