### PR TITLE
test: convert e2e test cases from old to new framework (part 4)

### DIFF
--- a/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -75,7 +75,9 @@ spec:
           {{- if .Values.nmi.metadataHeaderRequired}}
           - --metadata-header-required={{ .Values.nmi.metadataHeaderRequired }}
           {{- end }}
+          {{- if semverCompare ">= 1.6.0" .Values.nmi.tag }}
           - --operation-mode={{ .Values.operationMode }}
+          {{- end}}
           {{- if eq .Values.operationMode "managed" }}
           - --forceNamespaced
           {{- end }}

--- a/test/e2e_new/backward_compat_test.go
+++ b/test/e2e_new/backward_compat_test.go
@@ -3,11 +3,126 @@
 package e2e_new
 
 import (
+	"fmt"
+	"os"
+	"time"
+
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureassignedidentity"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureidentity"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureidentitybinding"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/exec"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/helm"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/identityvalidator"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/namespace"
+	corev1 "k8s.io/api/core/v1"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("When upgrading AAD Pod Identity", func() {
-	It("should be backward compatible with old and new version of mic and nmi", func() {
+var _ = Describe("[PR] When upgrading AAD Pod Identity", func() {
+	var (
+		specName                 = "backward-compat"
+		ns                       *corev1.Namespace
+		keyvaultIdentityBinding  = fmt.Sprintf("%s-binding", keyvaultIdentity)
+		keyvaultIdentitySelector = fmt.Sprintf("%s-selector", keyvaultIdentity)
+	)
 
+	BeforeEach(func() {
+		ns = namespace.Create(namespace.CreateInput{
+			Creator: kubeClient,
+			Name:    specName,
+		})
+	})
+
+	AfterEach(func() {
+		namespace.Delete(namespace.DeleteInput{
+			Deleter:   kubeClient,
+			Getter:    kubeClient,
+			Namespace: ns,
+		})
+
+		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
+			Lister: kubeClient,
+			Len:    0,
+		})
+	})
+
+	It("should be backward compatible with old and new version of MIC and NMI", func() {
+		helm.Uninstall()
+
+		By("Deleting the ConfigMap used to store upgrade information")
+		err := exec.KubectlDelete(kubeconfigPath, corev1.NamespaceDefault, []string{
+			"--ignore-not-found",
+			"cm",
+			"aad-pod-identity-config",
+		})
+		Expect(err).To(BeNil())
+
+		configOldVersion := config.DeepCopy()
+		configOldVersion.Registry = "mcr.microsoft.com/k8s/aad-pod-identity"
+		configOldVersion.MICVersion = "1.5"
+		configOldVersion.NMIVersion = "1.5"
+		helm.Install(helm.InstallInput{
+			Config: configOldVersion,
+		})
+
+		azureIdentityFile, identityClientID := azureidentity.CreateOld(azureidentity.CreateInput{
+			Config:       config,
+			AzureClient:  azureClient,
+			Name:         keyvaultIdentity,
+			Namespace:    ns.Name,
+			IdentityType: aadpodv1.UserAssignedMSI,
+			IdentityName: keyvaultIdentity,
+		})
+		defer os.Remove(azureIdentityFile)
+
+		err = exec.KubectlApply(kubeconfigPath, ns.Name, []string{"-f", azureIdentityFile})
+		Expect(err).To(BeNil())
+
+		azureIdentityBindingFile := azureidentitybinding.CreateOld(azureidentitybinding.CreateInput{
+			Name:              keyvaultIdentityBinding,
+			Namespace:         ns.Name,
+			AzureIdentityName: keyvaultIdentity,
+			Selector:          keyvaultIdentitySelector,
+		})
+		defer os.Remove(azureIdentityBindingFile)
+
+		err = exec.KubectlApply(kubeconfigPath, ns.Name, []string{"-f", azureIdentityBindingFile})
+		Expect(err).To(BeNil())
+
+		identityValidator := identityvalidator.Create(identityvalidator.CreateInput{
+			Creator:         kubeClient,
+			Config:          config,
+			Namespace:       ns.Name,
+			IdentityBinding: keyvaultIdentitySelector,
+		})
+
+		// We won't be able to wait for AzureAssignedIdentity to be Assigned
+		// due to change in JSON fields introduced in #398
+		// So wait for 60 seconds, which is enough for an identity to be assigned to a VMAS & VMSS node
+		By("Waiting for the identity to get assigned to the node")
+		time.Sleep(60 * time.Second)
+
+		identityvalidator.Validate(identityvalidator.ValidateInput{
+			Getter:           kubeClient,
+			Config:           config,
+			KubeconfigPath:   kubeconfigPath,
+			PodName:          identityValidator.Name,
+			Namespace:        ns.Name,
+			IdentityClientID: identityClientID,
+		})
+
+		helm.Upgrade(config)
+
+		identityvalidator.Validate(identityvalidator.ValidateInput{
+			Getter:           kubeClient,
+			Config:           config,
+			KubeconfigPath:   kubeconfigPath,
+			PodName:          identityValidator.Name,
+			Namespace:        ns.Name,
+			IdentityClientID: identityClientID,
+		})
 	})
 })

--- a/test/e2e_new/disruptive_test.go
+++ b/test/e2e_new/disruptive_test.go
@@ -3,15 +3,98 @@
 package e2e_new
 
 import (
+	"sync"
+
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureassignedidentity"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureidentity"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/azureidentitybinding"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/identityvalidator"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/mic"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/namespace"
+	corev1 "k8s.io/api/core/v1"
+
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = Describe("When AAD Pod Identity operations are disrupted", func() {
-	It("should establish a new AzureAssignedIdentity and remove the old one when re-scheduling identity validator", func() {
+var _ = Describe("[PR] When AAD Pod Identity operations are disrupted", func() {
+	var (
+		specName = "disruptive"
+		ns       *corev1.Namespace
+	)
 
+	BeforeEach(func() {
+		ns = namespace.Create(namespace.CreateInput{
+			Creator: kubeClient,
+			Name:    specName,
+		})
 	})
 
-	It("should pass multiple identity validating test even when MIC is failing over", func() {
+	AfterEach(func() {
+		namespace.Delete(namespace.DeleteInput{
+			Deleter:   kubeClient,
+			Getter:    kubeClient,
+			Namespace: ns,
+		})
+	})
 
+	It("should pass the identity validation even when MIC leader is changed", func() {
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			mic.DeleteLeader(mic.DeleteLeaderInput{
+				Getter:  kubeClient,
+				Deleter: kubeClient,
+			})
+		}()
+
+		go func() {
+			defer wg.Done()
+			azureIdentity := azureidentity.Create(azureidentity.CreateInput{
+				Creator:      kubeClient,
+				Config:       config,
+				AzureClient:  azureClient,
+				Name:         keyvaultIdentity,
+				Namespace:    ns.Name,
+				IdentityType: aadpodv1.UserAssignedMSI,
+				IdentityName: keyvaultIdentity,
+			})
+
+			azureIdentityBinding := azureidentitybinding.Create(azureidentitybinding.CreateInput{
+				Creator:           kubeClient,
+				Name:              keyvaultIdentityBinding,
+				Namespace:         ns.Name,
+				AzureIdentityName: azureIdentity.Name,
+				Selector:          keyvaultIdentitySelector,
+			})
+
+			identityValidator := identityvalidator.Create(identityvalidator.CreateInput{
+				Creator:         kubeClient,
+				Config:          config,
+				Namespace:       ns.Name,
+				IdentityBinding: azureIdentityBinding.Spec.Selector,
+			})
+
+			azureassignedidentity.Wait(azureassignedidentity.WaitInput{
+				Getter:            kubeClient,
+				PodName:           identityValidator.Name,
+				Namespace:         ns.Name,
+				AzureIdentityName: azureIdentity.Name,
+				StateToWaitFor:    aadpodv1.AssignedIDAssigned,
+			})
+
+			identityvalidator.Validate(identityvalidator.ValidateInput{
+				Getter:           kubeClient,
+				Config:           config,
+				KubeconfigPath:   kubeconfigPath,
+				PodName:          identityValidator.Name,
+				Namespace:        ns.Name,
+				IdentityClientID: azureIdentity.Spec.ClientID,
+			})
+		}()
+
+		wg.Wait()
 	})
 })

--- a/test/e2e_new/framework/config.go
+++ b/test/e2e_new/framework/config.go
@@ -30,6 +30,30 @@ type Config struct {
 	NmiMode                  string `envconfig:"NMI_MODE" default:"standard"`
 }
 
+func (c *Config) DeepCopy() *Config {
+	copy := new(Config)
+	copy.SubscriptionID = c.SubscriptionID
+	copy.ResourceGroup = c.ResourceGroup
+	copy.IdentityResourceGroup = c.IdentityResourceGroup
+	copy.ClusterResourceGroup = c.ClusterResourceGroup
+	copy.AzureClientID = c.AzureClientID
+	copy.AzureClientSecret = c.AzureClientSecret
+	copy.AzureTenantID = c.AzureTenantID
+	copy.KeyvaultName = c.KeyvaultName
+	copy.KeyvaultSecretName = c.KeyvaultSecretName
+	copy.KeyvaultSecretVersion = c.KeyvaultSecretVersion
+	copy.MICVersion = c.MICVersion
+	copy.NMIVersion = c.NMIVersion
+	copy.Registry = c.Registry
+	copy.IdentityValidatorVersion = c.IdentityValidatorVersion
+	copy.SystemMSICluster = c.SystemMSICluster
+	copy.EnableScaleFeatures = c.EnableScaleFeatures
+	copy.ImmutableUserMSIs = c.ImmutableUserMSIs
+	copy.NmiMode = c.NmiMode
+
+	return copy
+}
+
 // ParseConfig parses the needed environment variables for running the tests
 func ParseConfig() (*Config, error) {
 	c := new(Config)

--- a/test/e2e_new/framework/exec/kubectl.go
+++ b/test/e2e_new/framework/exec/kubectl.go
@@ -18,7 +18,8 @@ func KubectlApply(kubeconfigPath, namespace string, args []string) error {
 		fmt.Sprintf("--namespace=%s", namespace),
 	}, args...)
 
-	return kubectl(args)
+	_, err := kubectl(args)
+	return err
 }
 
 // KubectlDelete executes "kubectl delete" given a list of arguments.
@@ -29,11 +30,12 @@ func KubectlDelete(kubeconfigPath, namespace string, args []string) error {
 		fmt.Sprintf("--namespace=%s", namespace),
 	}, args...)
 
-	return kubectl(args)
+	_, err := kubectl(args)
+	return err
 }
 
 // KubectlExec executes "kubectl exec" given a list of arguments.
-func KubectlExec(kubeconfigPath, podName, namespace string, args []string) error {
+func KubectlExec(kubeconfigPath, podName, namespace string, args []string) (string, error) {
 	args = append([]string{
 		"exec",
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
@@ -45,12 +47,12 @@ func KubectlExec(kubeconfigPath, podName, namespace string, args []string) error
 	return kubectl(args)
 }
 
-func kubectl(args []string) error {
+func kubectl(args []string) (string, error) {
 	By(fmt.Sprintf("kubectl %s", strings.Join(args, " ")))
 
 	cmd := exec.Command("kubectl", args...)
 	stdoutStderr, err := cmd.CombinedOutput()
 	fmt.Printf("%s", stdoutStderr)
 
-	return err
+	return string(stdoutStderr), err
 }

--- a/test/e2e_new/framework/helm/helm_helpers.go
+++ b/test/e2e_new/framework/helm/helm_helpers.go
@@ -29,15 +29,10 @@ type InstallInput struct {
 func Install(input InstallInput) {
 	Expect(input.Config).NotTo(BeNil(), "input.Config is required for Helm.Install")
 
-	operationMode := "standard"
-	if input.ManagedMode {
-		operationMode = "managed"
-	}
-
 	cwd, err := os.Getwd()
 	Expect(err).To(BeNil())
 
-	// Change current working dirrectory to repo root
+	// Change current working directory to repo root
 	// Before installing aad-pod identity through Helm
 	os.Chdir("../..")
 	defer os.Chdir(cwd)
@@ -50,8 +45,11 @@ func Install(input InstallInput) {
 		fmt.Sprintf("--set=image.repository=%s", input.Config.Registry),
 		fmt.Sprintf("--set=mic.tag=%s", input.Config.MICVersion),
 		fmt.Sprintf("--set=nmi.tag=%s", input.Config.NMIVersion),
-		fmt.Sprintf("--set=operationMode=%s", operationMode),
 	})
+
+	if input.ManagedMode {
+		args = append(args, fmt.Sprintf("--set=operationMode=%s", "managed"))
+	}
 
 	helm(args)
 }
@@ -64,8 +62,26 @@ func Uninstall() {
 	})
 }
 
-func Upgrade() {
-	// TODO
+func Upgrade(config *framework.Config) {
+	cwd, err := os.Getwd()
+	Expect(err).To(BeNil())
+
+	// Change current working directory to repo root
+	// Before installing aad-pod identity through Helm
+	os.Chdir("../..")
+	defer os.Chdir(cwd)
+
+	args := append([]string{
+		"upgrade",
+		chartName,
+		"charts/aad-pod-identity",
+		"--wait",
+		fmt.Sprintf("--set=image.repository=%s", config.Registry),
+		fmt.Sprintf("--set=mic.tag=%s", config.MICVersion),
+		fmt.Sprintf("--set=nmi.tag=%s", config.NMIVersion),
+	})
+
+	helm(args)
 }
 
 func helm(args []string) {

--- a/test/e2e_new/framework/identityvalidator/identityvalidator_helpers.go
+++ b/test/e2e_new/framework/identityvalidator/identityvalidator_helpers.go
@@ -231,7 +231,7 @@ func Validate(input ValidateInput) {
 		input.Config.KeyvaultSecretVersion,
 	}
 
-	err := exec.KubectlExec(input.KubeconfigPath, input.PodName, input.Namespace, args)
+	_, err := exec.KubectlExec(input.KubeconfigPath, input.PodName, input.Namespace, args)
 	if input.ExpectError {
 		By(fmt.Sprintf("Ensuring an error has occurred in %s", input.PodName))
 		Expect(err).NotTo(BeNil())

--- a/test/e2e_new/framework/iptables/iptables_helpers.go
+++ b/test/e2e_new/framework/iptables/iptables_helpers.go
@@ -141,7 +141,7 @@ func WaitForRules(input WaitForRulesInput) {
 					noError: input.ShouldExist,
 				},
 			} {
-				err := exec.KubectlExec(input.KubeconfigPath, p.Name, input.Namespace, strings.Split(cmd.command, " "))
+				_, err := exec.KubectlExec(input.KubeconfigPath, p.Name, input.Namespace, strings.Split(cmd.command, " "))
 				if cmd.noError {
 					Expect(err).To(BeNil())
 				} else {

--- a/test/e2e_new/framework/mic/mic_helpers.go
+++ b/test/e2e_new/framework/mic/mic_helpers.go
@@ -1,0 +1,79 @@
+// +build e2e_new
+
+package mic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const (
+	getTimeout = 1 * time.Minute
+	getPolling = 5 * time.Second
+
+	deleteTimeout = 1 * time.Minute
+	deletePolling = 5 * time.Second
+)
+
+type GetLeaderInput struct {
+	Getter framework.Getter
+}
+
+func GetLeader(input GetLeaderInput) *corev1.Pod {
+	Expect(input.Getter).NotTo(BeNil(), "input.Getter is required for MIC.GetLeader")
+
+	By("Getting MIC Leader")
+
+	leaderPod := &corev1.Pod{}
+	Eventually(func() (bool, error) {
+		endpoints := &corev1.Endpoints{}
+		if err := input.Getter.Get(context.TODO(), client.ObjectKey{Name: "aad-pod-identity-mic", Namespace: corev1.NamespaceDefault}, endpoints); err != nil {
+			return false, err
+		}
+
+		leRecord := &rl.LeaderElectionRecord{}
+		err := json.Unmarshal([]byte(endpoints.ObjectMeta.Annotations["control-plane.alpha.kubernetes.io/leader"]), leRecord)
+		if err != nil {
+			return false, err
+		}
+
+		leaderName := leRecord.HolderIdentity
+		if err := input.Getter.Get(context.TODO(), client.ObjectKey{Name: leaderName, Namespace: corev1.NamespaceDefault}, leaderPod); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}, getTimeout, getPolling).Should(BeTrue())
+
+	return leaderPod
+}
+
+type DeleteLeaderInput struct {
+	Getter  framework.Getter
+	Deleter framework.Deleter
+}
+
+func DeleteLeader(input DeleteLeaderInput) {
+	Expect(input.Getter).NotTo(BeNil(), "input.Getter is required for MIC.DeleteLeader")
+	Expect(input.Deleter).NotTo(BeNil(), "input.Getter is required for MIC.DeleteLeader")
+
+	leader := GetLeader(GetLeaderInput{
+		Getter: input.Getter,
+	})
+
+	By(fmt.Sprintf("Deleting MIC Leader \"%s\"", leader.Name))
+
+	Eventually(func() error {
+		return input.Deleter.Delete(context.TODO(), leader)
+	}, deleteTimeout, deletePolling).Should(Succeed())
+}

--- a/test/e2e_new/liveness_probe_test.go
+++ b/test/e2e_new/liveness_probe_test.go
@@ -3,11 +3,72 @@
 package e2e_new
 
 import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/exec"
+	"github.com/Azure/aad-pod-identity/test/e2e_new/framework/mic"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("When liveness probe is enabled", func() {
+var _ = Describe("[PR] When liveness probe is enabled", func() {
 	It("should pass liveness probe test", func() {
+		pods := &corev1.PodList{}
+		Eventually(func() (bool, error) {
+			if err := kubeClient.List(context.TODO(), pods, client.InNamespace(corev1.NamespaceDefault)); err != nil {
+				return false, err
+			}
 
+			return true, nil
+		}, 10*time.Second, 1*time.Second).Should(BeTrue())
+
+		var micPods, nmiPods []corev1.Pod
+		for _, pod := range pods.Items {
+			if strings.HasPrefix(pod.Name, "aad-pod-identity-mic") {
+				micPods = append(micPods, pod)
+			} else if strings.HasPrefix(pod.Name, "aad-pod-identity-nmi") {
+				nmiPods = append(nmiPods, pod)
+			}
+		}
+
+		micLeader := mic.GetLeader(mic.GetLeaderInput{
+			Getter: kubeClient,
+		})
+
+		for _, micPod := range micPods {
+			cmd := "clean-install wget"
+			_, err := exec.KubectlExec(kubeconfigPath, micPod.Name, corev1.NamespaceDefault, strings.Split(cmd, " "))
+			Expect(err).To(BeNil())
+
+			cmd = "wget http://127.0.0.1:8080/healthz -q -O -"
+			stdout, err := exec.KubectlExec(kubeconfigPath, micPod.Name, corev1.NamespaceDefault, strings.Split(cmd, " "))
+			Expect(err).To(BeNil())
+			if micPod.Name == micLeader.Name {
+				By(fmt.Sprintf("Ensuring that %s's health probe is active", micPod.Name))
+				Expect(strings.EqualFold(stdout, "Active")).To(BeTrue())
+			} else {
+				By(fmt.Sprintf("Ensuring that %s's health probe is not active", micPod.Name))
+				Expect(strings.EqualFold(stdout, "Not Active")).To(BeTrue())
+			}
+		}
+
+		for _, nmiPod := range nmiPods {
+			cmd := "clean-install wget"
+			_, err := exec.KubectlExec(kubeconfigPath, nmiPod.Name, corev1.NamespaceDefault, strings.Split(cmd, " "))
+			Expect(err).To(BeNil())
+
+			cmd = "wget http://127.0.0.1:8080/healthz -q -O -"
+			stdout, err := exec.KubectlExec(kubeconfigPath, nmiPod.Name, corev1.NamespaceDefault, strings.Split(cmd, " "))
+			Expect(err).To(BeNil())
+
+			By(fmt.Sprintf("Ensuring that %s's health probe is active", nmiPod.Name))
+			Expect(strings.EqualFold(stdout, "Active")).To(BeTrue())
+		}
 	})
 })


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Follow-up PR for #662.

Converted the following test cases from old to new framework:
`should pass the identity validation even when MIC leader is changed`
`should pass liveness probe test`
`should be backward compatible with old and new version of MIC and NMI`


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

ref: #586, #657

**Notes for Reviewers**:
