### PR TITLE
feat: make update user msi calls retriable

### DIFF
--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -34,6 +34,7 @@ var (
 	immutableUserMSIs   string
 	cmConfig            mic.CMConfig
 	typeUpgradeConfig   mic.TypeUpgradeConfig
+	updateUserMSIConfig mic.UpdateUserMSIConfig
 )
 
 func main() {
@@ -81,6 +82,10 @@ func main() {
 	// Config map details for the type changes in the context of client-go upgrade.
 	flag.StringVar(&typeUpgradeConfig.TypeUpgradeStatusKey, "type-upgrade-status-key", "type-upgrade-status", "Configmap key for type upgrade status")
 	flag.BoolVar(&typeUpgradeConfig.EnableTypeUpgrade, "enable-type-upgrade", true, "Enable type upgrade")
+
+	// Parameters for retrying cloudprovider's UpdateUserMSI function
+	flag.IntVar(&updateUserMSIConfig.MaxRetry, "update-user-msi-max-retry", 2, "The maximum retry of UpdateUserMSI call")
+	flag.DurationVar(&updateUserMSIConfig.RetryPeriod, "update-user-msi-retry-period", 1*time.Second, "The duration to wait before retrying UpdateUserMSI")
 
 	flag.Parse()
 
@@ -142,6 +147,7 @@ func main() {
 		ImmutableUserMSIsList: immutableUserMSIsList,
 		CMcfg:                 &cmConfig,
 		TypeUpgradeCfg:        &typeUpgradeConfig,
+		UpdateUserMSICfg:      &updateUserMSIConfig,
 	}
 
 	micClient, err := mic.NewMICClient(micConfig)

--- a/cmd/mic/main.go
+++ b/cmd/mic/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	// Parameters for retrying cloudprovider's UpdateUserMSI function
 	flag.IntVar(&updateUserMSIConfig.MaxRetry, "update-user-msi-max-retry", 2, "The maximum retry of UpdateUserMSI call")
-	flag.DurationVar(&updateUserMSIConfig.RetryPeriod, "update-user-msi-retry-period", 1*time.Second, "The duration to wait before retrying UpdateUserMSI")
+	flag.DurationVar(&updateUserMSIConfig.RetryInterval, "update-user-msi-retry-interval", 1*time.Second, "The duration to wait before retrying UpdateUserMSI")
 
 	flag.Parse()
 

--- a/docs/readmes/README.troubleshooting.md
+++ b/docs/readmes/README.troubleshooting.md
@@ -38,4 +38,18 @@ Common issues or questions that users have run into when using pod identity are 
 
 ### Ignoring azure identity \<podns\>/\<podname\>, error: Invalid resource id: "", must match /subscriptions/\<subid\>/resourcegroups/\<resourcegroup\>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\<name\>
 
-If you are using MIC v1.6.0+, you will need to ensure the correct capitalization of `AzureIdentity` and `AzureIdentityBinding` fields. For more information, please refer to [this section](../../README.md#v160-breaking-change).
+If you are using MIC v1.6.0+, you will need to ensure the correct captialization of `AzureIdentity` and `AzureIdentityBinding` fields. For more information, please refer to [this section](../../README.md#v160-breaking-change).
+
+### LinkedAuthorizationFailed
+
+If you received the following error message in MIC:
+
+```log
+Code="LinkedAuthorizationFailed" Message="The client '<ClientID>' with object id '<ObjectID>' has permission to perform action 'Microsoft.Compute/<VMType>/write' on scope '<VM/VMSS scope>'; however, it does not have permission to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action' on the linked scope(s) '<UserAssignedIdentityScope>' or the linked scope(s) are invalid."
+```
+
+It means that your cluster service principal / managed identity does not have the correct role assignment to assign the chosen user-assigned identities to the VM/VMSS. For more information, please follow this [documentation](README.role-assignment.md) to allow your cluster service principal / managed identity to perform identity-related operation.
+
+Past issues:
+
+- https://github.com/Azure/aad-pod-identity/issues/585

--- a/docs/readmes/README.troubleshooting.md
+++ b/docs/readmes/README.troubleshooting.md
@@ -38,7 +38,7 @@ Common issues or questions that users have run into when using pod identity are 
 
 ### Ignoring azure identity \<podns\>/\<podname\>, error: Invalid resource id: "", must match /subscriptions/\<subid\>/resourcegroups/\<resourcegroup\>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\<name\>
 
-If you are using MIC v1.6.0+, you will need to ensure the correct captialization of `AzureIdentity` and `AzureIdentityBinding` fields. For more information, please refer to [this section](../../README.md#v160-breaking-change).
+If you are using MIC v1.6.0+, you will need to ensure the correct capitalization of `AzureIdentity` and `AzureIdentityBinding` fields. For more information, please refer to [this section](../../README.md#v160-breaking-change).
 
 ### LinkedAuthorizationFailed
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -44,19 +44,19 @@ const (
 	// have the correct role assignment to access a user-assigned identity.
 	linkedAuthorizationFailed retry.RetriableError = "LinkedAuthorizationFailed"
 	// Occurs when the user-assigned identity does not exist.
-	failedIdentityOperator retry.RetriableError = "FailedIdentityOperation"
+	failedIdentityOperation retry.RetriableError = "FailedIdentityOperation"
 )
 
 // NewCloudProvider returns a azure cloud provider client
-func NewCloudProvider(configFile string, updateUserMSIMaxRetry int, updateUseMSIRetryPeriod time.Duration) (c *Client, e error) {
+func NewCloudProvider(configFile string, updateUserMSIMaxRetry int, updateUseMSIRetryInterval time.Duration) (c *Client, e error) {
 	client := &Client{
 		configFile: configFile,
 	}
 	if err := client.Init(); err != nil {
 		return nil, err
 	}
-	client.RetryClient = retry.NewRetryClient(updateUserMSIMaxRetry, updateUseMSIRetryPeriod)
-	client.RetryClient.RegisterRetriableErrors(linkedAuthorizationFailed, failedIdentityOperator)
+	client.RetryClient = retry.NewRetryClient(updateUserMSIMaxRetry, updateUseMSIRetryInterval)
+	client.RetryClient.RegisterRetriableErrors(linkedAuthorizationFailed, failedIdentityOperation)
 	return client, nil
 }
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/aad-pod-identity/pkg/config"
+	"github.com/Azure/aad-pod-identity/pkg/retry"
 	"github.com/Azure/aad-pod-identity/pkg/utils"
 	"github.com/Azure/aad-pod-identity/version"
 
@@ -23,11 +24,12 @@ import (
 
 // Client is a cloud provider client
 type Client struct {
-	VMClient   VMClientInt
-	VMSSClient VMSSClientInt
-	ExtClient  compute.VirtualMachineExtensionsClient
-	Config     config.AzureConfig
-	configFile string
+	VMClient    VMClientInt
+	VMSSClient  VMSSClientInt
+	RetryClient retry.ClientInt
+	ExtClient   compute.VirtualMachineExtensionsClient
+	Config      config.AzureConfig
+	configFile  string
 }
 
 // ClientInt client interface
@@ -37,14 +39,24 @@ type ClientInt interface {
 	Init() error
 }
 
+const (
+	// Occurs when the cluster service principal / managed identity does not
+	// have the correct role assignment to access a user-assigned identity.
+	linkedAuthorizationFailed retry.RetriableError = "LinkedAuthorizationFailed"
+	// Occurs when the user-assigned identity does not exist.
+	failedIdentityOperator retry.RetriableError = "FailedIdentityOperation"
+)
+
 // NewCloudProvider returns a azure cloud provider client
-func NewCloudProvider(configFile string) (c *Client, e error) {
+func NewCloudProvider(configFile string, updateUserMSIMaxRetry int, updateUseMSIRetryPeriod time.Duration) (c *Client, e error) {
 	client := &Client{
 		configFile: configFile,
 	}
 	if err := client.Init(); err != nil {
 		return nil, err
 	}
+	client.RetryClient = retry.NewRetryClient(updateUserMSIMaxRetry, updateUseMSIRetryPeriod)
+	client.RetryClient.RegisterRetriableErrors(linkedAuthorizationFailed, failedIdentityOperator)
 	return client, nil
 }
 
@@ -188,16 +200,44 @@ func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs [
 	for _, userAssignedMSIID := range addUserAssignedMSIIDs {
 		ids[userAssignedMSIID] = true
 	}
-	requiresUpdate := info.SetUserIdentities(ids)
 
-	if requiresUpdate {
-		klog.Infof("Updating user assigned MSIs on %s, assign [%d], unassign [%d]", name, len(addUserAssignedMSIIDs), len(removeUserAssignedMSIIDs))
-		timeStarted := time.Now()
-		if err := updateFunc(); err != nil {
-			return err
-		}
-		klog.V(6).Infof("UpdateUserMSI of %s completed in %s", name, time.Since(timeStarted))
+	if requiresUpdate := info.SetUserIdentities(ids); !requiresUpdate {
+		return nil
 	}
+
+	klog.Infof("Updating user assigned MSIs on %s, assign [%d], unassign [%d]", name, len(addUserAssignedMSIIDs), len(removeUserAssignedMSIIDs))
+	timeStarted := time.Now()
+	shouldRetry := func(err error) bool {
+		if err == nil {
+			return false
+		}
+
+		// Filter previously-assigned IDs based on which identities
+		// are erroneous from the last occurred error
+		erroneousIDs := extractIdentitiesFromError(err)
+		removedAny := false
+		for _, erroneousID := range erroneousIDs {
+			if removed := info.RemoveUserIdentity(erroneousID); removed {
+				removedAny = true
+				klog.Infof("Removing %s from ID list since it is erroneous", erroneousID)
+			}
+		}
+
+		// Only retry if there is at least one ID after deleting
+		remainingIDs := info.GetUserIdentityList()
+		if removedAny && len(remainingIDs) > 0 {
+			klog.Infof("Attempting to retry with ID list %v", remainingIDs)
+			return true
+		}
+
+		return false
+	}
+	if err := c.RetryClient.Do(updateFunc, shouldRetry); err != nil {
+		return err
+	}
+
+	klog.V(6).Infof("UpdateUserMSI of %s completed in %s", name, time.Since(timeStarted))
+
 	return nil
 }
 
@@ -264,4 +304,40 @@ func ParseResourceID(resourceID string) (azure.Resource, error) {
 	}
 
 	return result, nil
+}
+
+const (
+	// This matches identity resource IDs on an error message from ARM
+	userAssignedIdentitiesPatternText = `'(,?(?i)/subscriptions/[a-zA-Z0-9-_]+/resourcegroups/[a-zA-Z0-9-_]+/providers/Microsoft.ManagedIdentity/userAssignedIdentities/[a-zA-Z0-9-_]+)+'`
+)
+
+var (
+	userAssignedIdentitiesPattern = regexp.MustCompile(userAssignedIdentitiesPatternText)
+)
+
+func extractIdentitiesFromError(err error) []string {
+	var extracted []string
+	if err == nil {
+		return extracted
+	}
+
+	matches := userAssignedIdentitiesPattern.FindStringSubmatch(err.Error())
+	if len(matches) == 0 {
+		return extracted
+	}
+
+	match := matches[0]
+	// Remove leading and trailing single quotes
+	match = match[1 : len(match)-1]
+
+	for _, id := range strings.Split(match, ",") {
+		// Sanity check
+		if err := utils.ValidateResourceID(id); err != nil {
+			klog.Error(err)
+			continue
+		}
+		extracted = append(extracted, id)
+	}
+
+	return extracted
 }

--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -20,7 +20,6 @@ type IdentityInfo interface {
 	GetUserIdentityList() []string
 	SetUserIdentities(map[string]bool) bool
 	RemoveUserIdentity(string) bool
-	ResetResourceIdentityType()
 }
 
 // getUpdatedResourceIdentityType returns the new resource identity type

--- a/pkg/cloudprovider/identity.go
+++ b/pkg/cloudprovider/identity.go
@@ -19,6 +19,8 @@ type IdentityHolder interface {
 type IdentityInfo interface {
 	GetUserIdentityList() []string
 	SetUserIdentities(map[string]bool) bool
+	RemoveUserIdentity(string) bool
+	ResetResourceIdentityType()
 }
 
 // getUpdatedResourceIdentityType returns the new resource identity type

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -163,12 +163,14 @@ func (i *vmIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 	nodeList := make(map[string]bool)
 	// add all current existing ids
 	for id := range i.info.UserAssignedIdentities {
+		id = strings.ToLower(id)
 		nodeList[id] = true
 	}
 
 	// add and remove the new list of identities keeping the same type as before
 	userAssignedIdentities := make(map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue)
 	for id, add := range ids {
+		id = strings.ToLower(id)
 		_, exists := nodeList[id]
 		// already exists on node and want to remove existing identity
 		if exists && !add {
@@ -186,7 +188,12 @@ func (i *vmIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 
 	// all identities are the node are to be removed
 	if len(nodeList) == 0 {
-		i.ResetResourceIdentityType()
+		i.info.UserAssignedIdentities = nil
+		if i.info.Type == compute.ResourceIdentityTypeSystemAssignedUserAssigned {
+			i.info.Type = compute.ResourceIdentityTypeSystemAssigned
+		} else {
+			i.info.Type = compute.ResourceIdentityTypeNone
+		}
 		return true
 	}
 
@@ -196,29 +203,13 @@ func (i *vmIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 }
 
 func (i *vmIdentityInfo) RemoveUserIdentity(delID string) bool {
-	removed := false
+	delID = strings.ToLower(delID)
 	if i.info.UserAssignedIdentities != nil {
-		for id := range i.info.UserAssignedIdentities {
-			if strings.EqualFold(id, delID) {
-				delete(i.info.UserAssignedIdentities, id)
-				removed = true
-				break
-			}
+		if _, ok := i.info.UserAssignedIdentities[delID]; ok {
+			delete(i.info.UserAssignedIdentities, delID)
+			return true
 		}
 	}
 
-	// Modify identity type in case we remove the last identity from the VM
-	if len(i.info.UserAssignedIdentities) == 0 {
-		i.ResetResourceIdentityType()
-	}
-	return removed
-}
-
-func (i *vmIdentityInfo) ResetResourceIdentityType() {
-	i.info.UserAssignedIdentities = nil
-	if i.info.Type == compute.ResourceIdentityTypeSystemAssignedUserAssigned {
-		i.info.Type = compute.ResourceIdentityTypeSystemAssigned
-	} else {
-		i.info.Type = compute.ResourceIdentityTypeNone
-	}
+	return false
 }

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -2,6 +2,7 @@ package cloudprovider
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/Azure/aad-pod-identity/pkg/config"
@@ -185,16 +186,39 @@ func (i *vmIdentityInfo) SetUserIdentities(ids map[string]bool) bool {
 
 	// all identities are the node are to be removed
 	if len(nodeList) == 0 {
-		i.info.UserAssignedIdentities = nil
-		if i.info.Type == compute.ResourceIdentityTypeSystemAssignedUserAssigned {
-			i.info.Type = compute.ResourceIdentityTypeSystemAssigned
-		} else {
-			i.info.Type = compute.ResourceIdentityTypeNone
-		}
+		i.ResetResourceIdentityType()
 		return true
 	}
 
 	i.info.Type = getUpdatedResourceIdentityType(i.info.Type)
 	i.info.UserAssignedIdentities = userAssignedIdentities
 	return len(i.info.UserAssignedIdentities) > 0
+}
+
+func (i *vmIdentityInfo) RemoveUserIdentity(delID string) bool {
+	removed := false
+	if i.info.UserAssignedIdentities != nil {
+		for id := range i.info.UserAssignedIdentities {
+			if strings.EqualFold(id, delID) {
+				delete(i.info.UserAssignedIdentities, id)
+				removed = true
+				break
+			}
+		}
+	}
+
+	// Modify identity type in case we remove the last identity from the VM
+	if len(i.info.UserAssignedIdentities) == 0 {
+		i.ResetResourceIdentityType()
+	}
+	return removed
+}
+
+func (i *vmIdentityInfo) ResetResourceIdentityType() {
+	i.info.UserAssignedIdentities = nil
+	if i.info.Type == compute.ResourceIdentityTypeSystemAssignedUserAssigned {
+		i.info.Type = compute.ResourceIdentityTypeSystemAssigned
+	} else {
+		i.info.Type = compute.ResourceIdentityTypeNone
+	}
 }

--- a/pkg/cloudprovider/vm_test.go
+++ b/pkg/cloudprovider/vm_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetUserIdentitiesVMSS(t *testing.T) {
-	testIdentityInfo := &vmssIdentityInfo{
-		info: &compute.VirtualMachineScaleSetIdentity{},
+func TestSetUserIdentitiesVM(t *testing.T) {
+	testIdentityInfo := &vmIdentityInfo{
+		info: &compute.VirtualMachineIdentity{},
 	}
 
 	// adding id1
@@ -23,10 +23,10 @@ func TestSetUserIdentitiesVMSS(t *testing.T) {
 	assert.True(t, update)
 }
 
-func TestRemoveUserIdentityVMSS(t *testing.T) {
-	testIdentityInfo := &vmssIdentityInfo{
-		info: &compute.VirtualMachineScaleSetIdentity{
-			UserAssignedIdentities: map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{
+func TestRemoveUserIdentityVM(t *testing.T) {
+	testIdentityInfo := &vmIdentityInfo{
+		info: &compute.VirtualMachineIdentity{
+			UserAssignedIdentities: map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{
 				"ID1": nil,
 				"iD2": nil,
 			},

--- a/pkg/cloudprovider/vm_test.go
+++ b/pkg/cloudprovider/vm_test.go
@@ -27,23 +27,23 @@ func TestRemoveUserIdentityVM(t *testing.T) {
 	testIdentityInfo := &vmIdentityInfo{
 		info: &compute.VirtualMachineIdentity{
 			UserAssignedIdentities: map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{
-				"ID1": nil,
-				"iD2": nil,
+				"id1": {},
+				"id2": {},
 			},
 		},
 	}
 
 	// removing id1 (should be case-insensitive)
-	removed := testIdentityInfo.RemoveUserIdentity("id1")
+	removed := testIdentityInfo.RemoveUserIdentity("ID1")
 	assert.True(t, removed)
 	assert.Len(t, testIdentityInfo.info.UserAssignedIdentities, 1)
 
 	// removing id2 (should be case-insensitive)
-	removed = testIdentityInfo.RemoveUserIdentity("id2")
+	removed = testIdentityInfo.RemoveUserIdentity("ID2")
 	assert.True(t, removed)
 	assert.Len(t, testIdentityInfo.info.UserAssignedIdentities, 0)
 
-	removed = testIdentityInfo.RemoveUserIdentity("id2")
+	removed = testIdentityInfo.RemoveUserIdentity("ID2")
 	assert.False(t, removed)
 	assert.Len(t, testIdentityInfo.info.UserAssignedIdentities, 0)
 }

--- a/pkg/cloudprovider/vmss_test.go
+++ b/pkg/cloudprovider/vmss_test.go
@@ -27,23 +27,23 @@ func TestRemoveUserIdentityVMSS(t *testing.T) {
 	testIdentityInfo := &vmssIdentityInfo{
 		info: &compute.VirtualMachineScaleSetIdentity{
 			UserAssignedIdentities: map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{
-				"ID1": nil,
-				"iD2": nil,
+				"id1": {},
+				"id2": {},
 			},
 		},
 	}
 
 	// removing id1 (should be case-insensitive)
-	removed := testIdentityInfo.RemoveUserIdentity("id1")
+	removed := testIdentityInfo.RemoveUserIdentity("ID1")
 	assert.True(t, removed)
 	assert.Len(t, testIdentityInfo.info.UserAssignedIdentities, 1)
 
 	// removing id2 (should be case-insensitive)
-	removed = testIdentityInfo.RemoveUserIdentity("id2")
+	removed = testIdentityInfo.RemoveUserIdentity("ID2")
 	assert.True(t, removed)
 	assert.Len(t, testIdentityInfo.info.UserAssignedIdentities, 0)
 
-	removed = testIdentityInfo.RemoveUserIdentity("id2")
+	removed = testIdentityInfo.RemoveUserIdentity("ID2")
 	assert.False(t, removed)
 	assert.Len(t, testIdentityInfo.info.UserAssignedIdentities, 0)
 }

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -70,8 +70,8 @@ type LeaderElectionConfig struct {
 
 // UpdateUserMSIConfig - parameters for retrying cloudprovider's UpdateUserMSI function
 type UpdateUserMSIConfig struct {
-	MaxRetry    int
-	RetryPeriod time.Duration
+	MaxRetry      int
+	RetryInterval time.Duration
 }
 
 // Client has the required pointers to talk to the api server
@@ -144,7 +144,7 @@ func NewMICClient(cfg *Config) (*Client, error) {
 
 	informer := informers.NewSharedInformerFactory(clientSet, 30*time.Second)
 
-	cloudClient, err := cloudprovider.NewCloudProvider(cfg.CloudCfgPath, cfg.UpdateUserMSICfg.MaxRetry, cfg.UpdateUserMSICfg.RetryPeriod)
+	cloudClient, err := cloudprovider.NewCloudProvider(cfg.CloudCfgPath, cfg.UpdateUserMSICfg.MaxRetry, cfg.UpdateUserMSICfg.RetryInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -9,11 +9,11 @@ import (
 type Func func() error
 
 // ShouldRetryFunc is a function that consumes the last-known error
-// from the targetted function and determine if we should run it again
+// from the targeted function and determine if we should run it again
 type ShouldRetryFunc func(error) bool
 
 // RetriableError is an error that when occurred,
-// we should retry targetted function.
+// we should retry targeted function.
 type RetriableError string
 
 // ClientInt is an abstraction that retries running a
@@ -27,22 +27,22 @@ type ClientInt interface {
 type client struct {
 	retriableErrors map[RetriableError]bool
 	maxRetry        int
-	retryPeriod     time.Duration
+	retryInterval   time.Duration
 }
 
 var _ ClientInt = &client{}
 
 // NewRetryClient returns an implementation of ClientInt that retries
 // running a given function based on the parameters provided.
-func NewRetryClient(maxRetry int, retryPeriod time.Duration) ClientInt {
+func NewRetryClient(maxRetry int, retryInterval time.Duration) ClientInt {
 	return &client{
 		retriableErrors: make(map[RetriableError]bool),
 		maxRetry:        maxRetry,
-		retryPeriod:     retryPeriod,
+		retryInterval:   retryInterval,
 	}
 }
 
-// Do runs the targetted function f and will retry running
+// Do runs the targeted function f and will retry running
 // it if it returns an error and shouldRetry returns true.
 func (c *client) Do(f Func, shouldRetry ShouldRetryFunc) error {
 	// The original error
@@ -58,7 +58,7 @@ func (c *client) Do(f Func, shouldRetry ShouldRetryFunc) error {
 			break
 		}
 
-		time.Sleep(c.retryPeriod)
+		time.Sleep(c.retryInterval)
 		// We should retry if:
 		// 1) the last known error is not nil
 		// 2) the error is retriable
@@ -81,9 +81,7 @@ func (c *client) RegisterRetriableErrors(rerrs ...RetriableError) {
 // UnregisterRetriableErrors unregisters an error from the retrier.
 func (c *client) UnregisterRetriableErrors(rerrs ...RetriableError) {
 	for _, rerr := range rerrs {
-		if _, ok := c.retriableErrors[rerr]; ok {
-			delete(c.retriableErrors, rerr)
-		}
+		delete(c.retriableErrors, rerr)
 	}
 }
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,0 +1,101 @@
+package retry
+
+import (
+	"strings"
+	"time"
+)
+
+// Func is a function that is being retried.
+type Func func() error
+
+// ShouldRetryFunc is a function that consumes the last-known error
+// from the targetted function and determine if we should run it again
+type ShouldRetryFunc func(error) bool
+
+// RetriableError is an error that when occurred,
+// we should retry targetted function.
+type RetriableError string
+
+// ClientInt is an abstraction that retries running a
+// function based on what type of error has occurred
+type ClientInt interface {
+	Do(f Func, shouldRetry ShouldRetryFunc) error
+	RegisterRetriableErrors(rerrs ...RetriableError)
+	UnregisterRetriableErrors(rerrs ...RetriableError)
+}
+
+type client struct {
+	retriableErrors map[RetriableError]bool
+	maxRetry        int
+	retryPeriod     time.Duration
+}
+
+var _ ClientInt = &client{}
+
+// NewRetryClient returns an implementation of ClientInt that retries
+// running a given function based on the parameters provided.
+func NewRetryClient(maxRetry int, retryPeriod time.Duration) ClientInt {
+	return &client{
+		retriableErrors: make(map[RetriableError]bool),
+		maxRetry:        maxRetry,
+		retryPeriod:     retryPeriod,
+	}
+}
+
+// Do runs the targetted function f and will retry running
+// it if it returns an error and shouldRetry returns true.
+func (c *client) Do(f Func, shouldRetry ShouldRetryFunc) error {
+	// The original error
+	err := f()
+	// Error occurred when retrying
+	rerr := err
+	for i := 0; i < c.maxRetry; i++ {
+		if err == nil {
+			return nil
+		}
+		if rerr == nil {
+			// Return the original error from the first run,
+			// indicating that we retried running the function
+			return err
+		}
+
+		if !c.isRetriable(rerr) || !shouldRetry(rerr) {
+			return rerr
+		}
+		time.Sleep(c.retryPeriod)
+		rerr = f()
+	}
+
+	return rerr
+}
+
+// RegisterRetriableErrors registers a retriable error to the retrier.
+func (c *client) RegisterRetriableErrors(rerrs ...RetriableError) {
+	for _, rerr := range rerrs {
+		c.retriableErrors[rerr] = true
+	}
+}
+
+// UnregisterRetriableErrors unregisters an error from the retrier.
+func (c *client) UnregisterRetriableErrors(rerrs ...RetriableError) {
+	for _, rerr := range rerrs {
+		if _, ok := c.retriableErrors[rerr]; ok {
+			delete(c.retriableErrors, rerr)
+		}
+	}
+}
+
+// isRetriable returns true if an error is retriable.
+func (c *client) isRetriable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	for rerr := range c.retriableErrors {
+		if strings.Contains(err.Error(), string(rerr)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -1,0 +1,53 @@
+package retry
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDo(t *testing.T) {
+	r := NewRetryClient(2, 0)
+	r.RegisterRetriableErrors("err1")
+
+	ran := 0
+	r.Do(func() error {
+		ran++
+		return nil
+	}, func(err error) bool {
+		return true
+	})
+	// Targetted function ran once since there is no error occurred
+	assert.Equal(t, 1, ran)
+
+	ran = 0
+	r.Do(func() error {
+		ran++
+		return errors.New("err1 occurred")
+	}, func(err error) bool {
+		return true
+	})
+	// Targetted function ran 3 times (1 initial run and 2 retries)
+	assert.Equal(t, 3, ran)
+
+	ran = 0
+	r.Do(func() error {
+		ran++
+		return errors.New("err1 occurred")
+	}, func(err error) bool {
+		return false
+	})
+	// Targetted function ran once since shouldRetryFunc returned false
+	assert.Equal(t, 1, ran)
+
+	ran = 0
+	r.Do(func() error {
+		ran++
+		return errors.New("err2 occurred")
+	}, func(err error) bool {
+		return true
+	})
+	// Targetted function only ran once since err2 was not registered
+	assert.Equal(t, 1, ran)
+}

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -12,42 +12,46 @@ func TestDo(t *testing.T) {
 	r.RegisterRetriableErrors("err1")
 
 	ran := 0
-	r.Do(func() error {
+	err := r.Do(func() error {
 		ran++
 		return nil
 	}, func(err error) bool {
 		return true
 	})
-	// Targetted function ran once since there is no error occurred
+	// Targeted function ran once since there is no error occurred
 	assert.Equal(t, 1, ran)
+	assert.NoError(t, err)
 
 	ran = 0
-	r.Do(func() error {
+	err = r.Do(func() error {
 		ran++
 		return errors.New("err1 occurred")
 	}, func(err error) bool {
 		return true
 	})
-	// Targetted function ran 3 times (1 initial run and 2 retries)
+	// Targeted function ran 3 times (1 initial run and 2 retries)
 	assert.Equal(t, 3, ran)
+	assert.Error(t, err)
 
 	ran = 0
-	r.Do(func() error {
+	err = r.Do(func() error {
 		ran++
 		return errors.New("err1 occurred")
 	}, func(err error) bool {
 		return false
 	})
-	// Targetted function ran once since shouldRetryFunc returned false
+	// Targeted function ran once since shouldRetryFunc returned false
 	assert.Equal(t, 1, ran)
+	assert.Error(t, err)
 
 	ran = 0
-	r.Do(func() error {
+	err = r.Do(func() error {
 		ran++
 		return errors.New("err2 occurred")
 	}, func(err error) bool {
 		return true
 	})
-	// Targetted function only ran once since err2 was not registered
+	// Targeted function only ran once since err2 was not registered
 	assert.Equal(t, 1, ran)
+	assert.Error(t, err)
 }

--- a/test/common/k8s/azureassignedidentity/azureassignedidentity.go
+++ b/test/common/k8s/azureassignedidentity/azureassignedidentity.go
@@ -93,17 +93,13 @@ func WaitOnLengthMatched(target int, checkStatus bool) (bool, error) {
 					successChannel <- true
 					return
 				}
-				// if checking for assigned identity count to be 0, then we just check if len matches
-				// but if checking for assigned identity count > 1, apart from checking if the len of
-				// assigned identities is desired, we also check if all the assigned identities are in
-				// desired state
-				if (checkStatus || target != 0) && list.Items != nil && len(list.Items) == target {
+				// check if assigned identities are in desired state
+				if (checkStatus || target != 0) && list.Items != nil {
 					var totalAssigned int
 					for _, item := range list.Items {
-						if item.Status.Status != aadpodid.AssignedIDAssigned {
-							break
+						if item.Status.Status == aadpodid.AssignedIDAssigned {
+							totalAssigned++
 						}
-						totalAssigned++
 					}
 					if totalAssigned == target {
 						successChannel <- true

--- a/test/common/k8s/azureidentity/azureidentity.go
+++ b/test/common/k8s/azureidentity/azureidentity.go
@@ -19,20 +19,24 @@ import (
 
 // CreateOnClusterOld will create an Azure Identity on a Kubernetes cluster
 func CreateOnClusterOld(subscriptionID, resourceGroup, name, templateOutputPath string) error {
-	return CreateOnClusterInternal(subscriptionID, resourceGroup, name, name, "aadpodidentity-old.yaml", templateOutputPath)
+	clientID, err := GetClientID(resourceGroup, name)
+	if err != nil {
+		return err
+	}
+	return CreateOnClusterInternal(subscriptionID, resourceGroup, name, name, clientID, "aadpodidentity-old.yaml", templateOutputPath)
 }
 
 // CreateOnCluster will create an Azure Identity on a Kubernetes cluster
 func CreateOnCluster(subscriptionID, resourceGroup, identity, name, templateOutputPath string) error {
-	return CreateOnClusterInternal(subscriptionID, resourceGroup, identity, name, "aadpodidentity.yaml", templateOutputPath)
-}
-
-// CreateOnClusterInternal will create an Azure Identity on a Kubernetes cluster
-func CreateOnClusterInternal(subscriptionID, resourceGroup, identity, name, templateInputFile, templateOutputPath string) error {
 	clientID, err := GetClientID(resourceGroup, identity)
 	if err != nil {
 		return err
 	}
+	return CreateOnClusterInternal(subscriptionID, resourceGroup, identity, name, clientID, "aadpodidentity.yaml", templateOutputPath)
+}
+
+// CreateOnClusterInternal will create an Azure Identity on a Kubernetes cluster
+func CreateOnClusterInternal(subscriptionID, resourceGroup, identity, name, clientID, templateInputFile, templateOutputPath string) error {
 
 	t, err := template.New(templateInputFile).ParseFiles(path.Join("template", templateInputFile))
 	if err != nil {

--- a/test/e2e/aadpodidentity_test.go
+++ b/test/e2e/aadpodidentity_test.go
@@ -894,6 +894,58 @@ var _ = Describe("Kubernetes cluster using aad-pod-identity", func() {
 
 		validateAzureAssignedIdentity(azureAssignedIdentity, keyvaultIdentity, identity)
 	})
+
+	It("should assign the valid identity to the node when batch assigning identities that contain invalid identities [PR]", func() {
+		// Create three AzureIdentities and AzureIdentityBindings:
+		// one of them is keyvault-identity (valid) and two of which are invalid
+		err := azureidentity.CreateOnCluster(cfg.SubscriptionID, cfg.IdentityResourceGroup, keyvaultIdentity, keyvaultIdentity, templateOutputPath)
+		Expect(err).NotTo(HaveOccurred())
+		err = azureidentitybinding.Create(keyvaultIdentity, keyvaultIdentity, templateOutputPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = azureidentity.CreateOnClusterInternal(cfg.SubscriptionID, cfg.IdentityResourceGroup, "invalid-identity-1", "invalid-identity-1", "00000000-0000-0000-0000-000000000000", "aadpodidentity.yaml", templateOutputPath)
+		Expect(err).NotTo(HaveOccurred())
+		err = azureidentitybinding.Create("invalid-identity-1", keyvaultIdentity, templateOutputPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = azureidentity.CreateOnClusterInternal(cfg.SubscriptionID, cfg.IdentityResourceGroup, "invalid-identity-2", "invalid-identity-2", "00000000-0000-0000-0000-000000000000", "aadpodidentity.yaml", templateOutputPath)
+		Expect(err).NotTo(HaveOccurred())
+		err = azureidentitybinding.Create("invalid-identity-2", keyvaultIdentity, templateOutputPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create an identityvalidator that consumes the three AzureIdentities created above
+		data := infra.IdentityValidatorTemplateData{
+			Name:                     identityValidator,
+			IdentityBinding:          keyvaultIdentity,
+			Registry:                 cfg.Registry,
+			IdentityValidatorVersion: cfg.IdentityValidatorVersion,
+			Replicas:                 "1",
+		}
+		err = infra.CreateIdentityValidator(cfg.SubscriptionID, cfg.IdentityResourceGroup, templateOutputPath, data)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait for one AzureAssignedIdentity to be in "Assigned" state
+		ok, err := azureassignedidentity.WaitOnLengthMatched(1, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		// Wait for all three AzureAssignedIdentities
+		ok, err = azureassignedidentity.WaitOnLengthMatched(3, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(Equal(true))
+
+		azureAssignedIdentities, err := azureassignedidentity.GetAllByPrefix(identityValidator)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, assignedID := range azureAssignedIdentities {
+			if strings.HasSuffix(assignedID.Name, keyvaultIdentity) {
+				validateAzureAssignedIdentity(assignedID, keyvaultIdentity, keyvaultIdentity)
+			} else {
+				// Ensure that AzureAssignedIdentities with invalid identities are in "Created" state
+				Expect(assignedID.Status.Status, aadpodid.AssignedIDCreated)
+			}
+		}
+	})
 })
 
 func GetVMSS(nodeList *node.List) ([]node.Node, string) {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Attempts to extract erroneous user-assigned identities from ARM error message and remove them from the identity update list before retrying.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #599.

**Notes for Reviewers**:
Steps I took to test:
1. Create two AzureIdentities and AzureIdentityBindings, one with valid resource ID and one with resource ID that does not exist
2. Create a pod that consumes the two AzureIdentities
3. Check that there are two AzureAssignedIdentities created. The one with valid resource ID should be in "Assigned" state and the other should be in "Created" state.
3. Check that one of the user-assigned identities is assigned correctly to the underlying node on Azure, and the other one isn't. 