### PR TITLE
Move exception to a different yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,18 @@ Deploy `aad-pod-identity` components to an RBAC-enabled cluster:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment-rbac.yaml
+
+# For managed identity clusters, deploy the MIC exception by running -
+kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/mic-exception.yaml
 ```
 
 Deploy `aad-pod-identity` components to a non-RBAC cluster:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment.yaml
+
+# For managed identity clusters, deploy the MIC exception by running -
+kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/mic-exception.yaml
 ```
 
 > Important: For AKS clusters with limited [egress-traffic], Please install pod-identity in `kube-system` namespace using the [helm charts].

--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -266,13 +266,3 @@ spec:
           path: /etc/kubernetes/azure.json
       nodeSelector:
         beta.kubernetes.io/os: linux
----
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzurePodIdentityException
-metadata:
-  name: mic-exception
-  namespace: default
-spec:
-  podLabels:
-    app: mic
-    component: mic

--- a/deploy/infra/deployment.yaml
+++ b/deploy/infra/deployment.yaml
@@ -180,13 +180,3 @@ spec:
           path: /etc/kubernetes/azure.json
       nodeSelector:
         beta.kubernetes.io/os: linux
----
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzurePodIdentityException
-metadata:
-  name: mic-exception
-  namespace: default
-spec:
-  podLabels:
-    app: mic
-    component: mic

--- a/deploy/infra/mic-exception.yaml
+++ b/deploy/infra/mic-exception.yaml
@@ -1,0 +1,9 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: mic-exception
+  namespace: default
+spec:
+  podLabels:
+    app: mic
+    component: mic

--- a/deploy/infra/noazurejson/deployment-rbac.yaml
+++ b/deploy/infra/noazurejson/deployment-rbac.yaml
@@ -302,13 +302,3 @@ spec:
           periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
----
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzurePodIdentityException
-metadata:
-  name: mic-exception
-  namespace: default
-spec:
-  podLabels:
-    app: mic
-    component: mic

--- a/deploy/infra/noazurejson/deployment.yaml
+++ b/deploy/infra/noazurejson/deployment.yaml
@@ -220,13 +220,3 @@ spec:
           path: /etc/kubernetes/certs
       nodeSelector:
         beta.kubernetes.io/os: linux
----
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzurePodIdentityException
-metadata:
-  name: mic-exception
-  namespace: default
-spec:
-  podLabels:
-    app: mic
-    component: mic


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
kubectl apply -f `<multi yaml file>` is not processed in order. This could mean in some scenarios the `AzurePodIdentityException` is applied first before the CRD is deployed. With this PR, we are moving the `AzurePodIdentityException` to a separate yaml, so users can apply it after deploying the infra components.

cc @dapolloxp 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
