### PR TITLE
chore: disable crd-install when using Helm 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master
 kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/mic-exception.yaml
 ```
 
-Deploy `aad-pod-identity` using Helm:
+Deploy `aad-pod-identity` using [Helm 3](https://v3.helm.sh/):
 
 ```bash
 helm repo add aad-pod-identity https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts

--- a/charts/aad-pod-identity/README.md
+++ b/charts/aad-pod-identity/README.md
@@ -2,52 +2,16 @@
 
 [aad-pod-identity](https://github.com/Azure/aad-pod-identity) enables Kubernetes applications to access cloud resources securely with [Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/) (AAD).
 
-## TL;DR:
+## TL;DR
 
 ```console
-$ helm repo add aad-pod-identity https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts
-$ helm install aad-pod-identity/aad-pod-identity
-```
+helm repo add aad-pod-identity https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts
 
-Expected output:
+# Helm 3
+helm install aad-pod-identity aad-pod-identity/aad-pod-identity
 
-```console
-NAME:   pod-identity
-LAST DEPLOYED: Mon Sep 16 11:47:45 2019
-NAMESPACE: default
-STATUS: DEPLOYED
-
-RESOURCES:
-==> v1/ClusterRole
-NAME                  AGE
-aad-pod-identity-mic  1s
-aad-pod-identity-nmi  1s
-
-==> v1/Pod(related)
-NAME                                  READY  STATUS             RESTARTS  AGE
-aad-pod-identity-mic-9658685f4-vnmwx  0/1    ContainerCreating  0         1s
-aad-pod-identity-mic-9658685f4-xrzmv  0/1    ContainerCreating  0         1s
-aad-pod-identity-nmi-d5hvt            0/1    ContainerCreating  0         1s
-aad-pod-identity-nmi-rq27p            0/1    ContainerCreating  0         1s
-aad-pod-identity-nmi-wdgdf            0/1    ContainerCreating  0         1s
-
-==> v1/ServiceAccount
-NAME                  SECRETS  AGE
-aad-pod-identity-mic  1        1s
-aad-pod-identity-nmi  1        1s
-
-==> v1beta1/ClusterRoleBinding
-NAME                  AGE
-aad-pod-identity-mic  1s
-aad-pod-identity-nmi  1s
-
-==> v1beta1/DaemonSet
-NAME                  DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR                AGE
-aad-pod-identity-nmi  3        3        0      3           0          beta.kubernetes.io/os=linux  1s
-
-==> v1beta1/Deployment
-NAME                  READY  UP-TO-DATE  AVAILABLE  AGE
-aad-pod-identity-mic  0/2    2           0          1s
+# Helm 2
+helm install aad-pod-identity/aad-pod-identity --set=installCRDs=true
 ```
 
 ## Introduction
@@ -71,11 +35,11 @@ The following steps will help you create a new Azure identity ([Managed Service 
 * [Azure Subscription](https://azure.microsoft.com/)
 * [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/services/kubernetes-service/) or [AKS Engine](https://github.com/Azure/aks-engine) deployment
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (authenticated to your Kubernetes cluster)
-* [Helm v2.14+](https://github.com/helm/helm)
+* [Helm 3](https://v3.helm.sh/)
 * [Azure CLI 2.0](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 * [git](https://git-scm.com/downloads)
 
-> Recommended Helm version > `2.14.2`. Issue with CRD during upgrade has been resolved after that release.
+> It is recommended to use [Helm 3](https://v3.helm.sh/) for installation and uninstallation, however, [Helm 2](https://v2.helm.sh/) is also supported.
 
 <details>
 <summary><strong>[Optional] Creating user identity</strong></summary>
@@ -109,7 +73,7 @@ adminsecret:
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release aad-pod-identity/aad-pod-identity
+helm install --name my-release aad-pod-identity/aad-pod-identity
 ```
 
 Deploy your application to Kubernetes. The application can use [ADAL](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-authentication-libraries) to request a token from the MSI endpoint as usual. If you do not currently have such an application, a demo application is available [here](https://github.com/Azure/aad-pod-identity#demo-app). If you do use the demo application, please update the `deployment.yaml` with the appropriate subscription ID, client ID and resource group name. Also make sure the selector you defined in your `AzureIdentityBinding` matches the `aadpodidbinding` label on the deployment.
@@ -119,8 +83,13 @@ Deploy your application to Kubernetes. The application can use [ADAL](https://do
 To uninstall/delete the last deployment:
 
 ```console
-$ helm ls
-$ helm delete [last deployment] --purge
+helm ls
+
+# Helm 3
+helm uninstall <ReleaseName>
+
+# Helm 2
+helm delete <ReleaseName> --purge
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -191,34 +160,35 @@ The following tables list the configurable parameters of the aad-pod-identity ch
 | `mic.logVerbosity`                       | Log level. Uses V logs (glog)                                                                                                                                                                                                                                                                                                 | `0`                                                            |
 | `mic.resources`                          | Resource limit for MIC                                                                                                                                                                                                                                                                                                        | `{}`                                                           |
 | `mic.podAnnotations`                     | Pod annotations for MIC                                                                                                                                                                                                                                                                                                       | `{}`                                                           |
-| `mic.tolerations`                        | Affinity settings                                                                                                                                                                                                                                                                                                             | `{}`                                                           |
-| `mic.affinity`                           | List of node taints to tolerate                                                                                                                                                                                                                                                                                               | `[]`                                                           |
+| `mic.tolerations`                        | Affinity settings                                                                                                                                                                                                                                                                                                              | `{}`                                                           |
+| `mic.affinity`                            | List of node taints to tolerate                                                                                                                                                                                                                                                                                               | `[]`                                                           |
 | `mic.leaderElection.instance`            | Override leader election instance name                                                                                                                                                                                                                                                                                        | If not provided, default value is `hostname`                   |
 | `mic.leaderElection.namespace`           | Override the namespace to create leader election objects                                                                                                                                                                                                                                                                      | `default`                                                      |
 | `mic.leaderElection.name`                | Override leader election name                                                                                                                                                                                                                                                                                                 | If not provided, default value is `aad-pod-identity-mic`       |
 | `mic.leaderElection.duration`            | Override leader election duration                                                                                                                                                                                                                                                                                             | If not provided, default value is `15s`                        |
 | `mic.probePort`                          | Override http liveliness probe port                                                                                                                                                                                                                                                                                           | If not provided, default port is `8080`                        |
 | `mic.syncRetryDuration`                  | Override interval in seconds at which sync loop should periodically check for errors and reconcile                                                                                                                                                                                                                            | If not provided, default value is `3600s`                      |
-| `mic.immutableUserMSIs`                  | List of  user-defined identities that shouldn't be deleted from VM/VMSS.                                                                                                                                                                                                                                                      | If not provided, default value is empty                        |
-| `mic.cloudConfig`                        | The cloud configuration used to authenticate with Azure                                                                                                                                                                                                                                                                       | If not provided, default value is `/etc/kubernetes/azure.json` |
-| `mic.updateUserMSIMaxRetry`                        | The maximum retry of UpdateUserMSI call in case of assignment errors                                                                                                                                                                                                                                                                   | If not provided, default value is `2` |
-| `mic.updateUserMSIRetryInterval`                        | The duration to wait before retrying UpdateUserMSI (batch assigning/un-assigning identity from VM/VMSS) in case of errors                                                                                                                                                                                                                                                                       | If not provided, default value is `1s` |
+| `mic.immutableUserMSIs`                  | List of  user-defined identities that shouldn't be deleted from VM/VMSS.                                                                                                                                                                                                                                                       | If not provided, default value is empty                        |
+| `mic.cloudConfig`                         | The cloud configuration used to authenticate with Azure                                                                                                                                                                                                                                                                        | If not provided, default value is `/etc/kubernetes/azure.json` |
+| `mic.updateUserMSIMaxRetry`              | The maximum retry of UpdateUserMSI call in case of assignment errors                                                                                                                                                                                                                                                          | If not provided, default value is `2`                          |
+| `mic.updateUserMSIRetryInterval`         | The duration to wait before retrying UpdateUserMSI (batch assigning/un-assigning identity from VM/VMSS) in case of errors                                                                                                                                                                                                     | If not provided, default value is `1s`                         |
 | `nmi.image`                              | NMI image name                                                                                                                                                                                                                                                                                                                | `nmi`                                                          |
 | `nmi.tag`                                | NMI image tag                                                                                                                                                                                                                                                                                                                 | `1.6.1`                                                        |
 | `nmi.PriorityClassName`                  | NMI priority class (can only be set when deploying to kube-system namespace)                                                                                                                                                                                                                                                  |                                                                |
 | `nmi.resources`                          | Resource limit for NMI                                                                                                                                                                                                                                                                                                        | `{}`                                                           |
 | `nmi.podAnnotations`                     | Pod annotations for NMI                                                                                                                                                                                                                                                                                                       | `{}`                                                           |
-| `nmi.tolerations`                        | Affinity settings                                                                                                                                                                                                                                                                                                             | `{}`                                                           |
-| `nmi.affinity`                           | List of node taints to tolerate                                                                                                                                                                                                                                                                                               | `[]`                                                           |
+| `nmi.tolerations`                        | Affinity settings                                                                                                                                                                                                                                                                                                              | `{}`                                                           |
+| `nmi.affinity`                            | List of node taints to tolerate                                                                                                                                                                                                                                                                                               | `[]`                                                           |
 | `nmi.ipTableUpdateTimeIntervalInSeconds` | Override iptables update interval in seconds                                                                                                                                                                                                                                                                                  | `60`                                                           |
 | `nmi.micNamespace`                       | Override mic namespace to short circuit MIC token requests                                                                                                                                                                                                                                                                    | If not provided, default is `default` namespace                |
 | `nmi.probePort`                          | Override http liveliness probe port                                                                                                                                                                                                                                                                                           | If not provided, default is `8080`                             |
-| `nmi.retryAttemptsForCreated`            | Override number of retries in NMI to find assigned identity in CREATED state                                                                                                                                                                                                                                                  | If not provided, default is  `16`                              |
-| `nmi.retryAttemptsForAssigned`           | Override number of retries in NMI to find assigned identity in ASSIGNED state                                                                                                                                                                                                                                                 | If not provided, default is  `4`                               |
-| `nmi.findIdentityRetryIntervalInSeconds` | Override retry interval to find assigned identities in seconds                                                                                                                                                                                                                                                                | If not provided, default is  `5`                               |
+| `nmi.retryAttemptsForCreated`            | Override number of retries in NMI to find assigned identity in CREATED state                                                                                                                                                                                                                                                   | If not provided, default is  `16`                              |
+| `nmi.retryAttemptsForAssigned`           | Override number of retries in NMI to find assigned identity in ASSIGNED state                                                                                                                                                                                                                                                  | If not provided, default is  `4`                               |
+| `nmi.findIdentityRetryIntervalInSeconds`  | Override retry interval to find assigned identities in seconds                                                                                                                                                                                                                                                                 | If not provided, default is  `5`                               |
 | `rbac.enabled`                           | Create and use RBAC for all aad-pod-identity resources                                                                                                                                                                                                                                                                        | `true`                                                         |
 | `rbac.allowAccessToSecrets`              | NMI requires permissions to get secrets when service principal (type: 1) is used in AzureIdentity. If using only MSI (type: 0) in AzureIdentity, secret get permission can be disabled by setting this to false.                                                                                                              | `true`                                                         |
 | `azureIdentities`                        | List of azure identities and azure identity bindings resources to create                                                                                                                                                                                                                                                      | `[]`                                                           |
+| `installCRDs`                            | If true, install necessary custom resources                                                                                                                                                                                                                                                                                   | `false`                                                        |
 
 ## Troubleshooting
 

--- a/charts/aad-pod-identity/templates/crds.yaml
+++ b/charts/aad-pod-identity/templates/crds.yaml
@@ -1,4 +1,6 @@
+{{- if .Values.installCRDs }}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
   {{ $.Files.Get $path }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/aad-pod-identity/values.yaml
+++ b/charts/aad-pod-identity/values.yaml
@@ -190,3 +190,6 @@ azureIdentities: []
   #     name: "azure-identity-binding"
   #     # The selector will also need to be included in labels for app deployment
   #     selector: "demo"
+
+# If true, install necessary custom resources.
+installCRDs: false


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->


**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Disable crd-install when using Helm 3.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #626

**Notes for Reviewers**:
