### PR TITLE
test: convert e2e test cases from old to new framework (part 2)

### DIFF
--- a/test/e2e_new/disruptive_test.go
+++ b/test/e2e_new/disruptive_test.go
@@ -1,0 +1,17 @@
+// +build e2e_new
+
+package e2e_new
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("When AAD Pod Identity operations are disrupted", func() {
+	It("should establish a new AzureAssignedIdentity and remove the old one when re-scheduling identity validator", func() {
+
+	})
+
+	It("should pass multiple identity validating test even when MIC is failing over", func() {
+
+	})
+})

--- a/test/e2e_new/framework/azure/azure_helpers.go
+++ b/test/e2e_new/framework/azure/azure_helpers.go
@@ -53,7 +53,10 @@ func (c *client) GetIdentityClientID(identityName string) string {
 	}
 
 	result, err := c.msiClient.Get(context.TODO(), c.config.IdentityResourceGroup, identityName)
-	Expect(err).To(BeNil())
+	if err != nil {
+		// Dummy client ID
+		return "00000000-0000-0000-0000-000000000000"
+	}
 
 	clientID := result.UserAssignedIdentityProperties.ClientID.String()
 	c.identityClientIDMap[identityName] = clientID

--- a/test/e2e_new/framework/interfaces.go
+++ b/test/e2e_new/framework/interfaces.go
@@ -31,6 +31,11 @@ type Deleter interface {
 	Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error
 }
 
+// Updater can update resources.
+type Updater interface {
+	Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error
+}
+
 // GetLister can get and list resources.
 type GetLister interface {
 	Getter

--- a/test/e2e_new/framework/iptables/iptables_helpers.go
+++ b/test/e2e_new/framework/iptables/iptables_helpers.go
@@ -64,7 +64,8 @@ func WaitForRules(input WaitForRulesInput) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						HostNetwork: true,
+						HostNetwork:                   true,
+						TerminationGracePeriodSeconds: to.Int64Ptr(int64(0)),
 						Containers: []corev1.Container{
 							{
 								Name:  "busybox",

--- a/test/e2e_new/identity_exception_test.go
+++ b/test/e2e_new/identity_exception_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ = Describe("When deploying AzurePodIdentityException", func() {
-	It("should pass validation by bypassing nmi using azurepodidentityexception crd", func() {
+	It("should pass validation by bypassing nmi using AzurePodIdentityException CRD", func() {
 
 	})
 })

--- a/test/e2e_new/init_containers_test.go
+++ b/test/e2e_new/init_containers_test.go
@@ -1,0 +1,91 @@
+// +build e2e_new
+
+package e2e_new
+
+import (
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureassignedidentity"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureidentity"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureidentitybinding"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/identityvalidator"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/namespace"
+
+	. "github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("[PR] When init containers are enabled", func() {
+	var (
+		specName             = "init-container"
+		ns                   *corev1.Namespace
+		azureIdentity        *aadpodv1.AzureIdentity
+		azureIdentityBinding *aadpodv1.AzureIdentityBinding
+		identityValidator    *corev1.Pod
+	)
+
+	BeforeEach(func() {
+		ns = namespace.Create(namespace.CreateInput{
+			Creator: kubeClient,
+			Name:    specName,
+		})
+
+		azureIdentity = azureidentity.Create(azureidentity.CreateInput{
+			Creator:      kubeClient,
+			Config:       config,
+			AzureClient:  azureClient,
+			Name:         keyvaultIdentity,
+			Namespace:    ns.Name,
+			IdentityType: aadpodv1.UserAssignedMSI,
+			IdentityName: keyvaultIdentity,
+		})
+
+		azureIdentityBinding = azureidentitybinding.Create(azureidentitybinding.CreateInput{
+			Creator:           kubeClient,
+			Name:              keyvaultIdentityBinding,
+			Namespace:         ns.Name,
+			AzureIdentityName: azureIdentity.Name,
+			Selector:          keyvaultIdentitySelector,
+		})
+
+		identityValidator = identityvalidator.Create(identityvalidator.CreateInput{
+			Creator:         kubeClient,
+			Config:          config,
+			Namespace:       ns.Name,
+			IdentityBinding: azureIdentityBinding.Spec.Selector,
+			InitContainer:   true,
+		})
+
+		azureassignedidentity.Wait(azureassignedidentity.WaitInput{
+			Getter:            kubeClient,
+			PodName:           identityValidator.Name,
+			Namespace:         ns.Name,
+			AzureIdentityName: azureIdentity.Name,
+			StateToWaitFor:    aadpodv1.AssignedIDAssigned,
+		})
+	})
+
+	AfterEach(func() {
+		namespace.Delete(namespace.DeleteInput{
+			Deleter:   kubeClient,
+			Getter:    kubeClient,
+			Namespace: ns,
+		})
+
+		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
+			Lister: kubeClient,
+			Len:    0,
+		})
+	})
+
+	It("should assign identity with init container", func() {
+		identityvalidator.Validate(identityvalidator.ValidateInput{
+			Getter:           kubeClient,
+			Config:           config,
+			KubeconfigPath:   kubeconfigPath,
+			PodName:          identityValidator.Name,
+			Namespace:        ns.Name,
+			IdentityClientID: azureIdentity.Spec.ClientID,
+			InitContainer:    true,
+		})
+	})
+})

--- a/test/e2e_new/invalid_identities_test.go
+++ b/test/e2e_new/invalid_identities_test.go
@@ -3,19 +3,165 @@
 package e2e_new
 
 import (
+	"fmt"
+
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureassignedidentity"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureidentity"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureidentitybinding"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/identityvalidator"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/namespace"
+
 	. "github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("When deploying invalid identities", func() {
-	It("should pass identity validation with correct identity and fail with wrong identity", func() {
+var _ = Describe("[PR] When deploying invalid identities", func() {
+	var (
+		specName              = "invalid-identities"
+		ns                    *corev1.Namespace
+		azureIdentities       = make([]*aadpodv1.AzureIdentity, 3)
+		azureIdentityBindings = make([]*aadpodv1.AzureIdentityBinding, 3)
+	)
 
+	BeforeEach(func() {
+		ns = namespace.Create(namespace.CreateInput{
+			Creator: kubeClient,
+			Name:    specName,
+		})
+
+		for i, identityName := range []string{keyvaultIdentity, "invalid-identity-1", "invalid-identity-2"} {
+			azureIdentities[i] = azureidentity.Create(azureidentity.CreateInput{
+				Creator:      kubeClient,
+				Config:       config,
+				AzureClient:  azureClient,
+				Name:         identityName,
+				Namespace:    ns.Name,
+				IdentityType: aadpodv1.UserAssignedMSI,
+				IdentityName: identityName,
+			})
+
+			azureIdentityBindings[i] = azureidentitybinding.Create(azureidentitybinding.CreateInput{
+				Creator:           kubeClient,
+				Name:              fmt.Sprintf("%s-binding", identityName),
+				Namespace:         ns.Name,
+				AzureIdentityName: identityName,
+				Selector:          fmt.Sprintf("%s-selector", identityName),
+			})
+		}
+	})
+
+	AfterEach(func() {
+		namespace.Delete(namespace.DeleteInput{
+			Deleter:   kubeClient,
+			Getter:    kubeClient,
+			Namespace: ns,
+		})
+
+		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
+			Lister: kubeClient,
+			Len:    0,
+		})
 	})
 
 	It("should assign the valid identity to the node when batch assigning identities that contain invalid identities", func() {
+		identityValidators := identityvalidator.CreateBatch(identityvalidator.CreateBatchInput{
+			Creator:          kubeClient,
+			Config:           config,
+			Namespace:        ns.Name,
+			IdentityBindings: azureIdentityBindings,
+		})
 
+		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
+			Lister: kubeClient,
+			Len:    3,
+		})
+
+		for i, tc := range []struct {
+			stateToWaitFor string
+			noError        bool
+		}{
+			{
+				stateToWaitFor: aadpodv1.AssignedIDAssigned,
+				noError:        true,
+			},
+			{
+				stateToWaitFor: aadpodv1.AssignedIDCreated,
+			},
+			{
+				stateToWaitFor: aadpodv1.AssignedIDCreated,
+			},
+		} {
+			azureassignedidentity.Wait(azureassignedidentity.WaitInput{
+				Getter:            kubeClient,
+				PodName:           identityValidators[i].Name,
+				Namespace:         ns.Name,
+				AzureIdentityName: azureIdentities[i].Name,
+				StateToWaitFor:    tc.stateToWaitFor,
+			})
+
+			if tc.noError {
+				identityvalidator.Validate(identityvalidator.ValidateInput{
+					Getter:           kubeClient,
+					Config:           config,
+					KubeconfigPath:   kubeconfigPath,
+					PodName:          identityValidators[i].Name,
+					Namespace:        ns.Name,
+					IdentityClientID: azureIdentities[i].Spec.ClientID,
+				})
+			}
+		}
 	})
 
 	It("should not unassign existing identity if we assign invalid identities", func() {
+		validIdentityValidator := identityvalidator.Create(identityvalidator.CreateInput{
+			Creator:         kubeClient,
+			Config:          config,
+			Namespace:       ns.Name,
+			IdentityBinding: azureIdentityBindings[0].Spec.Selector,
+		})
 
+		azureassignedidentity.Wait(azureassignedidentity.WaitInput{
+			Getter:            kubeClient,
+			PodName:           validIdentityValidator.Name,
+			Namespace:         ns.Name,
+			AzureIdentityName: azureIdentities[0].Name,
+			StateToWaitFor:    aadpodv1.AssignedIDAssigned,
+		})
+
+		identityvalidator.Validate(identityvalidator.ValidateInput{
+			Getter:           kubeClient,
+			Config:           config,
+			KubeconfigPath:   kubeconfigPath,
+			PodName:          validIdentityValidator.Name,
+			Namespace:        ns.Name,
+			IdentityClientID: azureIdentities[0].Spec.ClientID,
+		})
+
+		invalidIdentityValidators := identityvalidator.CreateBatch(identityvalidator.CreateBatchInput{
+			Creator:          kubeClient,
+			Config:           config,
+			Namespace:        ns.Name,
+			IdentityBindings: azureIdentityBindings[1:],
+		})
+
+		for i := 0; i < 2; i++ {
+			azureassignedidentity.Wait(azureassignedidentity.WaitInput{
+				Getter:            kubeClient,
+				PodName:           invalidIdentityValidators[i].Name,
+				Namespace:         ns.Name,
+				AzureIdentityName: azureIdentities[i+1].Name,
+				StateToWaitFor:    aadpodv1.AssignedIDCreated,
+			})
+		}
+
+		identityvalidator.Validate(identityvalidator.ValidateInput{
+			Getter:           kubeClient,
+			Config:           config,
+			KubeconfigPath:   kubeconfigPath,
+			PodName:          validIdentityValidator.Name,
+			Namespace:        ns.Name,
+			IdentityClientID: azureIdentities[0].Spec.ClientID,
+		})
 	})
 })

--- a/test/e2e_new/liveness_probe_test.go
+++ b/test/e2e_new/liveness_probe_test.go
@@ -1,0 +1,13 @@
+// +build e2e_new
+
+package e2e_new
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("When liveness probe is enabled", func() {
+	It("should pass liveness probe test", func() {
+
+	})
+})

--- a/test/e2e_new/multiple_identities_test.go
+++ b/test/e2e_new/multiple_identities_test.go
@@ -97,6 +97,7 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 			})
 
 			identityvalidator.Validate(identityvalidator.ValidateInput{
+				Getter:           kubeClient,
 				Config:           config,
 				KubeconfigPath:   kubeconfigPath,
 				PodName:          identityValidators[i].Name,
@@ -125,6 +126,7 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 				})
 
 				identityvalidator.Validate(identityvalidator.ValidateInput{
+					Getter:           kubeClient,
 					Config:           config,
 					KubeconfigPath:   kubeconfigPath,
 					PodName:          identityValidators[j].Name,
@@ -148,6 +150,11 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 			IdentityBindings: expandedAzureIdentityBindings,
 		})
 
+		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
+			Lister: kubeClient,
+			Len:    40,
+		})
+
 		start := time.Now()
 		for i := 0; i < 40; i++ {
 			azureassignedidentity.Wait(azureassignedidentity.WaitInput{
@@ -159,6 +166,7 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 			})
 
 			identityvalidator.Validate(identityvalidator.ValidateInput{
+				Getter:           kubeClient,
 				Config:           config,
 				KubeconfigPath:   kubeconfigPath,
 				PodName:          identityValidators[i].Name,


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Follow-up PR for #650.

Converted the following test cases from old to new framework:
`should assign the valid identity to the node when batch assigning identities that contain invalid identities`
`should not unassign existing identity if we assign invalid identities`
`should pass identity validation with correct identity and fail with wrong identity`
`should update AzureAssignedIdentity and when AzureIdentity fields are updated`
`should assign identity with init container`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

ref: #586, #657

**Notes for Reviewers**:
