### PR TITLE
chore: add aks add-on exception in kube-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Deploy `aad-pod-identity` components to an RBAC-enabled cluster:
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment-rbac.yaml
 
-# For managed identity clusters, deploy the MIC exception by running -
+# For AKS clusters, deploy the MIC and AKS add-on exception by running -
 kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/mic-exception.yaml
 ```
 
@@ -128,7 +128,7 @@ Deploy `aad-pod-identity` components to a non-RBAC cluster:
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment.yaml
 
-# For managed identity clusters, deploy the MIC exception by running -
+# For AKS clusters, deploy the MIC and AKS add-on exception by running -
 kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/mic-exception.yaml
 ```
 

--- a/charts/aad-pod-identity/templates/mic-exception.yaml
+++ b/charts/aad-pod-identity/templates/mic-exception.yaml
@@ -8,4 +8,13 @@ spec:
     app: mic
     component: mic
     app.kubernetes.io/component: mic
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: aks-addon-exception
+  namespace: kube-system
+spec:
+  podLabels:
+    kubernetes.azure.com/managedby: aks
 {{- end }}

--- a/deploy/infra/mic-exception.yaml
+++ b/deploy/infra/mic-exception.yaml
@@ -7,3 +7,12 @@ spec:
   podLabels:
     app: mic
     component: mic
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: aks-addon-exception
+  namespace: kube-system
+spec:
+  podLabels:
+    kubernetes.azure.com/managedby: aks


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Adds a default `AzurePodIdentityException` for AKS add-ons in kube-system namespace. This will ensure when aad-pod-identity is deployed on a managed identity cluster, it allows token requests from add-ons in kube-system namespace without pod-identity validation.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
