### PR TITLE
Adjust CRDs in the Helm chart to v1 specification and be backward compatible

### DIFF
--- a/charts/aad-pod-identity/Chart.yaml
+++ b/charts/aad-pod-identity/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Deploy components for aad-pod-identity
 name: aad-pod-identity
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.6.1
 home: https://github.com/Azure/aad-pod-identity
 sources:

--- a/charts/aad-pod-identity/crds/crd.yaml
+++ b/charts/aad-pod-identity/crds/crd.yaml
@@ -23,6 +23,9 @@ spec:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
   {{- end }}
   names:
     kind: AzureAssignedIdentity
@@ -49,6 +52,9 @@ spec:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
   {{- end }}
   names:
     kind: AzureIdentityBinding
@@ -75,6 +81,9 @@ spec:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
   {{- end }}
   names:
     kind: AzureIdentity
@@ -102,6 +111,9 @@ spec:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
   {{- end }}
   names:
     kind: AzurePodIdentityException

--- a/charts/aad-pod-identity/crds/crd.yaml
+++ b/charts/aad-pod-identity/crds/crd.yaml
@@ -1,4 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+{{- if (index .Values "aad-pod-identity").enabled -}}
+{{- $apiVersion := "apiextensions.k8s.io/v1beta1" -}}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" -}}
+{{- $apiVersion = "apiextensions.k8s.io/v1" -}}
+{{- end }}
+apiVersion: {{ $apiVersion | quote }}
 kind: CustomResourceDefinition
 metadata:
   name: azureassignedidentities.aadpodidentity.k8s.io
@@ -11,13 +16,20 @@ metadata:
     helm.sh/chart: aad-pod-identity
 spec:
   group: aadpodidentity.k8s.io
+  {{- if eq $apiVersion "apiextensions.k8s.io/v1beta1" }}
   version: v1
+  {{- else }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  {{- end }}
   names:
     kind: AzureAssignedIdentity
     plural: azureassignedidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ $apiVersion | quote }}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentitybindings.aadpodidentity.k8s.io
@@ -30,13 +42,20 @@ metadata:
     helm.sh/chart: aad-pod-identity
 spec:
   group: aadpodidentity.k8s.io
+  {{- if eq $apiVersion "apiextensions.k8s.io/v1beta1" }}
   version: v1
+  {{- else }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  {{- end }}
   names:
     kind: AzureIdentityBinding
     plural: azureidentitybindings
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ $apiVersion | quote }}
 kind: CustomResourceDefinition
 metadata:
   name: azureidentities.aadpodidentity.k8s.io
@@ -49,14 +68,21 @@ metadata:
     helm.sh/chart: aad-pod-identity
 spec:
   group: aadpodidentity.k8s.io
+  {{- if eq $apiVersion "apiextensions.k8s.io/v1beta1" }}
   version: v1
+  {{- else }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  {{- end }}
   names:
     kind: AzureIdentity
     singular: azureidentity
     plural: azureidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ $apiVersion | quote }}
 kind: CustomResourceDefinition
 metadata:
   name: azurepodidentityexceptions.aadpodidentity.k8s.io
@@ -69,7 +95,14 @@ metadata:
     helm.sh/chart: aad-pod-identity
 spec:
   group: aadpodidentity.k8s.io
+  {{- if eq $apiVersion "apiextensions.k8s.io/v1beta1" }}
   version: v1
+  {{- else }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  {{- end }}
   names:
     kind: AzurePodIdentityException
     singular: azurepodidentityexception


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
It allows using the Helm chart on Kubernetes clusters in version 1.16 and above.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
