### PR TITLE
change to 404 instead if no azure identity found

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -36,7 +36,6 @@ func GetServicePrincipalTokenFromMSI(resource string) (*adal.Token, error) {
 		}
 	}()
 
-	// Get the MSI endpoint accoriding with the OS (Linux/Windows)
 	msiEndpoint, err := adal.GetMSIVMEndpoint()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get the MSI endpoint. Error: %v", err)
@@ -74,7 +73,6 @@ func GetServicePrincipalTokenFromMSIWithUserAssignedID(clientID, resource string
 		}
 	}()
 
-	// Get the MSI endpoint accoriding with the OS (Linux/Windows)
 	msiEndpoint, err := adal.GetMSIVMEndpoint()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get the MSI endpoint. Error: %v", err)


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Return `404` for both scenarios - No AzureAssignedIdentity found in `CREATED` or `ASSIGNED` state

When `az login --identity -u <clientID>` command is invoked, the CLI adds the clientID in `client_id` header. When it receives a `400` back, it retries the request with the clientID in the `object_id` header. In this scenario, aad-pod-identity will return the token for the first AzureIdentity that matches the pod as `client_id` is empty. This is not wrong, but could confuse the user as they are not aware of the CLI internals.  The token they receive would be for a different identity.

Instead when a `404` is returned, then CLI still retries consistently with the `client_id` header which is the correct behavior. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
