### PR TITLE
Add ability to pull ClientId and ResourceId from Secrets [WIP]

### DIFF
--- a/pkg/apis/aadpodidentity/v1/conversion.go
+++ b/pkg/apis/aadpodidentity/v1/conversion.go
@@ -34,7 +34,7 @@ func ConvertV1IdentityToInternalIdentity(identity AzureIdentity, c kubernetes.In
 		clientIDSecret, err := getSecret(c, identity.Spec.ClientIDSecretRef.Namespace, identity.Spec.ClientIDSecretRef.Name)
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Unable to retrieve a secret named %s in namespace %s. %s", identity.Spec.ClientIDSecretRef.Name, identity.Spec.ClientIDSecretRef.Namespace, err.Error())
 		}
 
 		for _, v := range clientIDSecret.Data {
@@ -49,7 +49,7 @@ func ConvertV1IdentityToInternalIdentity(identity AzureIdentity, c kubernetes.In
 		resourceIDSecret, err := getSecret(c, identity.Spec.ResourceIDSecretRef.Namespace, identity.Spec.ResourceIDSecretRef.Name)
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Unable to retrieve a secret named %s in namespace %s. %s", identity.Spec.ResourceIDSecretRef.Name, identity.Spec.ResourceIDSecretRef.Namespace, err.Error())
 		}
 
 		for _, v := range resourceIDSecret.Data {

--- a/pkg/apis/aadpodidentity/v1/conversion.go
+++ b/pkg/apis/aadpodidentity/v1/conversion.go
@@ -34,7 +34,7 @@ func ConvertV1IdentityToInternalIdentity(identity AzureIdentity, c kubernetes.In
 		clientIDSecret, err := getSecret(c, identity.Spec.ClientIDSecretRef.Namespace, identity.Spec.ClientIDSecretRef.Name)
 
 		if err != nil {
-			return nil, fmt.Errorf("Unable to retrieve a secret named %s in namespace %s. %s", identity.Spec.ClientIDSecretRef.Name, identity.Spec.ClientIDSecretRef.Namespace, err.Error())
+			return nil, fmt.Errorf("Unable to retrieve a secret named %s in namespace %s. %v", identity.Spec.ClientIDSecretRef.Name, identity.Spec.ClientIDSecretRef.Namespace, err)
 		}
 
 		for _, v := range clientIDSecret.Data {
@@ -49,7 +49,7 @@ func ConvertV1IdentityToInternalIdentity(identity AzureIdentity, c kubernetes.In
 		resourceIDSecret, err := getSecret(c, identity.Spec.ResourceIDSecretRef.Namespace, identity.Spec.ResourceIDSecretRef.Name)
 
 		if err != nil {
-			return nil, fmt.Errorf("Unable to retrieve a secret named %s in namespace %s. %s", identity.Spec.ResourceIDSecretRef.Name, identity.Spec.ResourceIDSecretRef.Namespace, err.Error())
+			return nil, fmt.Errorf("Unable to retrieve a secret named %s in namespace %s. %v", identity.Spec.ResourceIDSecretRef.Name, identity.Spec.ResourceIDSecretRef.Namespace, err)
 		}
 
 		for _, v := range resourceIDSecret.Data {
@@ -199,7 +199,7 @@ func getSecret(c kubernetes.Interface, namespace string, secretName string) (*co
 	secret, err := c.CoreV1().Secrets(namespace).Get(secretName, v1.GetOptions{})
 
 	if err != nil {
-		return nil, fmt.Errorf("get failed for Secret with error: %v", err)
+		return nil, err
 	}
 
 	return secret, err

--- a/pkg/apis/aadpodidentity/v1/conversion_test.go
+++ b/pkg/apis/aadpodidentity/v1/conversion_test.go
@@ -277,6 +277,30 @@ func TestConvertV1IdentityWithSecretClientIdToInternalIdentity(t *testing.T) {
 	}
 }
 
+func TestConvertV1IdentityWithSecretClientIdToInternalIdentityIfNoSecretFound(t *testing.T) {
+	idV1 := CreateV1IdentityWithClientIdSecretRef()
+
+	client := fake.NewSimpleClientset()
+	_, err := ConvertV1IdentityToInternalIdentity(idV1, client)
+
+	errorMessage := "Unable to retrieve a secret named test in namespace test. get failed for Secret with error: secrets \"test\" not found"
+	if !cmp.Equal(errorMessage, err.Error()) {
+		t.Errorf("Error message was not returned")
+	}
+}
+
+func TestConvertV1IdentityWithSecretResourceIdToInternalIdentityIfNoSecretFound(t *testing.T) {
+	idV1 := CreateV1IdentityWithResourceIdSecretRef()
+
+	client := fake.NewSimpleClientset()
+	_, err := ConvertV1IdentityToInternalIdentity(idV1, client)
+
+	errorMessage := "Unable to retrieve a secret named test in namespace test. get failed for Secret with error: secrets \"test\" not found"
+	if !cmp.Equal(errorMessage, err.Error()) {
+		t.Errorf("Error message was not returned")
+	}
+}
+
 func TestConvertV1IdentityWithSecretResourceIdToInternalIdentity(t *testing.T) {
 	idV1 := CreateV1IdentityWithResourceIdSecretRef()
 

--- a/pkg/apis/aadpodidentity/v1/conversion_test.go
+++ b/pkg/apis/aadpodidentity/v1/conversion_test.go
@@ -283,9 +283,13 @@ func TestConvertV1IdentityWithSecretClientIdToInternalIdentityIfNoSecretFound(t 
 	client := fake.NewSimpleClientset()
 	_, err := ConvertV1IdentityToInternalIdentity(idV1, client)
 
-	errorMessage := "Unable to retrieve a secret named test in namespace test. get failed for Secret with error: secrets \"test\" not found"
+	if err == nil {
+		t.Errorf("Error was not returned.")
+	}
+
+	errorMessage := "Unable to retrieve a secret named test in namespace test. secrets \"test\" not found"
 	if !cmp.Equal(errorMessage, err.Error()) {
-		t.Errorf("Error message was not returned")
+		t.Errorf("Error message did not match expected. Expected: %s. Actual: %s", errorMessage, err.Error())
 	}
 }
 
@@ -295,9 +299,13 @@ func TestConvertV1IdentityWithSecretResourceIdToInternalIdentityIfNoSecretFound(
 	client := fake.NewSimpleClientset()
 	_, err := ConvertV1IdentityToInternalIdentity(idV1, client)
 
-	errorMessage := "Unable to retrieve a secret named test in namespace test. get failed for Secret with error: secrets \"test\" not found"
+	if err == nil {
+		t.Errorf("Error was not returned.")
+	}
+
+	errorMessage := "Unable to retrieve a secret named test in namespace test. secrets \"test\" not found"
 	if !cmp.Equal(errorMessage, err.Error()) {
-		t.Errorf("Error message was not returned")
+		t.Errorf("Error message did not match expected. Expected: %s. Actual: %s", errorMessage, err.Error())
 	}
 }
 
@@ -349,7 +357,7 @@ func TestConvertV1AssignedIdentityToInternalAssignedIdentity(t *testing.T) {
 
 	convertedAssignedIDInternal, err = ConvertV1AssignedIdentityToInternalAssignedIdentity(assignedIDV1, nil)
 
-	if err != nil{
+	if err != nil {
 		t.Errorf("Failed to convert from v1 to internal AzureAssignedIdentity")
 	}
 

--- a/pkg/apis/aadpodidentity/v1/conversion_test.go
+++ b/pkg/apis/aadpodidentity/v1/conversion_test.go
@@ -347,7 +347,12 @@ func TestConvertV1AssignedIdentityToInternalAssignedIdentity(t *testing.T) {
 	assignedIDV1.Spec.AzureIdentityRef = nil
 	assignedIDV1.Spec.AzureBindingRef = nil
 
-	convertedAssignedIDInternal, _ = ConvertV1AssignedIdentityToInternalAssignedIdentity(assignedIDV1, nil)
+	convertedAssignedIDInternal, err = ConvertV1AssignedIdentityToInternalAssignedIdentity(assignedIDV1, nil)
+
+	if err != nil{
+		t.Errorf("Failed to convert from v1 to internal AzureAssignedIdentity")
+	}
+
 	assignedIDInternal = CreateInternalAssignedIdentity()
 	assignedIDInternal.Spec.AzureIdentityRef = &aadpodid.AzureIdentity{}
 	assignedIDInternal.Spec.AzureBindingRef = &aadpodid.AzureIdentityBinding{}

--- a/pkg/apis/aadpodidentity/v1/types.go
+++ b/pkg/apis/aadpodidentity/v1/types.go
@@ -119,6 +119,12 @@ type AzureIdentitySpec struct {
 	//Both User Assigned MSI and SP can use this field.
 	ClientID string `json:"clientID"`
 
+	// Secret Reference for a User Assigned MSI resource id.
+	ResourceIDSecretRef *api.SecretReference `json:"resourceidSecretRef,omitempty"`
+
+	// Secret Reference for a Client ID
+	ClientIDSecretRef *api.SecretReference `json:"clientidSecretRef,omitempty"`
+
 	//Used for service principal
 	ClientPassword api.SecretReference `json:"clientPassword"`
 	// Service principal tenant id.

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -530,8 +530,13 @@ func (c *TestCrdClient) ListIds() (res *[]internalaadpodid.AzureIdentity, err er
 	idList := make([]internalaadpodid.AzureIdentity, 0)
 	c.mu.Lock()
 	for _, v := range c.idMap {
-		currID := aadpodid.ConvertV1IdentityToInternalIdentity(*v)
-		idList = append(idList, currID)
+		currID, err := aadpodid.ConvertV1IdentityToInternalIdentity(*v, nil)
+
+		if err != nil {
+			return nil, err
+		}
+
+		idList = append(idList, *currID)
 	}
 	c.mu.Unlock()
 	return &idList, nil


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
This PR allows the ClientId and ResourceId to be pulled from secrets. This allows GitOps flows to work better so that infrastructure can be efficiently deployed anywhere without needing to individually update the `AzureIdentity` configuration.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
This fixes #532 

**Notes for Reviewers**:
This is currently a WIP. Some of the existing tests are broken because of how they compare the converted identity and the internal assigned identity. I'd like to get some feedback on the best way to update the tests so that the correct things are getting tested.

I thought it would make the most sense to put the secret fetching in the conversion helper because that way the internal azure identity would not need to care about secrets. I wasn't super happy about having the add `kubernetes.Interface` to the method signature of the methods though because it is only indirectly needed in some cases. I added tests to ensure that secrets were getting fetched correctly.

I have not done much Go development so would definitely value feedback on if this could be organized/implemented better!