### PR TITLE
ci: set up nightly build and test against master

### DIFF
--- a/.pipelines/nightly.yml
+++ b/.pipelines/nightly.yml
@@ -1,0 +1,22 @@
+trigger: none
+
+schedules:
+  - cron: "0 0 * * *"
+    displayName: "Nightly Build & Test"
+    branches:
+      include:
+        - master
+
+pool:
+  vmImage: ubuntu-latest
+
+jobs:
+  - template: unit-tests-template.yml
+  - template: e2e-tests-template.yml
+    parameters:
+      k8sReleases:
+        - "1.18"
+      clusterConfigs:
+        # File names in test/e2e/cluster_configs without file extension
+        - "vmss"
+        - "vmas"

--- a/.pipelines/pr.yml
+++ b/.pipelines/pr.yml
@@ -1,11 +1,3 @@
-trigger:
-  branches:
-    include:
-      - master
-  paths:
-    exclude:
-      - docs/*
-
 pr:
   branches:
     include:
@@ -18,8 +10,8 @@ pool:
   vmImage: ubuntu-latest
 
 jobs:
-  - template: .pipelines/unit-tests-template.yml
-  - template: .pipelines/e2e-tests-template.yml
+  - template: unit-tests-template.yml
+  - template: e2e-tests-template.yml
     parameters:
       k8sReleases:
         - "1.18"


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Set up nightly build and test against master. I will need to point the current pipeline YAML from `azure-pipelines.yml` to `pr.yml` after this is merged.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
