### PR TITLE
update node selector label to kubernetes.io/os

### DIFF
--- a/charts/aad-pod-identity/values.yaml
+++ b/charts/aad-pod-identity/values.yaml
@@ -58,7 +58,7 @@ mic:
   ## Node labels for pod assignment
   ## aad-pod-identity is currently only supported on linux
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
   tolerations: []
 
@@ -130,7 +130,7 @@ nmi:
   ## Node labels for pod assignment
   ## aad-pod-identity is currently only supported on linux
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
   tolerations: []
 

--- a/deploy/demo/deployment.yaml
+++ b/deploy/demo/deployment.yaml
@@ -41,4 +41,4 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -157,7 +157,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -265,4 +265,4 @@ spec:
         hostPath:
           path: /etc/kubernetes/azure.json
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/deploy/infra/deployment.yaml
+++ b/deploy/infra/deployment.yaml
@@ -113,7 +113,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -179,4 +179,4 @@ spec:
         hostPath:
           path: /etc/kubernetes/azure.json
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/deploy/infra/managed-mode-deployment.yaml
+++ b/deploy/infra/managed-mode-deployment.yaml
@@ -144,4 +144,4 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/deploy/infra/noazurejson/deployment-rbac.yaml
+++ b/deploy/infra/noazurejson/deployment-rbac.yaml
@@ -155,7 +155,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -301,4 +301,4 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/deploy/infra/noazurejson/deployment.yaml
+++ b/deploy/infra/noazurejson/deployment.yaml
@@ -111,7 +111,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: v1
 data:
@@ -219,4 +219,4 @@ spec:
         hostPath:
           path: /etc/kubernetes/certs
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/test/e2e/template/busyboxds.yaml
+++ b/test/e2e/template/busyboxds.yaml
@@ -23,4 +23,4 @@ spec:
             add:
             - NET_ADMIN
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/test/e2e/template/deployment-rbac-old.yaml
+++ b/test/e2e/template/deployment-rbac-old.yaml
@@ -121,7 +121,7 @@ spec:
             add:
             - NET_ADMIN
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -199,3 +199,5 @@ spec:
       - name: k8s-azure-file
         hostPath:
           path: /etc/kubernetes/azure.json
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/test/e2e/template/deployment-rbac.yaml
+++ b/test/e2e/template/deployment-rbac.yaml
@@ -149,7 +149,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -257,3 +257,5 @@ spec:
       - name: k8s-azure-file
         hostPath:
           path: /etc/kubernetes/azure.json
+      nodeSelector:
+        kubernetes.io/os: linux


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Replacing deprecated labels `beta.kubernetes.io/os` with `kubernetes.io/os` which is GA since 1.14. `beta.kubernetes.io/os` will be deprecated in upcoming release 1.19.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/645

**Notes for Reviewers**:
