### PR TITLE
refactor: better error messages and handling

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	msiEndpoint, err := adal.GetMSIVMEndpoint()
 	if err != nil {
-		klog.Fatalf("failed to get msiendpoint, %+v", err)
+		klog.Fatalf("failed to get MSI endpoint, error: %+v", err)
 	}
 
 	for {
@@ -42,18 +42,16 @@ func main() {
 
 		t1 := testMSIEndpoint(msiEndpoint, *resource)
 		if t1 == nil {
-			klog.Errorf("testMSIEndpoint failed, %+v", err)
 			continue
 		}
 
 		t2 := testMSIEndpointFromUserAssignedID(msiEndpoint, *clientID, *resource)
 		if t2 == nil {
-			klog.Errorf("testMSIEndpointFromUserAssignedID failed, %+v", err)
 			continue
 		}
 
 		if !strings.EqualFold(t1.AccessToken, t2.AccessToken) {
-			klog.Errorf("msi, emsi test failed %+v %+v", t1, t2)
+			klog.Errorf("msi, emsi test failed with t1(%+v) and t2(%+v)", t1, t2)
 		}
 
 		testInstanceMetadataRequests()
@@ -65,33 +63,33 @@ func main() {
 func doARMOperations(subscriptionID, resourceGroup string) {
 	authorizer, err := auth.NewAuthorizerFromEnvironment()
 	if err != nil {
-		klog.Errorf("failed NewAuthorizerFromEnvironment  %+v", err)
+		klog.Errorf("failed to get authorizer from environment, error: %+v", err)
 		return
 	}
 	vmClient := compute.NewVirtualMachinesClient(subscriptionID)
 	vmClient.Authorizer = authorizer
 	vmlist, err := vmClient.List(context.Background(), resourceGroup)
 	if err != nil {
-		klog.Errorf("failed list all vm %+v", err)
+		klog.Errorf("failed list all vm, error: %+v", err)
 		return
 	}
 
-	klog.Infof("successful doARMOperations vm count %d", len(vmlist.Values()))
+	klog.Infof("successfully count VM from ARM: %d", len(vmlist.Values()))
 }
 
 func testMSIEndpoint(msiEndpoint, resource string) *adal.Token {
 	spt, err := adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource)
 	if err != nil {
-		klog.Errorf("failed to acquire a token using the MSI VM extension, Error: %+v", err)
+		klog.Errorf("failed to acquire a token using the MSI VM extension, error: %+v", err)
 		return nil
 	}
 	if err := spt.Refresh(); err != nil {
-		klog.Errorf("failed to refresh ServicePrincipalTokenFromMSI using the MSI VM extension, msiEndpoint(%s)", msiEndpoint)
+		klog.Errorf("failed to refresh ServicePrincipalTokenFromMSI using the MSI endpoint (%s), error: %+v", msiEndpoint, err)
 		return nil
 	}
 	token := spt.Token()
 	if token.IsZero() {
-		klog.Errorf("zero token found, MSI VM extension, msiEndpoint(%s)", msiEndpoint)
+		klog.Errorf("zero token found using the MSI endpoint (%s)", msiEndpoint)
 		return nil
 	}
 	klog.Infof("successfully acquired a token using the MSI, msiEndpoint(%s)", msiEndpoint)
@@ -101,7 +99,7 @@ func testMSIEndpoint(msiEndpoint, resource string) *adal.Token {
 func testMSIEndpointFromUserAssignedID(msiEndpoint, userAssignedID, resource string) *adal.Token {
 	spt, err := adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource, userAssignedID)
 	if err != nil {
-		klog.Errorf("failed NewServicePrincipalTokenFromMSIWithUserAssignedID, clientID: %s Error: %+v", userAssignedID, err)
+		klog.Errorf("failed NewServicePrincipalTokenFromMSIWithUserAssignedID, clientID: %s, error: %+v", userAssignedID, err)
 		return nil
 	}
 	if err := spt.Refresh(); err != nil {
@@ -125,7 +123,7 @@ func testInstanceMetadataRequests() {
 	}
 	req, err := http.NewRequest("GET", "http://169.254.169.254/metadata/instance?api-version=2017-08-01", nil)
 	if err != nil {
-		klog.Error(err)
+		klog.Errorf("failed to create new http request, error: %+v", err)
 		return
 	}
 	req.Header.Add("Metadata", "true")
@@ -137,7 +135,7 @@ func testInstanceMetadataRequests() {
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		klog.Error(err)
+		klog.Errorf("failed to read response body, error: %+v", err)
 		return
 	}
 	klog.Infof("successfully made GET on instance metadata, %s", body)

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -74,7 +74,7 @@ func doARMOperations(subscriptionID, resourceGroup string) {
 		return
 	}
 
-	klog.Infof("successfully count VM from ARM: %d", len(vmlist.Values()))
+	klog.Infof("successfully counted VM from ARM: %d", len(vmlist.Values()))
 }
 
 func testMSIEndpoint(msiEndpoint, resource string) *adal.Token {

--- a/cmd/simple/main.go
+++ b/cmd/simple/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	flag.Parse()
 
-	klog.V(2).Infof("Starting simple process. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
+	klog.V(2).Infof("starting simple process. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
 	if kubeconfig == "" {
 		klog.Warningf("--kubeconfig not passed will use InClusterConfig")
 	}
@@ -35,7 +35,7 @@ func main() {
 	klog.V(2).Infof("kubeconfig (%s)", kubeconfig)
 	config, err := buildConfig(kubeconfig)
 	if err != nil {
-		klog.Fatalf("Could not read config properly. Check the k8s config file, %+v", err)
+		klog.Fatalf("failed to build config from %s, error: %+v", kubeconfig, err)
 	}
 
 	eventCh := make(chan aadpodid.EventType, 100)
@@ -51,13 +51,13 @@ func main() {
 
 	ids, err := crdClient.ListIds()
 	if err != nil {
-		klog.Fatalf("Could not get the identities: %+v", err)
+		klog.Fatalf("could not get the identities: %+v", err)
 	}
 	klog.Infof("Identities len: %d", len(*ids))
 	for _, v := range *ids {
 		buf, err := json.MarshalIndent(v, "", "    ")
 		if err != nil {
-			klog.Errorf("Error in marshaling: %+v", err)
+			klog.Errorf("failed to marshal JSON, error: %+v", err)
 			os.Exit(1)
 		}
 		klog.Infof("\n%s", string(buf))
@@ -65,13 +65,13 @@ func main() {
 
 	bindings, err := crdClient.ListBindings()
 	if err != nil {
-		klog.Fatalf("Could not get the bindings: %+v", err)
+		klog.Fatalf("could not get the bindings: %+v", err)
 	}
-	klog.Infof("Bindings len: %d", len(*bindings))
+	klog.Infof("bindings len: %d", len(*bindings))
 	for _, v := range *bindings {
 		buf, err := json.MarshalIndent(v, "", "    ")
 		if err != nil {
-			klog.Errorf("Error in marshaling: %+v", err)
+			klog.Errorf("failed to marshal JSON, error: %+v", err)
 			os.Exit(1)
 		}
 		klog.Infof("\n%s", string(buf))
@@ -79,18 +79,18 @@ func main() {
 
 	assignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		klog.Fatalf("Could not get assigned ID")
+		klog.Fatalf("could not get assigned ID")
 	}
 
 	for _, a := range *assignedIDs {
 		buf, err := json.MarshalIndent(a, "", "    ")
 		if err != nil {
-			klog.Errorf("Error in marshaling: %+v", err)
+			klog.Errorf("failed to marshal JSON, error: %+v", err)
 			os.Exit(1)
 		}
 		klog.Infof("\n%s", string(buf))
 	}
-	klog.Info("\nDone !")
+	klog.Info("\ndone !")
 }
 
 // Create the client config. Use kubeconfig if given, otherwise assume in-cluster.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -29,29 +29,29 @@ func GetServicePrincipalTokenFromMSI(resource string) (*adal.Token, error) {
 		if err != nil {
 			err = reporter.ReportIMDSOperationError(metrics.AdalTokenFromMSIOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
 		err = reporter.ReportIMDSOperationDuration(metrics.AdalTokenFromMSIOperationName, time.Since(begin))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
 
 	msiEndpoint, err := adal.GetMSIVMEndpoint()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get the MSI endpoint. Error: %v", err)
+		return nil, fmt.Errorf("failed to get the MSI endpoint, error: %+v", err)
 	}
 	// Set up the configuration of the service principal
 	spt, err := adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to acquire a token for MSI. Error: %v", err)
+		return nil, fmt.Errorf("failed to acquire a token for MSI, error: %+v", err)
 	}
 	// obtain a fresh token
 	err = spt.Refresh()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to refresh token, error: %+v", err)
 	}
 	token := spt.Token()
 	return &token, nil
@@ -66,32 +66,32 @@ func GetServicePrincipalTokenFromMSIWithUserAssignedID(clientID, resource string
 		if err != nil {
 			err = reporter.ReportIMDSOperationError(metrics.AdalTokenFromMSIWithUserAssignedIDOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
 		err = reporter.ReportIMDSOperationDuration(metrics.AdalTokenFromMSIWithUserAssignedIDOperationName, time.Since(begin))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
 
 	msiEndpoint, err := adal.GetMSIVMEndpoint()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get the MSI endpoint. Error: %v", err)
+		return nil, fmt.Errorf("failed to get the MSI endpoint, error: %+v", err)
 	}
 	// The ID of the user for whom the token is requested
 	userAssignedID := clientID
 	// Set up the configuration of the service principal
 	spt, err := adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource, userAssignedID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to acquire a token using the MSI VM extension. Error: %v", err)
+		return nil, fmt.Errorf("failed to acquire a token using the MSI VM extension, error: %+v", err)
 	}
 
 	// obtain a fresh token
 	err = spt.Refresh()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to refresh token, error: %+v", err)
 	}
 	token := spt.Token()
 	return &token, nil
@@ -106,13 +106,13 @@ func GetServicePrincipalToken(adEndpointFromSpec, tenantID, clientID, secret, re
 		if err != nil {
 			err = reporter.ReportIMDSOperationError(metrics.AdalTokenOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
 		err = reporter.ReportIMDSOperationDuration(metrics.AdalTokenOperationName, time.Since(begin))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
 
@@ -122,7 +122,7 @@ func GetServicePrincipalToken(adEndpointFromSpec, tenantID, clientID, secret, re
 	}
 	oauthConfig, err := adal.NewOAuthConfig(activeDirectoryEndpoint, tenantID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create OAuth config. Error: %v", err)
+		return nil, fmt.Errorf("failed to create OAuth config, error: %+v", err)
 	}
 	spt, err := adal.NewServicePrincipalToken(*oauthConfig, clientID, secret, resource)
 	if err != nil {
@@ -131,7 +131,7 @@ func GetServicePrincipalToken(adEndpointFromSpec, tenantID, clientID, secret, re
 	// obtain a fresh token
 	err = spt.Refresh()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to refresh token, error: %+v", err)
 	}
 	token := spt.Token()
 	return &token, nil
@@ -146,13 +146,13 @@ func GetServicePrincipalTokenWithCertificate(adEndpointFromSpec, tenantID, clien
 		if err != nil {
 			err = reporter.ReportIMDSOperationError(metrics.AdalTokenOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
 		err = reporter.ReportIMDSOperationDuration(metrics.AdalTokenOperationName, time.Since(begin))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
 
@@ -162,12 +162,12 @@ func GetServicePrincipalTokenWithCertificate(adEndpointFromSpec, tenantID, clien
 	}
 	oauthConfig, err := adal.NewOAuthConfig(activeDirectoryEndpoint, tenantID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create OAuth config. Error: %v", err)
+		return nil, fmt.Errorf("failed to create OAuth config, error: %+v", err)
 	}
 
 	privateKey, cert, err := pkcs12.Decode(certificate, password)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to decode certificate. Error: %v", err)
+		return nil, fmt.Errorf("failed to decode certificate, error: %+v", err)
 	}
 
 	spt, err := adal.NewServicePrincipalTokenFromCertificate(*oauthConfig, clientID, cert, privateKey.(*rsa.PrivateKey), resource)
@@ -177,7 +177,7 @@ func GetServicePrincipalTokenWithCertificate(adEndpointFromSpec, tenantID, clien
 	// obtain a fresh token
 	err = spt.Refresh()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to refresh token, error: %+v", err)
 	}
 	token := spt.Token()
 	return &token, nil

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -71,7 +71,7 @@ func (c *Client) Init() error {
 			return fmt.Errorf("failed to config file %s, error: %+v", c.configFile, err)
 		}
 		if err = yaml.Unmarshal(bytes, &c.Config); err != nil {
-			return fmt.Errorf("failed to marshal JSON, error: %+v", err)
+			return fmt.Errorf("failed to unmarshal JSON, error: %+v", err)
 		}
 	} else {
 		klog.V(6).Info("populating AzureConfig from secret/environment variables")
@@ -235,7 +235,7 @@ func (c *Client) getIdentityResource(name string, isvmss bool) (idH IdentityHold
 	if isvmss {
 		vmss, err := c.VMSSClient.Get(rg, name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get %s in %s, error: %+v", name, rg, err)
+			return nil, nil, fmt.Errorf("failed to get vmss %s in resource group %s, error: %+v", name, rg, err)
 		}
 
 		update = func() error {
@@ -247,7 +247,7 @@ func (c *Client) getIdentityResource(name string, isvmss bool) (idH IdentityHold
 
 	vm, err := c.VMClient.Get(rg, name)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get %s in %s, error: %+v", name, rg, err)
+		return nil, nil, fmt.Errorf("failed to get vm %s in resource group %s, error: %+v", name, rg, err)
 	}
 	update = func() error {
 		return c.VMClient.UpdateIdentities(rg, name, vm)

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -53,7 +53,7 @@ func NewCloudProvider(configFile string, updateUserMSIMaxRetry int, updateUseMSI
 		configFile: configFile,
 	}
 	if err := client.Init(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize cloud provider client, error: %+v", err)
 	}
 	client.RetryClient = retry.NewRetryClient(updateUserMSIMaxRetry, updateUseMSIRetryInterval)
 	client.RetryClient.RegisterRetriableErrors(linkedAuthorizationFailed, failedIdentityOperation)
@@ -65,18 +65,16 @@ func NewCloudProvider(configFile string, updateUserMSIMaxRetry int, updateUseMSI
 func (c *Client) Init() error {
 	c.Config = config.AzureConfig{}
 	if c.configFile != "" {
-		klog.V(6).Info("Populate AzureConfig from azure.json")
+		klog.V(6).Info("populating AzureConfig from azure.json")
 		bytes, err := ioutil.ReadFile(c.configFile)
 		if err != nil {
-			klog.Errorf("Read file (%s) error: %+v", c.configFile, err)
-			return err
+			return fmt.Errorf("failed to config file %s, error: %+v", c.configFile, err)
 		}
 		if err = yaml.Unmarshal(bytes, &c.Config); err != nil {
-			klog.Errorf("Unmarshall error: %v", err)
-			return err
+			return fmt.Errorf("failed to marshal JSON, error: %+v", err)
 		}
 	} else {
-		klog.V(6).Info("Populate AzureConfig from secret/environment variables")
+		klog.V(6).Info("populating AzureConfig from secret/environment variables")
 		c.Config.Cloud = os.Getenv("CLOUD")
 		c.Config.TenantID = os.Getenv("TENANT_ID")
 		c.Config.ClientID = os.Getenv("CLIENT_ID")
@@ -90,20 +88,17 @@ func (c *Client) Init() error {
 
 	azureEnv, err := azure.EnvironmentFromName(c.Config.Cloud)
 	if err != nil {
-		klog.Errorf("Get cloud env error: %+v", err)
-		return err
+		return fmt.Errorf("failed to get cloud environment, error: %+v", err)
 	}
 
 	err = adal.AddToUserAgent(version.GetUserAgent("MIC", version.MICVersion))
 	if err != nil {
-		klog.Errorf("add to user agent error: %+v", err)
-		return err
+		return fmt.Errorf("failed to add MIC to user agent, error: %+v", err)
 	}
 
 	oauthConfig, err := adal.NewOAuthConfig(azureEnv.ActiveDirectoryEndpoint, c.Config.TenantID)
 	if err != nil {
-		klog.Errorf("Create OAuth config error: %+v", err)
-		return err
+		return fmt.Errorf("failed to create OAuth config, error: %+v", err)
 	}
 
 	var spt *adal.ServicePrincipalToken
@@ -111,23 +106,20 @@ func (c *Client) Init() error {
 		// MSI endpoint is required for both types of MSI - system assigned and user assigned.
 		msiEndpoint, err := adal.GetMSIVMEndpoint()
 		if err != nil {
-			klog.Errorf("Failed to get MSI endpoint. Error: %+v", err)
-			return err
+			return fmt.Errorf("failed to get MSI endpoint, error: %+v", err)
 		}
 		// UserAssignedIdentityID is empty, so we are going to use system assigned MSI
 		if c.Config.UserAssignedIdentityID == "" {
 			klog.Infof("MIC using system assigned identity for authentication.")
 			spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, azureEnv.ResourceManagerEndpoint)
 			if err != nil {
-				klog.Errorf("Get token from system assigned MSI error: %+v", err)
-				return err
+				return fmt.Errorf("failed to get token from system-assigned identity, error: %+v", err)
 			}
 		} else { // User assigned identity usage.
 			klog.Infof("MIC using user assigned identity: %s for authentication.", utils.RedactClientID(c.Config.UserAssignedIdentityID))
 			spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, azureEnv.ResourceManagerEndpoint, c.Config.UserAssignedIdentityID)
 			if err != nil {
-				klog.Errorf("Get token from user assigned MSI error: %+v", err)
-				return err
+				return fmt.Errorf("failed to get token from user-assigned identity, error: %+v", err)
 			}
 		}
 	} else { // This is the default scenario - use service principal to get the token.
@@ -138,8 +130,7 @@ func (c *Client) Init() error {
 			azureEnv.ResourceManagerEndpoint,
 		)
 		if err != nil {
-			klog.Errorf("Get service principal token error: %+v", err)
-			return err
+			return fmt.Errorf("failed to get service principal token, error: %+v", err)
 		}
 	}
 
@@ -150,13 +141,11 @@ func (c *Client) Init() error {
 
 	c.VMSSClient, err = NewVMSSClient(c.Config, spt)
 	if err != nil {
-		klog.Errorf("Create VMSS Client error: %+v", err)
-		return err
+		return fmt.Errorf("failed to create VMSS client, error: %+v", err)
 	}
 	c.VMClient, err = NewVirtualMachinesClient(c.Config, spt)
 	if err != nil {
-		klog.Errorf("Create VM Client error: %+v", err)
-		return err
+		return fmt.Errorf("failed to create VM client, error: %+v", err)
 	}
 
 	return nil
@@ -166,8 +155,7 @@ func (c *Client) Init() error {
 func (c *Client) GetUserMSIs(name string, isvmss bool) ([]string, error) {
 	idH, _, err := c.getIdentityResource(name, isvmss)
 	if err != nil {
-		klog.Errorf("GetUserMSIs: get identity resource failed with error %v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to get identity resource, error %v", err)
 	}
 	info := idH.IdentityInfo()
 	if info == nil {
@@ -181,7 +169,7 @@ func (c *Client) GetUserMSIs(name string, isvmss bool) ([]string, error) {
 func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs []string, name string, isvmss bool) error {
 	idH, updateFunc, err := c.getIdentityResource(name, isvmss)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get identity resource, error %v", err)
 	}
 
 	info := idH.IdentityInfo()
@@ -205,7 +193,7 @@ func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs [
 		return nil
 	}
 
-	klog.Infof("Updating user assigned MSIs on %s, assign [%d], unassign [%d]", name, len(addUserAssignedMSIIDs), len(removeUserAssignedMSIIDs))
+	klog.Infof("updating user-assigned identities on %s, assign [%d], unassign [%d]", name, len(addUserAssignedMSIIDs), len(removeUserAssignedMSIIDs))
 	timeStarted := time.Now()
 	shouldRetry := func(err error) bool {
 		if err == nil {
@@ -219,14 +207,14 @@ func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs [
 		for _, erroneousID := range erroneousIDs {
 			if removed := info.RemoveUserIdentity(erroneousID); removed {
 				removedAny = true
-				klog.Infof("Removing %s from ID list since it is erroneous", erroneousID)
+				klog.Infof("removing %s from ID list since it is erroneous", erroneousID)
 			}
 		}
 
 		// Only retry if there is at least one ID after deleting
 		remainingIDs := info.GetUserIdentityList()
 		if removedAny && len(remainingIDs) > 0 {
-			klog.Infof("Attempting to retry with ID list %v", remainingIDs)
+			klog.Infof("attempting to retry with ID list %v", remainingIDs)
 			return true
 		}
 
@@ -247,7 +235,7 @@ func (c *Client) getIdentityResource(name string, isvmss bool) (idH IdentityHold
 	if isvmss {
 		vmss, err := c.VMSSClient.Get(rg, name)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("failed to get %s in %s, error: %+v", name, rg, err)
 		}
 
 		update = func() error {
@@ -259,7 +247,7 @@ func (c *Client) getIdentityResource(name string, isvmss bool) (idH IdentityHold
 
 	vm, err := c.VMClient.Get(rg, name)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get %s in %s, error: %+v", name, rg, err)
 	}
 	update = func() error {
 		return c.VMClient.UpdateIdentities(rg, name, vm)
@@ -292,7 +280,7 @@ func ParseResourceID(resourceID string) (azure.Resource, error) {
 	}
 
 	if len(match) < 6 {
-		return azure.Resource{}, fmt.Errorf("parsing failed for %s: invalid resource id format", resourceID)
+		return azure.Resource{}, fmt.Errorf("failed to parse %s: invalid resource ID format", resourceID)
 	}
 
 	result := azure.Resource{
@@ -333,7 +321,7 @@ func extractIdentitiesFromError(err error) []string {
 	for _, id := range strings.Split(match, ",") {
 		// Sanity check
 		if err := utils.ValidateResourceID(id); err != nil {
-			klog.Error(err)
+			klog.Errorf("failed to validate %s, error: %+v", id, err)
 			continue
 		}
 		extracted = append(extracted, id)

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -48,7 +48,7 @@ func NewVirtualMachinesClient(config config.AzureConfig, spt *adal.ServicePrinci
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
+		return nil, fmt.Errorf("failed to create reporter for metrics, error: %+v", err)
 	}
 
 	return &VMClient{
@@ -79,7 +79,7 @@ func (c *VMClient) Get(rgName string, nodeName string) (compute.VirtualMachine, 
 
 	vm, err := c.client.Get(ctx, rgName, nodeName, "")
 	if err != nil {
-		return vm, fmt.Errorf("failed to get %s in %s, error: %+v", nodeName, rgName, err)
+		return vm, fmt.Errorf("failed to get vm %s in resource group %s, error: %+v", nodeName, rgName, err)
 	}
 	stats.UpdateCount(stats.TotalGetCalls, 1)
 	stats.Update(stats.CloudGet, time.Since(begin))
@@ -111,7 +111,7 @@ func (c *VMClient) UpdateIdentities(rg, nodeName string, vm compute.VirtualMachi
 		return fmt.Errorf("failed to update identities for %s in %s, error: %+v", nodeName, rg, err)
 	}
 	if err = future.WaitForCompletionRef(ctx, c.client.Client); err != nil {
-		return fmt.Errorf("failed to wait for identity update completion, error: %+v", err)
+		return fmt.Errorf("failed to wait for identity update completion for vm %s in resource group %s, error: %+v", nodeName, rg, err)
 	}
 	stats.UpdateCount(stats.TotalPutCalls, 1)
 	stats.Update(stats.CloudPut, time.Since(begin))

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -2,6 +2,7 @@ package cloudprovider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -35,22 +36,19 @@ func NewVirtualMachinesClient(config config.AzureConfig, spt *adal.ServicePrinci
 
 	azureEnv, err := azure.EnvironmentFromName(config.Cloud)
 	if err != nil {
-		klog.Errorf("Get cloud env error: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to get cloud environment, error: %+v", err)
 	}
 	client.BaseURI = azureEnv.ResourceManagerEndpoint
 	client.Authorizer = autorest.NewBearerAuthorizer(spt)
 	client.PollingDelay = 5 * time.Second
 	err = client.AddToUserAgent(version.GetUserAgent("MIC", version.MICVersion))
 	if err != nil {
-		klog.Errorf("Error updating user agent: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to add MIC to user agent, error: %+v", err)
 	}
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		klog.Errorf("New reporter error: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
 	}
 
 	return &VMClient{
@@ -69,20 +67,19 @@ func (c *VMClient) Get(rgName string, nodeName string) (compute.VirtualMachine, 
 		if err != nil {
 			err = c.reporter.ReportCloudProviderOperationError(metrics.GetVMOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
 		err = c.reporter.ReportCloudProviderOperationDuration(metrics.GetVMOperationName, time.Since(begin))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
 
 	vm, err := c.client.Get(ctx, rgName, nodeName, "")
 	if err != nil {
-		klog.Error(err)
-		return vm, err
+		return vm, fmt.Errorf("failed to get %s in %s, error: %+v", nodeName, rgName, err)
 	}
 	stats.UpdateCount(stats.TotalGetCalls, 1)
 	stats.Update(stats.CloudGet, time.Since(begin))
@@ -100,24 +97,21 @@ func (c *VMClient) UpdateIdentities(rg, nodeName string, vm compute.VirtualMachi
 		if err != nil {
 			err = c.reporter.ReportCloudProviderOperationError(metrics.PutVMOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
 		err = c.reporter.ReportCloudProviderOperationDuration(metrics.PutVMOperationName, time.Since(begin))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
 
-	if future, err = c.client.Update(ctx, rg, nodeName, compute.VirtualMachineUpdate{
-		Identity: vm.Identity}); err != nil {
-		klog.Errorf("Failed to update VM with error %v", err)
-		return err
+	if future, err = c.client.Update(ctx, rg, nodeName, compute.VirtualMachineUpdate{Identity: vm.Identity}); err != nil {
+		return fmt.Errorf("failed to update identities for %s in %s, error: %+v", nodeName, rg, err)
 	}
 	if err = future.WaitForCompletionRef(ctx, c.client.Client); err != nil {
-		klog.Error(err)
-		return err
+		return fmt.Errorf("failed to wait for identity update completion, error: %+v", err)
 	}
 	stats.UpdateCount(stats.TotalPutCalls, 1)
 	stats.Update(stats.CloudPut, time.Since(begin))

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -2,6 +2,7 @@ package cloudprovider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -35,22 +36,19 @@ func NewVMSSClient(config config.AzureConfig, spt *adal.ServicePrincipalToken) (
 
 	azureEnv, err := azure.EnvironmentFromName(config.Cloud)
 	if err != nil {
-		klog.Errorf("Get cloud env error: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to get cloud environment, error: %+v", err)
 	}
 	client.BaseURI = azureEnv.ResourceManagerEndpoint
 	client.Authorizer = autorest.NewBearerAuthorizer(spt)
 	client.PollingDelay = 5 * time.Second
 	err = client.AddToUserAgent(version.GetUserAgent("MIC", version.MICVersion))
 	if err != nil {
-		klog.Errorf("Error updating user agent: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to add MIC to user agent, error: %+v", err)
 	}
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		klog.Errorf("New reporter error: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
 	}
 
 	return &VMSSClient{
@@ -70,24 +68,21 @@ func (c *VMSSClient) UpdateIdentities(rg, vmssName string, vmssIdentities comput
 		if err != nil {
 			err = c.reporter.ReportCloudProviderOperationError(metrics.PutVmssOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
 		err = c.reporter.ReportCloudProviderOperationDuration(metrics.PutVmssOperationName, time.Since(begin))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
 
-	if future, err = c.client.Update(ctx, rg, vmssName, compute.VirtualMachineScaleSetUpdate{
-		Identity: vmssIdentities.Identity}); err != nil {
-		klog.Errorf("Failed to update VM with error %v", err)
-		return err
+	if future, err = c.client.Update(ctx, rg, vmssName, compute.VirtualMachineScaleSetUpdate{Identity: vmssIdentities.Identity}); err != nil {
+		return fmt.Errorf("failed to update identities for %s in %s, error: %+v", vmssName, rg, err)
 	}
 	if err = future.WaitForCompletionRef(ctx, c.client.Client); err != nil {
-		klog.Error(err)
-		return err
+		return fmt.Errorf("failed to wait for identity update completion, error: %+v", err)
 	}
 	stats.UpdateCount(stats.TotalPutCalls, 1)
 	stats.Update(stats.CloudPut, time.Since(begin))
@@ -103,23 +98,22 @@ func (c *VMSSClient) Get(rgName string, vmssName string) (ret compute.VirtualMac
 		if err != nil {
 			err = c.reporter.ReportCloudProviderOperationError(metrics.GetVmssOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
 		err = c.reporter.ReportCloudProviderOperationDuration(metrics.GetVmssOperationName, time.Since(begin))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
-	vm, err := c.client.Get(ctx, rgName, vmssName)
+	vmss, err := c.client.Get(ctx, rgName, vmssName)
 	if err != nil {
-		klog.Error(err)
-		return vm, err
+		return vmss, fmt.Errorf("failed to get %s in %s, error: %+v", vmssName, rgName, err)
 	}
 	stats.UpdateCount(stats.TotalGetCalls, 1)
 	stats.Update(stats.CloudGet, time.Since(begin))
-	return vm, nil
+	return vmss, nil
 }
 
 // vmssIdentityHolder implements `IdentityHolder` for vmss resources.

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -48,7 +48,7 @@ func NewVMSSClient(config config.AzureConfig, spt *adal.ServicePrincipalToken) (
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
+		return nil, fmt.Errorf("failed to create reporter for metrics, error: %+v", err)
 	}
 
 	return &VMSSClient{
@@ -82,7 +82,7 @@ func (c *VMSSClient) UpdateIdentities(rg, vmssName string, vmssIdentities comput
 		return fmt.Errorf("failed to update identities for %s in %s, error: %+v", vmssName, rg, err)
 	}
 	if err = future.WaitForCompletionRef(ctx, c.client.Client); err != nil {
-		return fmt.Errorf("failed to wait for identity update completion, error: %+v", err)
+		return fmt.Errorf("failed to wait for identity update completion for vmss %s in resource group %s, error: %+v", vmssName, rg, err)
 	}
 	stats.UpdateCount(stats.TotalPutCalls, 1)
 	stats.Update(stats.CloudPut, time.Since(begin))
@@ -109,7 +109,7 @@ func (c *VMSSClient) Get(rgName string, vmssName string) (ret compute.VirtualMac
 	}()
 	vmss, err := c.client.Get(ctx, rgName, vmssName)
 	if err != nil {
-		return vmss, fmt.Errorf("failed to get %s in %s, error: %+v", vmssName, rgName, err)
+		return vmss, fmt.Errorf("failed to get vmss %s in resource group %s, error: %+v", vmssName, rgName, err)
 	}
 	stats.UpdateCount(stats.TotalGetCalls, 1)
 	stats.Update(stats.CloudGet, time.Since(begin))

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -63,7 +63,6 @@ type ClientInt interface {
 func NewCRDClientLite(config *rest.Config, nodeName string, scale, isStandardMode bool) (crdClient *Client, err error) {
 	restClient, err := newRestClient(config)
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 
@@ -80,7 +79,6 @@ func NewCRDClientLite(config *rest.Config, nodeName string, scale, isStandardMod
 
 		assignedIDListInformer, err = newAssignedIDInformer(assignedIDListWatch)
 		if err != nil {
-			klog.Error(err)
 			return nil, err
 		}
 	} else {
@@ -95,14 +93,12 @@ func NewCRDClientLite(config *rest.Config, nodeName string, scale, isStandardMod
 	podIdentityExceptionListWatch := newPodIdentityExceptionListWatch(restClient)
 	podIdentityExceptionInformer, err := newPodIdentityExceptionInformer(podIdentityExceptionListWatch)
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		klog.Error(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
 	}
 
 	return &Client{
@@ -119,35 +115,30 @@ func NewCRDClientLite(config *rest.Config, nodeName string, scale, isStandardMod
 func NewCRDClient(config *rest.Config, eventCh chan aadpodid.EventType) (crdClient *Client, err error) {
 	restClient, err := newRestClient(config)
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 
 	bindingListWatch := newBindingListWatch(restClient)
 	bindingInformer, err := newBindingInformer(restClient, eventCh, bindingListWatch)
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 
 	idListWatch := newIDListWatch(restClient)
 	idInformer, err := newIDInformer(restClient, eventCh, idListWatch)
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 
 	assignedIDListWatch := newAssignedIDListWatch(restClient)
 	assignedIDListInformer, err := newAssignedIDInformer(assignedIDListWatch)
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		klog.Error(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
 	}
 
 	return &Client{
@@ -201,20 +192,20 @@ func newBindingInformer(r *rest.RESTClient, eventCh chan aadpodid.EventType, lw 
 		&aadpodv1.AzureIdentityBinding{},
 		time.Minute*10)
 	if azBindingInformer == nil {
-		return nil, fmt.Errorf("Could not create watcher for %s", aadpodv1.AzureIDBindingResource)
+		return nil, fmt.Errorf("failed to create watcher for %s", aadpodv1.AzureIDBindingResource)
 	}
 	azBindingInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				klog.V(6).Infof("Binding created")
+				klog.V(6).Infof("binding created")
 				eventCh <- aadpodid.BindingCreated
 			},
 			DeleteFunc: func(obj interface{}) {
-				klog.V(6).Infof("Binding deleted")
+				klog.V(6).Infof("binding deleted")
 				eventCh <- aadpodid.BindingDeleted
 			},
 			UpdateFunc: func(OldObj, newObj interface{}) {
-				klog.V(6).Infof("Binding updated")
+				klog.V(6).Infof("binding updated")
 				eventCh <- aadpodid.BindingUpdated
 			},
 		},
@@ -232,20 +223,20 @@ func newIDInformer(r *rest.RESTClient, eventCh chan aadpodid.EventType, lw *cach
 		&aadpodv1.AzureIdentity{},
 		time.Minute*10)
 	if azIDInformer == nil {
-		return nil, fmt.Errorf("Could not create Identity watcher for %s", aadpodv1.AzureIDResource)
+		return nil, fmt.Errorf("failed to create watcher for %s", aadpodv1.AzureIDResource)
 	}
 	azIDInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				klog.V(6).Infof("Identity created")
+				klog.V(6).Infof("identity created")
 				eventCh <- aadpodid.IdentityCreated
 			},
 			DeleteFunc: func(obj interface{}) {
-				klog.V(6).Infof("Identity deleted")
+				klog.V(6).Infof("identity deleted")
 				eventCh <- aadpodid.IdentityDeleted
 			},
 			UpdateFunc: func(OldObj, newObj interface{}) {
-				klog.V(6).Infof("Identity updated")
+				klog.V(6).Infof("identity updated")
 				eventCh <- aadpodid.IdentityUpdated
 			},
 		},
@@ -276,7 +267,7 @@ func newAssignedIDListWatch(r *rest.RESTClient) *cache.ListWatch {
 func newAssignedIDInformer(lw *cache.ListWatch) (cache.SharedInformer, error) {
 	azAssignedIDInformer := cache.NewSharedInformer(lw, &aadpodv1.AzureAssignedIdentity{}, time.Minute*10)
 	if azAssignedIDInformer == nil {
-		return nil, fmt.Errorf("could not create %s informer", aadpodv1.AzureAssignedIDResource)
+		return nil, fmt.Errorf("failed to create %s informer", aadpodv1.AzureAssignedIDResource)
 	}
 	return azAssignedIDInformer, nil
 }
@@ -284,7 +275,7 @@ func newAssignedIDInformer(lw *cache.ListWatch) (cache.SharedInformer, error) {
 func newBindingInformerLite(lw *cache.ListWatch) (cache.SharedInformer, error) {
 	azBindingInformer := cache.NewSharedInformer(lw, &aadpodv1.AzureIdentityBinding{}, time.Minute*10)
 	if azBindingInformer == nil {
-		return nil, fmt.Errorf("could not create %s informer", aadpodv1.AzureIDBindingResource)
+		return nil, fmt.Errorf("failed to create %s informer", aadpodv1.AzureIDBindingResource)
 	}
 	return azBindingInformer, nil
 }
@@ -292,7 +283,7 @@ func newBindingInformerLite(lw *cache.ListWatch) (cache.SharedInformer, error) {
 func newIDInformerLite(lw *cache.ListWatch) (cache.SharedInformer, error) {
 	azIDInformer := cache.NewSharedInformer(lw, &aadpodv1.AzureIdentity{}, time.Minute*10)
 	if azIDInformer == nil {
-		return nil, fmt.Errorf("could not create %s informer", aadpodv1.AzureIDResource)
+		return nil, fmt.Errorf("failed to create %s informer", aadpodv1.AzureIDResource)
 	}
 	return azIDInformer, nil
 }
@@ -310,7 +301,7 @@ func newPodIdentityExceptionListWatch(r *rest.RESTClient) *cache.ListWatch {
 func newPodIdentityExceptionInformer(lw *cache.ListWatch) (cache.SharedInformer, error) {
 	azPodIDExceptionInformer := cache.NewSharedInformer(lw, &aadpodv1.AzurePodIdentityException{}, time.Minute*10)
 	if azPodIDExceptionInformer == nil {
-		return nil, fmt.Errorf("could not create %s informer", aadpodv1.AzureIdentityExceptionResource)
+		return nil, fmt.Errorf("failed to create %s informer", aadpodv1.AzureIdentityExceptionResource)
 	}
 	return azPodIDExceptionInformer, nil
 }
@@ -320,11 +311,11 @@ func (c *Client) getObjectList(resource string, i runtime.Object) (runtime.Objec
 	do := c.rest.Get().Namespace(v1.NamespaceAll).Resource(resource).VersionedParams(&options, v1.ParameterCodec).Do()
 	body, err := do.Raw()
 	if err != nil {
-		return nil, fmt.Errorf("get failed for %s with error: %v", resource, err)
+		return nil, fmt.Errorf("failed to get %s, error: %+v", resource, err)
 	}
 	err = json.Unmarshal(body, &i)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal to object: %T, error: %v", i, err)
+		return nil, fmt.Errorf("failed to unmarshal to object %T, error: %+v", i, err)
 	}
 	return i, err
 }
@@ -332,7 +323,7 @@ func (c *Client) getObjectList(resource string, i runtime.Object) (runtime.Objec
 func (c *Client) setObject(resource, ns, name string, i interface{}, obj runtime.Object) error {
 	err := c.rest.Put().Namespace(ns).Resource(resource).Name(name).Body(i).Do().Into(obj)
 	if err != nil {
-		return fmt.Errorf("set object for resource: %s, error: %v", resource, err)
+		return fmt.Errorf("failed to set object for resource %s, error: %+v", resource, err)
 	}
 	return nil
 }
@@ -346,13 +337,13 @@ func (c *Client) Upgrade(resource string, i runtime.Object) (map[string]runtime.
 
 	list, err := meta.ExtractList(i)
 	if err != nil {
-		return m, fmt.Errorf("extract list error for resource: %s, err: %v", resource, err)
+		return m, fmt.Errorf("failed to extract list for resource %s, error: %+v", resource, err)
 	}
 
 	for _, item := range list {
 		o, err := meta.Accessor(item)
 		if err != nil {
-			return m, fmt.Errorf("get object for resource: %s, error: %v", resource, err)
+			return m, fmt.Errorf("failed to get object for resource %s, error: %+v", resource, err)
 		}
 		switch resource {
 		case aadpodv1.AzureIDResource:
@@ -402,12 +393,12 @@ func (c *Client) UpgradeAll() error {
 	}
 	list, err := meta.ExtractList(i)
 	if err != nil {
-		return fmt.Errorf("extract list error for resource: %s, err: %v", aadpodv1.AzureAssignedIDResource, err)
+		return fmt.Errorf("failed to extract list for resource: %s, error: %+v", aadpodv1.AzureAssignedIDResource, err)
 	}
 	for _, item := range list {
 		o, err := meta.Accessor(item)
 		if err != nil {
-			return fmt.Errorf("get object for resource: %s, error: %v", aadpodv1.AzureAssignedIDResource, err)
+			return fmt.Errorf("failed to get object for resource: %s, error: %+v", aadpodv1.AzureAssignedIDResource, err)
 		}
 		obj := o.(*aadpodv1.AzureAssignedIdentity)
 		idName := obj.Spec.AzureIdentityRef.Name
@@ -466,10 +457,10 @@ func (c *Client) Start(exit <-chan struct{}) {
 func (c *Client) SyncCache(exit <-chan struct{}, initial bool, cacheSyncs ...cache.InformerSynced) {
 	if !cache.WaitForCacheSync(exit, cacheSyncs...) {
 		if !initial {
-			klog.Errorf("Cache could not be synchronized")
+			klog.Errorf("cache failed to be synchronized")
 			return
 		}
-		panic("Cache could not be synchronized")
+		panic("Cache failed to be synchronized")
 	}
 }
 
@@ -480,14 +471,14 @@ func (c *Client) SyncCacheAll(exit <-chan struct{}, initial bool) {
 
 // RemoveAssignedIdentity removes the assigned identity
 func (c *Client) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) (err error) {
-	klog.V(6).Infof("Deletion of assigned id named: %s", assignedIdentity.Name)
+	klog.V(6).Infof("deletion of assigned id named: %s", assignedIdentity.Name)
 	begin := time.Now()
 
 	defer func() {
 		if err != nil {
 			err = c.reporter.ReportKubernetesAPIOperationError(metrics.AssignedIdentityDeletionOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
@@ -511,21 +502,21 @@ func (c *Client) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 		err = c.rest.Put().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Name(assignedIdentity.Name).Body(&res).Do().Error()
 	}
 
-	klog.V(5).Infof("Deletion %s took: %v", assignedIdentity.Name, time.Since(begin))
+	klog.V(5).Infof("deletion %s took: %v", assignedIdentity.Name, time.Since(begin))
 	stats.Update(stats.AssignedIDDel, time.Since(begin))
 	return err
 }
 
 // CreateAssignedIdentity creates new assigned identity
 func (c *Client) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) (err error) {
-	klog.Infof("Got assigned id %s to assign", assignedIdentity.Name)
+	klog.Infof("got assigned id %s to assign", assignedIdentity.Name)
 	begin := time.Now()
 
 	defer func() {
 		if err != nil {
 			err = c.reporter.ReportKubernetesAPIOperationError(metrics.AssignedIdentityAdditionOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 			return
 		}
@@ -542,24 +533,23 @@ func (c *Client) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 	}
 	err = c.rest.Post().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Body(&v1AssignedID).Do().Into(&res)
 	if err != nil {
-		klog.Error(err)
 		return err
 	}
 
-	klog.V(5).Infof("Time take to create %s: %v", assignedIdentity.Name, time.Since(begin))
+	klog.V(5).Infof("time take to create %s: %v", assignedIdentity.Name, time.Since(begin))
 	stats.Update(stats.AssignedIDAdd, time.Since(begin))
 	return nil
 }
 
 // UpdateAssignedIdentity updates an existing assigned identity
 func (c *Client) UpdateAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) (err error) {
-	klog.Infof("Got assigned id %s/%s to update", assignedIdentity.Namespace, assignedIdentity.Name)
+	klog.Infof("got assigned id %s/%s to update", assignedIdentity.Namespace, assignedIdentity.Name)
 	begin := time.Now()
 
 	defer func() {
 		if err != nil {
 			err = c.reporter.ReportKubernetesAPIOperationError(metrics.AssignedIdentityUpdateOperationName)
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 			return
 		}
 		c.reporter.Report(
@@ -571,10 +561,10 @@ func (c *Client) UpdateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 	v1AssignedID := aadpodv1.ConvertInternalAssignedIdentityToV1AssignedIdentity(*assignedIdentity)
 	err = c.rest.Put().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Name(assignedIdentity.Name).Body(&v1AssignedID).Do().Error()
 	if err != nil {
-		return fmt.Errorf("failed to update assigned identity: %v", err)
+		return fmt.Errorf("failed to update AzureAssignedIdentity, error: %+v", err)
 	}
 
-	klog.V(5).Infof("Time take to update %s/%s: %v", assignedIdentity.Namespace, assignedIdentity.Name, time.Since(begin))
+	klog.V(5).Infof("time take to update %s/%s: %v", assignedIdentity.Namespace, assignedIdentity.Name, time.Since(begin))
 	stats.Update(stats.AssignedIDAdd, time.Since(begin))
 	return nil
 }
@@ -589,9 +579,7 @@ func (c *Client) ListBindings() (res *[]aadpodid.AzureIdentityBinding, err error
 	for _, binding := range list {
 		o, ok := binding.(*aadpodv1.AzureIdentityBinding)
 		if !ok {
-			err := fmt.Errorf("could not cast %T to %s", binding, aadpodv1.AzureIDBindingResource)
-			klog.Error(err)
-			return nil, err
+			return nil, fmt.Errorf("failed to cast %T to %s", binding, aadpodv1.AzureIDBindingResource)
 		}
 		// Note: List items returned from cache have empty Kind and API version..
 		// Work around this issue since we need that for event recording to work.
@@ -603,7 +591,7 @@ func (c *Client) ListBindings() (res *[]aadpodid.AzureIdentityBinding, err error
 		internalBinding := aadpodv1.ConvertV1BindingToInternalBinding(*o)
 
 		resList = append(resList, internalBinding)
-		klog.V(6).Infof("Appending binding: %s/%s to list.", o.Namespace, o.Name)
+		klog.V(6).Infof("appending binding: %s/%s to list.", o.Namespace, o.Name)
 	}
 
 	stats.Update(stats.BindingList, time.Since(begin))
@@ -620,9 +608,7 @@ func (c *Client) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity, err e
 	for _, assignedID := range list {
 		o, ok := assignedID.(*aadpodv1.AzureAssignedIdentity)
 		if !ok {
-			err := fmt.Errorf("could not cast %T to %s", assignedID, aadpodv1.AzureAssignedIDResource)
-			klog.Error(err)
-			return nil, err
+			return nil, fmt.Errorf("failed to cast %T to %s", assignedID, aadpodv1.AzureAssignedIDResource)
 		}
 		// Note: List items returned from cache have empty Kind and API version..
 		// Work around this issue since we need that for event recording to work.
@@ -632,7 +618,7 @@ func (c *Client) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity, err e
 			Kind:    reflect.TypeOf(*o).String()})
 		out := aadpodv1.ConvertV1AssignedIdentityToInternalAssignedIdentity(*o)
 		resList = append(resList, out)
-		klog.V(6).Infof("Appending Assigned ID: %s/%s to list.", o.Namespace, o.Name)
+		klog.V(6).Infof("appending AzureAssignedIdentity: %s/%s to list.", o.Namespace, o.Name)
 	}
 
 	stats.Update(stats.AssignedIDList, time.Since(begin))
@@ -650,9 +636,7 @@ func (c *Client) ListAssignedIDsInMap() (map[string]aadpodid.AzureAssignedIdenti
 
 		o, ok := assignedID.(*aadpodv1.AzureAssignedIdentity)
 		if !ok {
-			err := fmt.Errorf("could not cast %T to %s", assignedID, aadpodv1.AzureAssignedIDResource)
-			klog.Error(err)
-			return nil, err
+			return nil, fmt.Errorf("failed to cast %T to %s", assignedID, aadpodv1.AzureAssignedIDResource)
 		}
 		// Note: List items returned from cache have empty Kind and API version..
 		// Work around this issue since we need that for event recording to work.
@@ -664,7 +648,7 @@ func (c *Client) ListAssignedIDsInMap() (map[string]aadpodid.AzureAssignedIdenti
 		out := aadpodv1.ConvertV1AssignedIdentityToInternalAssignedIdentity(*o)
 		// assigned identities names are unique across namespaces as we use pod name-<id ns>-<id name>
 		result[o.Name] = out
-		klog.V(6).Infof("Added to map with key: %s", o.Name)
+		klog.V(6).Infof("added to map with key: %s", o.Name)
 	}
 
 	stats.Update(stats.AssignedIDList, time.Since(begin))
@@ -681,9 +665,7 @@ func (c *Client) ListIds() (res *[]aadpodid.AzureIdentity, err error) {
 	for _, id := range list {
 		o, ok := id.(*aadpodv1.AzureIdentity)
 		if !ok {
-			err := fmt.Errorf("could not cast %T to %s", id, aadpodv1.AzureIDResource)
-			klog.Error(err)
-			return nil, err
+			return nil, fmt.Errorf("failed to cast %T to %s", id, aadpodv1.AzureIDResource)
 		}
 		// Note: List items returned from cache have empty Kind and API version..
 		// Work around this issue since we need that for event recording to work.
@@ -695,7 +677,7 @@ func (c *Client) ListIds() (res *[]aadpodid.AzureIdentity, err error) {
 		out := aadpodv1.ConvertV1IdentityToInternalIdentity(*o)
 
 		resList = append(resList, out)
-		klog.V(6).Infof("Appending Identity: %s/%s to list.", o.Namespace, o.Name)
+		klog.V(6).Infof("appending AzureIdentity %s/%s to list.", o.Namespace, o.Name)
 	}
 
 	stats.Update(stats.IDList, time.Since(begin))
@@ -712,9 +694,7 @@ func (c *Client) ListPodIdentityExceptions(ns string) (res *[]aadpodid.AzurePodI
 	for _, binding := range list {
 		o, ok := binding.(*aadpodv1.AzurePodIdentityException)
 		if !ok {
-			err := fmt.Errorf("could not cast %T to %s", binding, aadpodid.AzureIdentityExceptionResource)
-			klog.Error(err)
-			return nil, err
+			return nil, fmt.Errorf("failed to cast %T to %s", binding, aadpodid.AzureIdentityExceptionResource)
 		}
 		if o.Namespace == ns {
 			// Note: List items returned from cache have empty Kind and API version..
@@ -726,7 +706,7 @@ func (c *Client) ListPodIdentityExceptions(ns string) (res *[]aadpodid.AzurePodI
 			out := aadpodv1.ConvertV1PodIdentityExceptionToInternalPodIdentityException(*o)
 
 			resList = append(resList, out)
-			klog.V(6).Infof("Appending exception: %s/%s to list.", o.Namespace, o.Name)
+			klog.V(6).Infof("appending exception: %s/%s to list.", o.Namespace, o.Name)
 		}
 	}
 
@@ -796,13 +776,13 @@ type patchStatusOps struct {
 
 // UpdateAzureAssignedIdentityStatus updates the status field in AzureAssignedIdentity to indicate current status
 func (c *Client) UpdateAzureAssignedIdentityStatus(assignedIdentity *aadpodid.AzureAssignedIdentity, status string) (err error) {
-	klog.Infof("Updating assigned identity %s/%s status to %s", assignedIdentity.Namespace, assignedIdentity.Name, status)
+	klog.Infof("updating AzureAssignedIdentity %s/%s status to %s", assignedIdentity.Namespace, assignedIdentity.Name, status)
 
 	defer func() {
 		if err != nil {
 			err = c.reporter.ReportKubernetesAPIOperationError(metrics.UpdateAzureAssignedIdentityStatusOperationName)
 			if err != nil {
-				klog.Warningf("Metrics reporter error: %+v", err)
+				klog.Warningf("failed to report metrics, error: %+v", err)
 			}
 		}
 	}()
@@ -826,7 +806,7 @@ func (c *Client) UpdateAzureAssignedIdentityStatus(assignedIdentity *aadpodid.Az
 		Body(patchBytes).
 		Do().
 		Error()
-	klog.V(5).Infof("Patch of %s took: %v", assignedIdentity.Name, time.Since(begin))
+	klog.V(5).Infof("patch of %s took: %v", assignedIdentity.Name, time.Since(begin))
 	return err
 }
 

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -98,7 +98,7 @@ func NewCRDClientLite(config *rest.Config, nodeName string, scale, isStandardMod
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
+		return nil, fmt.Errorf("failed to create reporter for metrics, error: %+v", err)
 	}
 
 	return &Client{
@@ -138,7 +138,7 @@ func NewCRDClient(config *rest.Config, eventCh chan aadpodid.EventType) (crdClie
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
+		return nil, fmt.Errorf("failed to create reporter for metrics, error: %+v", err)
 	}
 
 	return &Client{
@@ -471,7 +471,7 @@ func (c *Client) SyncCacheAll(exit <-chan struct{}, initial bool) {
 
 // RemoveAssignedIdentity removes the assigned identity
 func (c *Client) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) (err error) {
-	klog.V(6).Infof("deletion of assigned id named: %s", assignedIdentity.Name)
+	klog.V(6).Infof("deleting assigned id %s/%s", assignedIdentity.Namespace, assignedIdentity.Name)
 	begin := time.Now()
 
 	defer func() {
@@ -502,14 +502,14 @@ func (c *Client) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 		err = c.rest.Put().Namespace(assignedIdentity.Namespace).Resource(aadpodid.AzureAssignedIDResource).Name(assignedIdentity.Name).Body(&res).Do().Error()
 	}
 
-	klog.V(5).Infof("deletion %s took: %v", assignedIdentity.Name, time.Since(begin))
+	klog.V(5).Infof("deleting %s took: %v", assignedIdentity.Name, time.Since(begin))
 	stats.Update(stats.AssignedIDDel, time.Since(begin))
 	return err
 }
 
 // CreateAssignedIdentity creates new assigned identity
 func (c *Client) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) (err error) {
-	klog.Infof("got assigned id %s to assign", assignedIdentity.Name)
+	klog.Infof("creating assigned id %s/%s", assignedIdentity.Namespace, assignedIdentity.Name)
 	begin := time.Now()
 
 	defer func() {
@@ -536,14 +536,14 @@ func (c *Client) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 		return err
 	}
 
-	klog.V(5).Infof("time take to create %s: %v", assignedIdentity.Name, time.Since(begin))
+	klog.V(5).Infof("time taken to create %s/%s: %v", assignedIdentity.Namespace, assignedIdentity.Name, time.Since(begin))
 	stats.Update(stats.AssignedIDAdd, time.Since(begin))
 	return nil
 }
 
 // UpdateAssignedIdentity updates an existing assigned identity
 func (c *Client) UpdateAssignedIdentity(assignedIdentity *aadpodid.AzureAssignedIdentity) (err error) {
-	klog.Infof("got assigned id %s/%s to update", assignedIdentity.Namespace, assignedIdentity.Name)
+	klog.Infof("updating assigned id %s/%s", assignedIdentity.Namespace, assignedIdentity.Name)
 	begin := time.Now()
 
 	defer func() {
@@ -564,7 +564,7 @@ func (c *Client) UpdateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 		return fmt.Errorf("failed to update AzureAssignedIdentity, error: %+v", err)
 	}
 
-	klog.V(5).Infof("time take to update %s/%s: %v", assignedIdentity.Namespace, assignedIdentity.Name, time.Since(begin))
+	klog.V(5).Infof("time taken to update %s/%s: %v", assignedIdentity.Namespace, assignedIdentity.Name, time.Since(begin))
 	stats.Update(stats.AssignedIDAdd, time.Since(begin))
 	return nil
 }

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -55,7 +55,7 @@ func (c *client) Start(exit <-chan struct{}) {
 			case <-exit:
 				return
 			case event := <-c.watcher.Events:
-				klog.Infof("Detect file modification: %s", event.String())
+				klog.Infof("detect file modification: %s", event.String())
 				if c.eventHandler != nil {
 					c.eventHandler(event)
 				}

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -55,7 +55,7 @@ func (c *client) Start(exit <-chan struct{}) {
 			case <-exit:
 				return
 			case event := <-c.watcher.Events:
-				klog.Infof("detect file modification: %s", event.String())
+				klog.Infof("detected file modification: %s", event.String())
 				if c.eventHandler != nil {
 					c.eventHandler(event)
 				}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -73,7 +73,7 @@ func NewKubeClient(nodeName string, scale, isStandardMode bool) (Client, error) 
 	}
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
+		return nil, fmt.Errorf("failed to create reporter for metrics, error: %+v", err)
 	}
 
 	podInformer := informersv1.NewFilteredPodInformer(clientset, v1.NamespaceAll, 10*time.Minute,

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -73,7 +73,7 @@ func NewKubeClient(nodeName string, scale, isStandardMode bool) (Client, error) 
 	}
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
 	}
 
 	podInformer := informersv1.NewFilteredPodInformer(clientset, v1.NamespaceAll, 10*time.Minute,
@@ -93,7 +93,7 @@ func NewKubeClient(nodeName string, scale, isStandardMode bool) (Client, error) 
 // Sync ...
 func (c *KubeClient) Sync(exit <-chan struct{}) {
 	if !cache.WaitForCacheSync(exit, c.PodInformer.HasSynced) {
-		klog.Errorf("Pod cache could not be synchronized")
+		klog.Error("pod cache could not be synchronized")
 	}
 }
 
@@ -129,14 +129,14 @@ func (c *KubeClient) GetPod(namespace, name string) (v1.Pod, error) {
 	// TODO (aramase) wrap this with retries
 	obj, exists, err := c.PodInformer.GetIndexer().GetByKey(namespace + "/" + name)
 	if err != nil {
-		return v1.Pod{}, fmt.Errorf("failed to get pod %s/%s, err: %+v", namespace, name, err)
+		return v1.Pod{}, fmt.Errorf("failed to get pod %s/%s, error: %+v", namespace, name, err)
 	}
 	if !exists {
-		return v1.Pod{}, fmt.Errorf("pod with key %s/%s doesn't exist", namespace, name)
+		return v1.Pod{}, fmt.Errorf("pod %s/%s doesn't exist", namespace, name)
 	}
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		return v1.Pod{}, fmt.Errorf("could not cast %T to %s", pod, "v1.Pod")
+		return v1.Pod{}, fmt.Errorf("could not cast %T to v1.Pod", pod)
 	}
 	return *pod, nil
 }
@@ -144,7 +144,7 @@ func (c *KubeClient) GetPod(namespace, name string) (v1.Pod, error) {
 // GetPodInfo get pod ns,name from apiserver
 func (c *KubeClient) GetPodInfo(podip string) (podns, poddname, rsName string, labels *metav1.LabelSelector, err error) {
 	if podip == "" {
-		return "", "", "", nil, fmt.Errorf("podip is empty")
+		return "", "", "", nil, fmt.Errorf("pod IP is empty")
 	}
 
 	podList, err := c.getPodListRetry(podip, getPodListRetries, getPodListSleepTimeMilliseconds)
@@ -158,7 +158,7 @@ func (c *KubeClient) GetPodInfo(podip string) (podns, poddname, rsName string, l
 			MatchLabels: podList[0].Labels}, nil
 	}
 
-	return "", "", "", nil, fmt.Errorf("match failed, ip:%s matching pods:%v", podip, podList)
+	return "", "", "", nil, fmt.Errorf("failed to match pod IP %s with %v", podip, podList)
 }
 
 func isPhaseValid(p v1.PodPhase) bool {
@@ -171,8 +171,7 @@ func (c *KubeClient) getPodList(podip string) ([]*v1.Pod, error) {
 	for _, o := range list {
 		pod, ok := o.(*v1.Pod)
 		if !ok {
-			err := fmt.Errorf("could not cast %T to %s", pod, "v1.Pod")
-			klog.Error(err)
+			err := fmt.Errorf("could not cast %T to v1.Pod", pod)
 			return nil, err
 		}
 		if pod.Status.PodIP == podip && isPhaseValid(pod.Status.Phase) {
@@ -180,9 +179,7 @@ func (c *KubeClient) getPodList(podip string) ([]*v1.Pod, error) {
 		}
 	}
 	if len(podList) == 0 {
-		err := fmt.Errorf("pod list empty")
-		klog.Error(err)
-		return nil, err
+		return nil, fmt.Errorf("pod list is empty")
 	}
 	return podList, nil
 }
@@ -200,14 +197,14 @@ func (c *KubeClient) getPodListRetry(podip string, retries int, sleeptime time.D
 		}
 		err = c.reporter.ReportKubernetesAPIOperationError(metrics.GetPodListOperationName)
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 
 		if i >= retries {
 			break
 		}
 		i++
-		klog.Warningf("List pod error: %+v. Retrying, attempt number: %d", err, i)
+		klog.Warningf("list pod error: %+v. Retrying, attempt number: %d", err, i)
 		time.Sleep(sleeptime * time.Millisecond)
 	}
 	// We reach here only if there is an error and we have exhausted all retries.
@@ -229,7 +226,7 @@ func GetLocalIP() (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("non loopback ip address not found")
+	return "", fmt.Errorf("non loopback IP address not found")
 }
 
 // ListPodIds lists matching ids for pod or error
@@ -253,7 +250,7 @@ func (c *KubeClient) GetSecret(secretRef *v1.SecretReference) (*v1.Secret, error
 	if err != nil {
 		merr := c.reporter.ReportKubernetesAPIOperationError(metrics.GetSecretOperationName)
 		if merr != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 		return nil, err
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -323,17 +324,15 @@ func (r *Reporter) ReportOperation(operationType string, measurement stats.Measu
 func RegisterAndExport(port string) error {
 	err := registerViews()
 	if err != nil {
-		klog.Errorf("Failed to register views for metrics. error:%v", err)
-		return err
+		return fmt.Errorf("failed to register views for metrics, error:%v", err)
 	}
-	klog.Infof("Registered views for metric")
+	klog.Infof("registered views for metric")
 	exporter, err := newPrometheusExporter(componentNamespace, port)
 	if err != nil {
-		klog.Errorf("Prometheus exporter error: %+v", err)
-		return err
+		return fmt.Errorf("failed to create Prometheus exporter, error: %+v", err)
 	}
 	view.RegisterExporter(exporter)
-	klog.Infof("Registered and exported metrics on port %s", port)
+	klog.Infof("registered and exported metrics on port %s", port)
 	return nil
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -90,7 +90,7 @@ func initTest() (*Reporter, error) {
 	}
 	reporter, err := NewReporter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
+		return nil, fmt.Errorf("failed to create reporter for metrics, error: %+v", err)
 	}
 	return reporter, nil
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"testing"
 
 	"go.opencensus.io/stats"
@@ -89,7 +90,7 @@ func initTest() (*Reporter, error) {
 	}
 	reporter, err := NewReporter()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
 	}
 	return reporter, nil
 }

--- a/pkg/metrics/prometheus_exporter.go
+++ b/pkg/metrics/prometheus_exporter.go
@@ -16,17 +16,16 @@ func newPrometheusExporter(namespace string, portNumber string) (*prometheus.Exp
 	})
 
 	if err != nil {
-		klog.Errorf("Failed to create the Prometheus exporter. error: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create the Prometheus exporter, error: %+v", err)
 	}
-	klog.Info("Starting Prometheus exporter")
+	klog.Info("starting Prometheus exporter")
 	// Run the Prometheus exporter as a scrape endpoint.
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", prometheusExporter)
 		address := fmt.Sprintf(":%v", portNumber)
 		if err := http.ListenAndServe(address, mux); err != nil {
-			klog.Errorf("Failed to run Prometheus scrape endpoint: %v", err)
+			klog.Errorf("failed to run Prometheus scrape endpoint, error: %+v", err)
 		}
 	}()
 	return prometheusExporter, nil

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -225,7 +225,7 @@ func NewMICClient(cfg *Config) (*Client, error) {
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
+		return nil, fmt.Errorf("failed to create reporter for metrics, error: %+v", err)
 	}
 	c.Reporter = reporter
 	return c, nil
@@ -1133,7 +1133,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			}
 			inUse, checkErr := c.checkIfInUse(delID, newAssignedIDs, vmssGroups)
 			if checkErr != nil {
-				klog.Errorf("failed to check if identity is in used, error: %+v", getErr)
+				klog.Errorf("failed to check if identity is in use, error: %+v", getErr)
 				continue
 			}
 			// the identity still exists on node, which means removing the identity from the node failed

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -133,7 +133,7 @@ type trackUserAssignedMSIIds struct {
 
 // NewMICClient returnes new mic client
 func NewMICClient(cfg *Config) (*Client, error) {
-	klog.Infof("Starting to create the pod identity client. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
+	klog.Infof("starting to create the pod identity client. Version: %v. Build date: %v", version.MICVersion, version.BuildDate)
 
 	clientSet := kubernetes.NewForConfigOrDie(cfg.RestConfig)
 
@@ -148,7 +148,7 @@ func NewMICClient(cfg *Config) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	klog.V(1).Infof("Cloud provider initialized")
+	klog.V(1).Infof("cloud provider initialized")
 
 	eventCh := make(chan aadpodid.EventType, 100)
 
@@ -159,7 +159,7 @@ func NewMICClient(cfg *Config) (*Client, error) {
 	klog.V(1).Infof("CRD client initialized")
 
 	podClient := pod.NewPodClient(informer, eventCh)
-	klog.V(1).Infof("Pod Client initialized")
+	klog.V(1).Infof("pod Client initialized")
 
 	cloudConfigWatcher, err := filewatcher.NewFileWatcher(
 		func(event fsnotify.Event) {
@@ -167,10 +167,10 @@ func NewMICClient(cfg *Config) (*Client, error) {
 				if err := cloudClient.Init(); err != nil {
 					return
 				}
-				klog.V(1).Infof("Cloud provider re-initialized")
+				klog.V(1).Infof("cloud provider re-initialized")
 			}
 		}, func(err error) {
-			klog.Error(err)
+			klog.Errorf("failed to handle fsnotify event, error: %+v", err)
 		})
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func NewMICClient(cfg *Config) (*Client, error) {
 	if err := cloudConfigWatcher.Add(cfg.CloudCfgPath); err != nil {
 		return nil, err
 	}
-	klog.V(1).Infof("Cloud config watcher initialized")
+	klog.V(1).Infof("cloud config watcher initialized")
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
@@ -219,15 +219,13 @@ func NewMICClient(cfg *Config) (*Client, error) {
 
 	leaderElector, err := c.NewLeaderElector(clientSet, recorder, cfg.LeaderElectionCfg)
 	if err != nil {
-		klog.Errorf("New leader elector failure. Error: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create new leader elector, error: %+v", err)
 	}
 	c.leaderElector = leaderElector
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		klog.Errorf("Not able to create New Reporter. Error: %+v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create new failed to report metrics, error: %+v", err)
 	}
 	c.Reporter = reporter
 	return c, nil
@@ -235,7 +233,7 @@ func NewMICClient(cfg *Config) (*Client, error) {
 
 // Run - Initiates the leader election run call to find if its leader and run it
 func (c *Client) Run() {
-	klog.Info("Initiating MIC Leader election")
+	klog.Info("initiating MIC Leader election")
 	// counter to track number of mic election
 	c.Reporter.Report(metrics.MICNewLeaderElectionCountM.M(1))
 	c.leaderElector.Run(context.Background())
@@ -253,8 +251,7 @@ func (c *Client) NewLeaderElector(clientSet *kubernetes.Clientset, recorder reco
 			Identity:      c.Instance,
 			EventRecorder: recorder})
 	if err != nil {
-		klog.Errorf("Resource lock creation for leader election failed with error : %v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create resource lock for leader election, error: %+v", err)
 	}
 	config := leaderelection.LeaderElectionConfig{
 		LeaseDuration: c.Duration,
@@ -265,7 +262,7 @@ func (c *Client) NewLeaderElector(clientSet *kubernetes.Clientset, recorder reco
 				c.Start(ctx.Done())
 			},
 			OnStoppedLeading: func() {
-				klog.Errorf("Lost leader lease")
+				klog.Error("lost leader lease")
 				klog.Flush()
 				os.Exit(1)
 			},
@@ -285,7 +282,7 @@ func (c *Client) UpgradeTypeIfRequired() error {
 		cm, err := c.CMClient.Get(c.CMCfg.Name, v1.GetOptions{})
 		// If we get an error and its not NotFound then return, because we cannot proceed.
 		if err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("config map get for %s failed with error: %v", c.CMCfg.Name, err)
+			return fmt.Errorf("failed to get ConfigMap %s/%s, error: %+v", c.CMCfg.Namespace, c.CMCfg.Name, err)
 		}
 
 		// Now either the configmap is not there or we successfully got the configmap
@@ -299,7 +296,7 @@ func (c *Client) UpgradeTypeIfRequired() error {
 				},
 			}
 			if cm, err = c.CMClient.Create(newCfgMap); err != nil {
-				return fmt.Errorf("create configmap %s/%s failed with error: %v", c.CMCfg.Namespace, c.CMCfg.Name, err)
+				return fmt.Errorf("failed to create ConfigMap %s/%s, error: %+v", c.CMCfg.Namespace, c.CMCfg.Name, err)
 			}
 		}
 
@@ -308,11 +305,11 @@ func (c *Client) UpgradeTypeIfRequired() error {
 		// then the upgrade is already performed. If not then go through the type upgrade
 		// process.
 		if v, ok := cm.Data[c.TypeUpgradeCfg.TypeUpgradeStatusKey]; !ok {
-			klog.Infof("Upgrading the types to work with case sensitive go-client")
+			klog.Infof("upgrading the types to work with case sensitive go-client")
 			if err := c.CRDClient.UpgradeAll(); err != nil {
-				return fmt.Errorf("type upgrade failed. error: %+v", err)
+				return fmt.Errorf("failed to upgrade type, error: %+v", err)
 			}
-			klog.Infof("Type upgrade completed !!")
+			klog.Infof("type upgrade completed !!")
 			// Upgrade completed so update the data with the upgrade key.
 			if cm.Data == nil {
 				cm.Data = make(map[string]string)
@@ -320,10 +317,10 @@ func (c *Client) UpgradeTypeIfRequired() error {
 			cm.Data[c.TypeUpgradeCfg.TypeUpgradeStatusKey] = version.MICVersion
 			_, err = c.CMClient.Update(cm)
 			if err != nil {
-				return fmt.Errorf("updating config map key for %s failed. error: %+v", c.TypeUpgradeCfg.TypeUpgradeStatusKey, err)
+				return fmt.Errorf("failed to update ConfigMap key %s failed, error: %+v", c.TypeUpgradeCfg.TypeUpgradeStatusKey, err)
 			}
 		} else {
-			klog.Infof("Type upgrade status configmap found from version: %s. Skipping type upgrade!", v)
+			klog.Infof("type upgrade status configmap found from version: %s. Skipping type upgrade!", v)
 		}
 	}
 	return nil
@@ -334,7 +331,7 @@ func (c *Client) Start(exit <-chan struct{}) {
 	klog.V(6).Infof("MIC client starting..")
 
 	if err := c.UpgradeTypeIfRequired(); err != nil {
-		klog.Fatalf("Type upgrade failed with error: %v", err)
+		klog.Fatalf("type upgrade failed with error: %+v", err)
 		return
 	}
 
@@ -343,7 +340,7 @@ func (c *Client) Start(exit <-chan struct{}) {
 	wg.Add(1)
 	go func() {
 		c.PodClient.Start(exit)
-		klog.V(6).Infof("Pod client started")
+		klog.V(6).Infof("pod client started")
 		wg.Done()
 	}()
 
@@ -357,14 +354,14 @@ func (c *Client) Start(exit <-chan struct{}) {
 	wg.Add(1)
 	go func() {
 		c.NodeClient.Start(exit)
-		klog.V(6).Infof("Node client started")
+		klog.V(6).Infof("node client started")
 		wg.Done()
 	}()
 
 	wg.Add(1)
 	go func() {
 		c.CloudConfigWatcher.Start(exit)
-		klog.V(6).Infof("Cloud config watcher started")
+		klog.V(6).Infof("cloud config watcher started")
 		wg.Done()
 	}()
 
@@ -390,7 +387,7 @@ func (c *Client) Sync(exit <-chan struct{}) {
 	ticker := time.NewTicker(c.syncRetryInterval)
 	defer ticker.Stop()
 
-	klog.Info("Sync thread started.")
+	klog.Info("sync thread started.")
 	c.SyncLoopStarted = true
 	var event aadpodid.EventType
 	totalWorkDoneCycles := 0
@@ -401,9 +398,9 @@ func (c *Client) Sync(exit <-chan struct{}) {
 		case <-exit:
 			return
 		case event = <-c.EventChannel:
-			klog.V(6).Infof("Received event: %v", event)
+			klog.V(6).Infof("received event: %v", event)
 		case <-ticker.C:
-			klog.V(6).Infof("Running periodic sync loop")
+			klog.V(6).Infof("running periodic sync loop")
 		}
 		totalSyncCycles++
 		stats.Init()
@@ -422,22 +419,22 @@ func (c *Client) Sync(exit <-chan struct{}) {
 		systemTime := time.Now()
 		listPods, err := c.PodClient.GetPods()
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("failed to list pods, error: %+v", err)
 			continue
 		}
 		listBindings, err := c.CRDClient.ListBindings()
 		if err != nil {
 			continue
 		}
-		klog.V(6).Infof("Number of bindings: %d", len(*listBindings))
+		klog.V(6).Infof("number of bindings: %d", len(*listBindings))
 		listIDs, err := c.CRDClient.ListIds()
 		if err != nil {
 			continue
 		}
-		klog.V(6).Infof("Number of identities: %d", len(*listIDs))
+		klog.V(6).Infof("number of identities: %d", len(*listIDs))
 		idMap, err := c.convertIDListToMap(*listIDs)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("failed to convert ID list to map, error: %+v", err)
 			continue
 		}
 
@@ -445,13 +442,13 @@ func (c *Client) Sync(exit <-chan struct{}) {
 		if err != nil {
 			continue
 		}
-		klog.V(6).Infof("Number of assigned identities: %d", len(currentAssignedIDs))
+		klog.V(6).Infof("number of assigned identities: %d", len(currentAssignedIDs))
 		stats.Put(stats.System, time.Since(systemTime))
 
 		beginNewListTime := time.Now()
 		newAssignedIDs, nodeRefs, err := c.createDesiredAssignedIdentityList(listPods, listBindings, idMap)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("failed to create a list of desired AzureAssignedIdentity, error: %+v", err)
 			continue
 		}
 		stats.Put(stats.CurrentState, time.Since(beginNewListTime))
@@ -460,12 +457,12 @@ func (c *Client) Sync(exit <-chan struct{}) {
 		// and the ones we have arrived at in the volatile list (newAssignedIDs).
 		addList, err := c.getAzureAssignedIDsToCreate(currentAssignedIDs, newAssignedIDs)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("failed to get a list of AzureAssignedIdentities to create, error: %+v", err)
 			continue
 		}
 		deleteList, err := c.getAzureAssignedIDsToDelete(currentAssignedIDs, newAssignedIDs)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("failed to get a list of AzureAssignedIdentities to delete, error: %+v", err)
 			continue
 		}
 		beforeUpdateList, afterUpdateList := c.getAzureAssignedIdentitiesToUpdate(addList, deleteList)
@@ -511,8 +508,8 @@ func (c *Client) Sync(exit <-chan struct{}) {
 			if listBindings != nil {
 				bindingsFound = len(*listBindings)
 			}
-			klog.Infof("Work done: %v. Found %d pods, %d ids, %d bindings", workDone, len(listPods), idsFound, bindingsFound)
-			klog.Infof("Total work cycles: %d, out of which work was done in: %d", totalSyncCycles, totalWorkDoneCycles)
+			klog.Infof("work done: %v. Found %d pods, %d ids, %d bindings", workDone, len(listPods), idsFound, bindingsFound)
+			klog.Infof("total work cycles: %d, out of which work was done in: %d", totalSyncCycles, totalWorkDoneCycles)
 			stats.Put(stats.Total, time.Since(begin))
 
 			c.Reporter.Report(
@@ -570,31 +567,31 @@ func (c *Client) createDesiredAssignedIdentityList(
 	newAssignedIDs := make(map[string]aadpodid.AzureAssignedIdentity)
 
 	for _, pod := range listPods {
-		klog.V(6).Infof("Checking pod %s/%s", pod.Namespace, pod.Name)
+		klog.V(6).Infof("checking pod %s/%s", pod.Namespace, pod.Name)
 		if pod.Spec.NodeName == "" {
 			//Node is not yet allocated. In that case skip the pod
-			klog.V(2).Infof("Pod %s/%s has no assigned node yet. it will be ignored", pod.Namespace, pod.Name)
+			klog.V(2).Infof("pod %s/%s has no assigned node yet. it will be ignored", pod.Namespace, pod.Name)
 			continue
 		}
 		crdPodLabelVal := pod.Labels[aadpodid.CRDLabelKey]
-		klog.V(6).Infof("Pod: %s/%s. Label value: %v", pod.Namespace, pod.Name, crdPodLabelVal)
+		klog.V(6).Infof("pod: %s/%s. Label value: %v", pod.Namespace, pod.Name, crdPodLabelVal)
 		if crdPodLabelVal == "" {
 			//No binding mentioned in the label. Just continue to the next pod
-			klog.V(2).Infof("Pod %s/%s has correct %s label but with no value. it will be ignored", pod.Namespace, pod.Name, aadpodid.CRDLabelKey)
+			klog.V(2).Infof("pod %s/%s has correct %s label but with no value. it will be ignored", pod.Namespace, pod.Name, aadpodid.CRDLabelKey)
 			continue
 		}
 		var matchedBindings []aadpodid.AzureIdentityBinding
 		for _, allBinding := range *listBindings {
-			klog.V(6).Infof("Check the binding (pod - %s/%s): %s", pod.Namespace, pod.Name, allBinding.Spec.Selector)
+			klog.V(6).Infof("check the binding (pod - %s/%s): %s", pod.Namespace, pod.Name, allBinding.Spec.Selector)
 			if allBinding.Spec.Selector == crdPodLabelVal {
-				klog.V(5).Infof("Found binding match for pod %s/%s with binding %s/%s", pod.Namespace, pod.Name, allBinding.Namespace, allBinding.Name)
+				klog.V(5).Infof("found binding match for pod %s/%s with binding %s/%s", pod.Namespace, pod.Name, allBinding.Namespace, allBinding.Name)
 				matchedBindings = append(matchedBindings, allBinding)
 				nodeRefs[pod.Spec.NodeName] = true
 			}
 		}
 
 		for _, binding := range matchedBindings {
-			klog.V(5).Infof("Looking up id map: %s/%s", binding.Namespace, binding.Spec.AzureIdentity)
+			klog.V(5).Infof("looking up id map: %s/%s", binding.Namespace, binding.Spec.AzureIdentity)
 			if azureID, idPresent := idMap[getIDKey(binding.Namespace, binding.Spec.AzureIdentity)]; idPresent {
 				// working in Namespaced mode or this specific identity is namespaced
 				if c.IsNamespaced || aadpodid.IsNamespacedIdentity(&azureID) {
@@ -609,7 +606,7 @@ func (c *Client) createDesiredAssignedIdentityList(
 				assignedID, err := c.makeAssignedIDs(azureID, binding, pod.Name, pod.Namespace, pod.Spec.NodeName)
 
 				if err != nil {
-					klog.Errorf("failed to create assignment for pod %s/%s with identity %s/%s with error %v", pod.Namespace, pod.Name, azureID.Namespace, azureID.Name, err.Error())
+					klog.Errorf("failed to create an AzureAssignedIdentity between pod %s/%s and AzureIdentity %s/%s, error: %+v", pod.Namespace, pod.Name, azureID.Namespace, azureID.Name, err)
 					continue
 				}
 				newAssignedIDs[assignedID.Name] = *assignedID
@@ -632,7 +629,7 @@ func (c *Client) getListOfIdsToDelete(deleteList, beforeUpdateList, afterUpdateL
 	nodeRefs map[string]bool) {
 	vmssGroups, err := getVMSSGroups(c.NodeClient, nodeRefs)
 	if err != nil {
-		klog.Error(err)
+		klog.Errorf("failed to get VMSS groups, error: %+v", err)
 		return
 	}
 
@@ -647,7 +644,7 @@ func (c *Client) getListOfIdsToDelete(deleteList, beforeUpdateList, afterUpdateL
 	for _, delID := range deleteList {
 		err := c.shouldRemoveID(delID, consolidatedMapToCheck, nodeMap, vmssGroups)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("failed to check if identity should be removed, error: %+v", err)
 		}
 	}
 	// this loop checks the azure identity before it was updated and cleans up
@@ -655,7 +652,7 @@ func (c *Client) getListOfIdsToDelete(deleteList, beforeUpdateList, afterUpdateL
 	for _, oldUpdateID := range beforeUpdateList {
 		err := c.shouldRemoveID(oldUpdateID, consolidatedMapToCheck, nodeMap, vmssGroups)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("failed to check if identity should be removed, error: %+v", err)
 		}
 	}
 }
@@ -679,13 +676,13 @@ func (c *Client) shouldAssignID(assignedID aadpodid.AzureAssignedIdentity, nodeM
 			c.appendToAddListForNode(id.Spec.ResourceID, assignedID.Spec.NodeName, nodeMap)
 		}
 	}
-	klog.V(5).Infof("Binding applied: %+v", assignedID.Spec.AzureBindingRef)
+	klog.V(5).Infof("binding applied: %+v", assignedID.Spec.AzureBindingRef)
 }
 
 func (c *Client) shouldRemoveID(assignedID aadpodid.AzureAssignedIdentity,
 	newAssignedIDs map[string]aadpodid.AzureAssignedIdentity,
 	nodeMap map[string]trackUserAssignedMSIIds, vmssGroups *vmssGroupList) error {
-	klog.V(5).Infof("Deletion of id: %s", assignedID.Name)
+	klog.V(5).Infof("deletion of id: %s", assignedID.Name)
 	inUse, err := c.checkIfInUse(assignedID, newAssignedIDs, vmssGroups)
 	if err != nil {
 		return err
@@ -702,7 +699,7 @@ func (c *Client) shouldRemoveID(assignedID aadpodid.AzureAssignedIdentity,
 			c.appendToRemoveListForNode(id.Spec.ResourceID, assignedID.Spec.NodeName, nodeMap)
 		}
 	}
-	klog.V(5).Infof("Binding removed: %+v", assignedID.Spec.AzureBindingRef)
+	klog.V(5).Infof("binding removed: %+v", assignedID.Spec.AzureBindingRef)
 	return nil
 }
 
@@ -854,8 +851,8 @@ func (c *Client) makeAssignedIDs(azID aadpodid.AzureIdentity, azBinding aadpodid
 		assignedID.Namespace = "default"
 	}
 
-	klog.V(6).Infof("Binding - %+v Identity - %+v", azBinding, azID)
-	klog.V(5).Infof("Making assigned ID: %+v", assignedID)
+	klog.V(6).Infof("binding - %+v identity - %+v", azBinding, azID)
+	klog.V(5).Infof("making assigned ID: %+v", assignedID)
 	return assignedID, nil
 }
 
@@ -929,7 +926,7 @@ func (c *Client) convertIDListToMap(azureIdentities []aadpodid.AzureIdentity) (m
 		if c.checkIfUserAssignedMSI(azureIdentity) {
 			err := utils.ValidateResourceID(azureIdentity.Spec.ResourceID)
 			if err != nil {
-				klog.Errorf("Ignoring azure identity %s/%s, error: %v", azureIdentity.Namespace, azureIdentity.Name, err)
+				klog.Errorf("ignoring azure identity %s/%s, error: %+v", azureIdentity.Namespace, azureIdentity.Name, err)
 				continue
 			}
 		}
@@ -1006,7 +1003,7 @@ func (c *Client) updateNodeAndDeps(newAssignedIDs map[string]aadpodid.AzureAssig
 func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedIdentity, nodeOrVMSSName string, nodeTrackList trackUserAssignedMSIIds, nodeRefs map[string]bool, wg *sync.WaitGroup) {
 	defer wg.Done()
 	beginAdding := time.Now()
-	klog.Infof("Processing node %s, add [%d], del [%d], update [%d]", nodeOrVMSSName,
+	klog.Infof("processing node %s, add [%d], del [%d], update [%d]", nodeOrVMSSName,
 		len(nodeTrackList.assignedIDsToCreate), len(nodeTrackList.assignedIDsToDelete), len(nodeTrackList.assignedIDsToUpdate))
 
 	ctx := context.TODO()
@@ -1018,7 +1015,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	for _, createID := range nodeTrackList.assignedIDsToCreate {
 		if err := semCreateOrUpdate.Acquire(ctx, 1); err != nil {
-			klog.Errorf("Failed to acquire semaphore in the create loop: %v", err)
+			klog.Errorf("failed to acquire semaphore in the create loop, error: %+v", err)
 			return
 		}
 		go func(assignedID aadpodid.AzureAssignedIdentity) {
@@ -1027,14 +1024,14 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 				binding := assignedID.Spec.AzureBindingRef
 
 				// this is the state when the azure assigned identity is yet to be created
-				klog.V(5).Infof("Initiating assigned id creation for pod - %s, binding - %s", assignedID.Spec.Pod, binding.Name)
+				klog.V(5).Infof("initiating AzureAssignedIdentity creation for pod - %s, binding - %s", assignedID.Spec.Pod, binding.Name)
 
 				assignedID.Status.Status = aadpodid.AssignedIDCreated
 				err := c.createAssignedIdentity(&assignedID)
 				if err != nil {
-					c.EventRecorder.Event(binding, corev1.EventTypeWarning, "binding apply error",
-						fmt.Sprintf("Creating assigned identity for pod %s resulted in error %v", assignedID.Name, err))
-					klog.Error(err)
+					message := fmt.Sprintf("failed to create AzureAssignedIdentity %s/%s for pod %s/%s, error: %+v", assignedID.Name, assignedID.Namespace, assignedID.Spec.PodNamespace, assignedID.Spec.Pod, err)
+					c.EventRecorder.Event(binding, corev1.EventTypeWarning, "binding apply error", message)
+					klog.Error(message)
 				}
 			}
 		}(createID)
@@ -1042,7 +1039,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	for _, updateID := range nodeTrackList.assignedIDsToUpdate {
 		if err := semCreateOrUpdate.Acquire(ctx, 1); err != nil {
-			klog.Errorf("Failed to acquire semaphore in the update loop: %v", err)
+			klog.Errorf("failed to acquire semaphore in the update loop, error: %+v", err)
 			return
 		}
 		go func(assignedID aadpodid.AzureAssignedIdentity) {
@@ -1051,14 +1048,14 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 				binding := assignedID.Spec.AzureBindingRef
 
 				// this is the state when the azure assigned identity is yet to be created
-				klog.V(5).Infof("Initiating assigned id creation for pod - %s, binding - %s", assignedID.Spec.Pod, binding.Name)
+				klog.V(5).Infof("initiating assigned id creation for pod - %s, binding - %s", assignedID.Spec.Pod, binding.Name)
 
 				assignedID.Status.Status = aadpodid.AssignedIDCreated
 				err := c.updateAssignedIdentity(&assignedID)
 				if err != nil {
-					c.EventRecorder.Event(binding, corev1.EventTypeWarning, "binding apply error",
-						fmt.Sprintf("Updating assigned identity for pod %s/%s resulted in error %v", assignedID.Namespace, assignedID.Name, err))
-					klog.Error(err)
+					message := fmt.Sprintf("failed to update AzureAssignedIdentity %s/%s for pod %s/%s, error %+v", assignedID.Namespace, assignedID.Name, assignedID.Spec.Pod, assignedID.Spec.PodNamespace, err)
+					c.EventRecorder.Event(binding, corev1.EventTypeWarning, "binding apply error", message)
+					klog.Error(message)
 				}
 			}
 		}(updateID)
@@ -1066,7 +1063,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	// Ensure that all creates are complete
 	if err := semCreateOrUpdate.Acquire(ctx, c.createDeleteBatch); err != nil {
-		klog.Errorf("Failed to acquire semaphore at the end of creates: %v", err)
+		klog.Errorf("failed to acquire semaphore at the end of creates, error: %+v", err)
 		return
 	}
 	// generate unique list so we don't make multiple calls to assign/remove same id
@@ -1077,10 +1074,10 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	err := c.CloudClient.UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs, nodeOrVMSSName, nodeTrackList.isvmss)
 	if err != nil {
-		klog.Errorf("Updating msis on node %s, add [%d], del [%d], update[%d] failed with error %v", nodeOrVMSSName, len(nodeTrackList.assignedIDsToCreate), len(nodeTrackList.assignedIDsToDelete), len(nodeTrackList.assignedIDsToUpdate), err)
+		klog.Errorf("failed to update user-assigned identities on node %s (add [%d], del [%d], update[%d]), error: %+v", nodeOrVMSSName, len(nodeTrackList.assignedIDsToCreate), len(nodeTrackList.assignedIDsToDelete), len(nodeTrackList.assignedIDsToUpdate), err)
 		idList, getErr := c.getUserMSIListForNode(nodeOrVMSSName, nodeTrackList.isvmss)
 		if getErr != nil {
-			klog.Errorf("Getting list of msis from node %s resulted in error %v", nodeOrVMSSName, getErr)
+			klog.Errorf("failed to get a list of user-assigned identites from node %s, error: %+v", nodeOrVMSSName, getErr)
 			return
 		}
 
@@ -1092,20 +1089,20 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			idExistsOnNode := c.checkIfMSIExistsOnNode(id, createID.Spec.NodeName, idList)
 
 			if isUserAssignedMSI && !idExistsOnNode {
-				message := fmt.Sprintf("Applying binding %s node %s for pod %s resulted in error %v", binding.Name, createID.Spec.NodeName, createID.Name, err.Error())
+				message := fmt.Sprintf("failed to apply binding %s/%s node %s for pod %s/%s, error: %+v", binding.Namespace, binding.Name, createID.Spec.NodeName, createID.Spec.PodNamespace, createID.Spec.Pod, err)
 				c.EventRecorder.Event(binding, corev1.EventTypeWarning, "binding apply error", message)
 				klog.Error(message)
 				continue
 			}
 			// the identity was successfully assigned to the node
 			c.EventRecorder.Event(binding, corev1.EventTypeNormal, "binding applied",
-				fmt.Sprintf("Binding %s applied on node %s for pod %s", binding.Name, createID.Spec.NodeName, createID.Name))
+				fmt.Sprintf("binding %s applied on node %s for pod %s", binding.Name, createID.Spec.NodeName, createID.Name))
 
-			klog.Infof("Identity %s/%s has successfully been assigned to node %s", id.Namespace, id.Name, createID.Spec.NodeName)
+			klog.Infof("identity %s/%s has successfully been assigned to node %s", id.Namespace, id.Name, createID.Spec.NodeName)
 
 			// Identity is successfully assigned to node, so update the status of assigned identity to assigned
 			if updateErr := c.updateAssignedIdentityStatus(&createID, aadpodid.AssignedIDAssigned); updateErr != nil {
-				message := fmt.Sprintf("Updating assigned identity %s status to %s for pod %s failed with error %v", createID.Name, aadpodid.AssignedIDAssigned, createID.Spec.Pod, updateErr.Error())
+				message := fmt.Sprintf("failed to update AzureAssignedIdentity %s/%s status to %s for pod %s/%s, error: %+v", createID.Namespace, createID.Name, aadpodid.AssignedIDAssigned, createID.Spec.PodNamespace, createID.Spec.Pod, updateErr)
 				c.EventRecorder.Event(&createID, corev1.EventTypeWarning, "status update error", message)
 				klog.Error(message)
 			}
@@ -1131,27 +1128,26 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			idExistsOnNode := c.checkIfMSIExistsOnNode(id, delID.Spec.NodeName, idList)
 			vmssGroups, getErr := getVMSSGroups(c.NodeClient, nodeRefs)
 			if getErr != nil {
-				klog.Error(getErr)
+				klog.Errorf("failed to get VMSS groups, error: %+v", getErr)
 				continue
 			}
 			inUse, checkErr := c.checkIfInUse(delID, newAssignedIDs, vmssGroups)
 			if checkErr != nil {
-				klog.Error(checkErr)
+				klog.Errorf("failed to check if identity is in used, error: %+v", getErr)
 				continue
 			}
 			// the identity still exists on node, which means removing the identity from the node failed
 			if isUserAssignedMSI && !inUse && idExistsOnNode {
-				message := fmt.Sprintf("Binding %s removal from node %s for pod %s resulted in error %v", removedBinding.Name, delID.Spec.NodeName, delID.Spec.Pod, err.Error())
-				klog.Error(message)
+				klog.Errorf("failed to remove AzureIdentityBinding %s from node %s for pod %s/%s, error: %+v", removedBinding.Name, delID.Spec.NodeName, delID.Spec.PodNamespace, delID.Spec.Pod, err)
 				continue
 			}
 
-			klog.Infof("Updating msis on node %s failed, but identity %s/%s has successfully been removed from node", delID.Spec.NodeName, id.Namespace, id.Name)
+			klog.Infof("updating msis on node %s failed, but identity %s/%s has successfully been removed from node", delID.Spec.NodeName, id.Namespace, id.Name)
 
 			// remove assigned identity crd from cluster as the identity has successfully been removed from the node
 			err = c.removeAssignedIdentity(&delID)
 			if err != nil {
-				klog.Error(err)
+				klog.Errorf("failed to remove AzureAssignedIdentity %s, error: %+v", delID.Name, err)
 				continue
 			}
 			klog.Infof("deleted assigned identity %s/%s", delID.Namespace, delID.Name)
@@ -1165,7 +1161,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	for _, createID := range createOrUpdateList {
 		if err := semUpdate.Acquire(ctx, 1); err != nil {
-			klog.Errorf("Failed to acquire semaphore in the update loop: %v", err)
+			klog.Errorf("failed to acquire semaphore in the update loop, error: %+v", err)
 			return
 		}
 		go func(assignedID aadpodid.AzureAssignedIdentity) {
@@ -1174,7 +1170,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			// update the status to assigned for assigned identity as identity was successfully assigned to node.
 			err := c.updateAssignedIdentityStatus(&assignedID, aadpodid.AssignedIDAssigned)
 			if err != nil {
-				message := fmt.Sprintf("Updating assigned identity %s status to %s for pod %s failed with error %v", assignedID.Name, aadpodid.AssignedIDAssigned, assignedID.Spec.Pod, err.Error())
+				message := fmt.Sprintf("failed to update AzureAssignedIdentity %s/%s status to %s for pod %s, error: %+v", assignedID.Namespace, assignedID.Name, aadpodid.AssignedIDAssigned, assignedID.Spec.Pod, err.Error())
 				c.EventRecorder.Event(&assignedID, corev1.EventTypeWarning, "status update error", message)
 				klog.Error(message)
 				return
@@ -1186,7 +1182,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	// Ensure that all updates are complete
 	if err := semUpdate.Acquire(ctx, c.createDeleteBatch); err != nil {
-		klog.Errorf("Failed to acquire semaphore at the end of updates: %v", err)
+		klog.Errorf("failed to acquire semaphore at the end of updates, error: %+v", err)
 		return
 	}
 
@@ -1194,7 +1190,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	for _, delID := range nodeTrackList.assignedIDsToDelete {
 		if err := semDel.Acquire(ctx, 1); err != nil {
-			klog.Errorf("Failed to acquire semaphore in the delete loop: %v", err)
+			klog.Errorf("failed to acquire semaphore in the delete loop, error: %+v", err)
 			return
 		}
 		go func(assignedID aadpodid.AzureAssignedIdentity) {
@@ -1203,7 +1199,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			// this will ensure on next sync loop we only try to delete the assigned identity instead of doing everything.
 			err := c.updateAssignedIdentityStatus(&assignedID, aadpodid.AssignedIDUnAssigned)
 			if err != nil {
-				message := fmt.Sprintf("Updating assigned identity %s status to %s for pod %s failed with error %v", assignedID.Name, aadpodid.AssignedIDUnAssigned, assignedID.Spec.Pod, err.Error())
+				message := fmt.Sprintf("failed to update AzureAssignedIdentity %s/%s status to %s for pod %s/%s, error: %+v", assignedID.Namespace, assignedID.Name, aadpodid.AssignedIDUnAssigned, assignedID.Spec.PodNamespace, assignedID.Spec.Pod, err)
 				c.EventRecorder.Event(&assignedID, corev1.EventTypeWarning, "status update error", message)
 				klog.Error(message)
 				return
@@ -1211,7 +1207,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 			// remove assigned identity crd from cluster as the identity has successfully been removed from the node
 			err = c.removeAssignedIdentity(&assignedID)
 			if err != nil {
-				klog.Error(err)
+				klog.Errorf("failed to remove AzureAssignedIdentity %s/%s, error: %+v", assignedID.Namespace, assignedID.Name, err)
 				return
 			}
 			klog.V(1).Infof("deleted assigned identity %s/%s", assignedID.Namespace, assignedID.Name)
@@ -1220,7 +1216,7 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 
 	// Ensure that all deletes are complete
 	if err := semDel.Acquire(ctx, c.createDeleteBatch); err != nil {
-		klog.Errorf("Failed to acquire semaphore at the end of deletes: %v", err)
+		klog.Errorf("failed to acquire semaphore at the end of deletes, error: %+v", err)
 		return
 	}
 
@@ -1239,9 +1235,9 @@ func (c *Client) cleanUpAllAssignedIdentitiesOnNode(node string, nodeTrackList t
 
 		err := c.removeAssignedIdentity(&deleteID)
 		if err != nil {
-			c.EventRecorder.Event(binding, corev1.EventTypeWarning, "binding remove error",
-				fmt.Sprintf("Removing assigned identity binding %s node %s for pod %s resulted in error %v", binding.Name, deleteID.Spec.NodeName, deleteID.Name, err.Error()))
-			klog.Error(err)
+			message := fmt.Sprintf("failed to remove AzureIdentityBinding %s/%s from node %s for pod %s/%s, error %v", binding.Namespace, binding.Name, deleteID.Spec.NodeName, deleteID.Spec.PodNamespace, deleteID.Spec.Pod, err)
+			c.EventRecorder.Event(binding, corev1.EventTypeWarning, "binding remove error", message)
+			klog.Error(message)
 			continue
 		}
 		c.EventRecorder.Event(binding, corev1.EventTypeNormal, "binding removed",
@@ -1258,11 +1254,11 @@ func (c *Client) consolidateVMSSNodes(nodeMap map[string]trackUserAssignedMSIIds
 	for nodeName, nodeTrackList := range nodeMap {
 		node, err := c.NodeClient.Get(nodeName)
 		if err != nil && !strings.Contains(err.Error(), "not found") {
-			klog.Errorf("Unable to get node %s. Error %v", nodeName, err)
+			klog.Errorf("failed to get node %s, error %+v", nodeName, err)
 			continue
 		}
 		if err != nil && strings.Contains(err.Error(), "not found") {
-			klog.Warningf("Unable to get node %s while updating user msis. Error %v", nodeName, err)
+			klog.Warningf("failed to get node %s while updating user-assigned identities, error: %+v", nodeName, err)
 			wg.Add(1)
 			// node is no longer found in the cluster, all the assigned identities that were created in this sync loop
 			// and those that already exist for this node need to be deleted.
@@ -1272,7 +1268,7 @@ func (c *Client) consolidateVMSSNodes(nodeMap map[string]trackUserAssignedMSIIds
 		}
 		vmssName, isvmss, err := isVMSS(node)
 		if err != nil {
-			klog.Errorf("error checking if node %s is vmss. Error: %v", nodeName, err)
+			klog.Errorf("failed to check if node %s is VMSS, error: %+v", nodeName, err)
 			continue
 		}
 		if isvmss {

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -280,7 +280,7 @@ func (c *TestCloudClient) CompareMSI(nodeName string, userIDs []string) bool {
 
 func (c *TestCloudClient) PrintMSI() {
 	for key, val := range c.ListMSI() {
-		klog.Infof("\nNode name: %s", key)
+		klog.Infof("\nnode name: %s", key)
 		if val != nil {
 			for i, id := range *val {
 				klog.Infof("%d) %s", i, id)
@@ -363,7 +363,7 @@ func NewTestPodClient() *TestPodClient {
 }
 
 func (c *TestPodClient) Start(exit <-chan struct{}) {
-	klog.Info("Start called from the test interface")
+	klog.Info("start called from the test interface")
 }
 
 func (c *TestPodClient) GetPods() ([]*corev1.Pod, error) {
@@ -912,7 +912,7 @@ func TestSimpleMICClient(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 
 	assignedID := (*listAssignedIDs)[0]
@@ -940,7 +940,7 @@ func TestSimpleMICClient(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	if (*listAssignedIDs)[0].Status.Status != aadpodid.AssignedIDCreated {
 		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDCreated, (*listAssignedIDs)[0].Status.Status)
@@ -974,7 +974,7 @@ func TestUpdateAssignedIdentities(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 
 	assignedID := (*listAssignedIDs)[0]
@@ -999,7 +999,7 @@ func TestUpdateAssignedIdentities(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	// check updated assigned identity has the right resource id
 	if listAssignedIDs != nil {
@@ -1070,7 +1070,7 @@ func TestAddUpdateDel(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("failed to list assigned ids, err: %v", err)
+		t.Fatalf("failed to list assigned ids, error: %+v", err)
 	}
 	// check the updated identity has the correct azureid ref
 	for _, assignedID := range *listAssignedIDs {
@@ -1263,7 +1263,7 @@ func TestMICStateFlow(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
 		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
@@ -1285,7 +1285,7 @@ func TestMICStateFlow(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
 		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
@@ -1310,7 +1310,7 @@ func TestMICStateFlow(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	for _, assignedID := range *listAssignedIDs {
 		if assignedID.Spec.Pod == "test-pod1" {
@@ -1363,7 +1363,7 @@ func TestForceNamespaced(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
 		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
@@ -1385,7 +1385,7 @@ func TestForceNamespaced(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 
 	for _, assignedID := range *listAssignedIDs {
@@ -1430,7 +1430,7 @@ func TestSyncRetryLoop(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
 		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
@@ -1452,7 +1452,7 @@ func TestSyncRetryLoop(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	if !((*listAssignedIDs)[0].Status.Status == aadpodid.AssignedIDAssigned) {
 		t.Fatalf("expected status to be %s, got: %s", aadpodid.AssignedIDAssigned, (*listAssignedIDs)[0].Status.Status)
@@ -1496,7 +1496,7 @@ func TestSyncNodeNotFound(t *testing.T) {
 	}
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	for i := range *listAssignedIDs {
 		if !((*listAssignedIDs)[i].Status.Status == aadpodid.AssignedIDAssigned) {
@@ -1523,7 +1523,7 @@ func TestSyncNodeNotFound(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	for i := range *listAssignedIDs {
 		if !((*listAssignedIDs)[i].Status.Status == aadpodid.AssignedIDAssigned) {
@@ -1562,7 +1562,7 @@ func TestProcessingTimeForScale(t *testing.T) {
 
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 20000) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 20000, len(*listAssignedIDs))
@@ -1578,7 +1578,7 @@ func TestProcessingTimeForScale(t *testing.T) {
 	}
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 	if !(len(*listAssignedIDs) == 10000) {
 		t.Fatalf("expected assigned identities len: %d, got: %d", 10000, len(*listAssignedIDs))
@@ -1718,7 +1718,7 @@ func TestCloudProviderRetryLoop(t *testing.T) {
 
 	listAssignedIDs, err := crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 
 	assignedID := findAssignedIDByName("test-pod-1-default-test-id-1", listAssignedIDs)
@@ -1746,7 +1746,7 @@ func TestCloudProviderRetryLoop(t *testing.T) {
 
 	listAssignedIDs, err = crdClient.ListAssignedIDs()
 	if err != nil {
-		t.Fatalf("list assigned ids failed with err: %v", err)
+		t.Fatalf("list assigned ids failed , error: %+v", err)
 	}
 
 	assignedID = findAssignedIDByName("test-pod-1-default-test-id-1", listAssignedIDs)

--- a/pkg/nmi/iptables/iptables.go
+++ b/pkg/nmi/iptables/iptables.go
@@ -55,7 +55,7 @@ func LogCustomChain() error {
 	if err != nil {
 		return err
 	}
-	klog.V(5).Infof("Rules for table(%s) chain(%s) rules(%+v)", tablename, customchainname, strings.Join(rules, ", "))
+	klog.V(5).Infof("rules for table(%s) chain(%s) rules(%+v)", tablename, customchainname, strings.Join(rules, ", "))
 
 	return nil
 }
@@ -120,7 +120,7 @@ func ensureCustomChain(ipt *iptables.IPTables, destIP, destPort, targetip, targe
 }
 
 func flushCreateCustomChainrules(ipt *iptables.IPTables, destIP, destPort, targetip, targetport string) error {
-	klog.Warning("Flushing iptables to add aad-metadata custom chains")
+	klog.Warning("flushing iptables to add aad-metadata custom chains")
 	if err := ipt.ClearChain(tablename, customchainname); err != nil {
 		return err
 	}

--- a/pkg/nmi/managed.go
+++ b/pkg/nmi/managed.go
@@ -38,12 +38,12 @@ func (mc *ManagedClient) GetIdentities(ctx context.Context, podns, podname, clie
 	// get pod object to retrieve labels
 	pod, err := mc.KubeClient.GetPod(podns, podname)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pod %s/%s, err: %+v", podns, podname, err)
+		return nil, fmt.Errorf("failed to get pod %s/%s, error: %+v", podns, podname, err)
 	}
 	// get all the azure identities based on azure identity bindings
 	azureIdentities, err := mc.KubeClient.ListPodIdsWithBinding(podns, pod.Labels)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get azure identities %s/%s, err: %+v", podns, podname, err)
+		return nil, fmt.Errorf("failed to get AzureIdentities for pod %s/%s, error: %+v", podns, podname, err)
 	}
 	identityUnspecified := len(clientID) == 0 && len(resourceID) == 0
 	for _, id := range azureIdentities {
@@ -60,7 +60,7 @@ func (mc *ManagedClient) GetIdentities(ctx context.Context, podns, podname, clie
 
 		// if client doesn't exist in the request, then return the first identity in the same namespace as the pod
 		if identityUnspecified && strings.EqualFold(id.Namespace, podns) {
-			klog.Infof("No clientID or resourceID in request. %s/%s has been matched with azure identity %s/%s", podns, podname, id.Namespace, id.Name)
+			klog.Infof("no clientID or resourceID in request. %s/%s has been matched with azure identity %s/%s", podns, podname, id.Namespace, id.Name)
 			return &id, nil
 		}
 	}
@@ -76,7 +76,7 @@ func (mc *ManagedClient) GetToken(ctx context.Context, rqClientID, rqResource st
 	switch idType {
 	case aadpodid.UserAssignedMSI:
 		if rqHasClientID && !strings.EqualFold(rqClientID, clientID) {
-			klog.Warningf("clientid mismatch, requested:%s available:%s", rqClientID, clientID)
+			klog.Warningf("client ID mismatch, requested:%s available:%s", rqClientID, clientID)
 		}
 		klog.Infof("matched identityType:%v clientid:%s resource:%s", idType, utils.RedactClientID(clientID), rqResource)
 		token, err := auth.GetServicePrincipalTokenFromMSIWithUserAssignedID(clientID, rqResource)

--- a/pkg/nmi/nmi.go
+++ b/pkg/nmi/nmi.go
@@ -49,7 +49,7 @@ type TokenClient interface {
 
 // GetTokenClient returns a token client
 func GetTokenClient(client k8s.Client, config Config) (TokenClient, error) {
-	klog.Infof("Initializing in %s mode", config.Mode)
+	klog.Infof("initializing in %s mode", config.Mode)
 
 	switch getOperationMode(config.Mode) {
 	case StandardMode:

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -65,7 +65,7 @@ type MetadataResponse struct {
 func NewServer(micNamespace string, blockInstanceMetadata bool, metadataHeaderRequired bool) *Server {
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		klog.Errorf("Error creating new reporter to emit metrics: %v", err)
+		klog.Errorf("failed to create new failed to report metrics, error: %+v", err)
 	} else {
 		// keeping this reference to be used in ServeHTTP, as server is not accessible in ServeHTTP
 		appHandlerReporter = reporter
@@ -93,9 +93,9 @@ func (s *Server) Run() error {
 	}
 	mux.Handle("/", appHandler(s.defaultPathHandler))
 
-	klog.Infof("Listening on port %s", s.NMIPort)
+	klog.Infof("listening on port %s", s.NMIPort)
 	if err := http.ListenAndServe("localhost:"+s.NMIPort, mux); err != nil {
-		klog.Fatalf("Error creating http server: %+v", err)
+		klog.Fatalf("error creating http server: %+v", err)
 	}
 	return nil
 }
@@ -180,14 +180,14 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			default:
 				err = errors.New("Unknown error")
 			}
-			klog.Errorf("Panic processing request: %+v, file: %s, line: %d, stacktrace: '%s' %s res.status=%d", r, file, line, stack, tracker, http.StatusInternalServerError)
+			klog.Errorf("panic processing request: %+v, file: %s, line: %d, stacktrace: '%s' %s res.status=%d", r, file, line, stack, tracker, http.StatusInternalServerError)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}()
 	rw := newResponseWriter(w)
 	ns := fn(rw, r)
 	latency := time.Since(start)
-	klog.Infof("Status (%d) took %d ns for %s", rw.statusCode, latency.Nanoseconds(), tracker)
+	klog.Infof("status (%d) took %d ns for %s", rw.statusCode, latency.Nanoseconds(), tracker)
 
 	tokenRequest := parseTokenRequest(r)
 
@@ -199,7 +199,7 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			tokenRequest.Resource,
 			metrics.NMIOperationsDurationM.M(metrics.SinceInSeconds(start)))
 		if err != nil {
-			klog.Warningf("Metrics reporter error: %+v", err)
+			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}
 }
@@ -229,13 +229,13 @@ func (s *Server) hostHandler(w http.ResponseWriter, r *http.Request) (ns string)
 
 	podID, err := s.TokenClient.GetIdentities(r.Context(), podns, podname, tokenRequest.ClientID, tokenRequest.ResourceID)
 	if err != nil {
-		klog.Error(err)
+		klog.Errorf("failed to get identities, error: %+v", err)
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	token, err := s.TokenClient.GetToken(r.Context(), tokenRequest.ClientID, tokenRequest.Resource, *podID)
 	if err != nil {
-		klog.Errorf("failed to get service principal token for pod:%s/%s, err: %+v", podns, podname, err)
+		klog.Errorf("failed to get service principal token for pod:%s/%s, error: %+v", podns, podname, err)
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
@@ -245,7 +245,7 @@ func (s *Server) hostHandler(w http.ResponseWriter, r *http.Request) (ns string)
 	}
 	response, err := json.Marshal(nmiResp)
 	if err != nil {
-		klog.Errorf("failed to marshal service principal token and clientid for pod:%s/%s, err: %+v", podns, podname, err)
+		klog.Errorf("failed to marshal service principal token and clientid for pod:%s/%s, error: %+v", podns, podname, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -293,21 +293,19 @@ func (s *Server) getTokenForExceptedPod(rqClientID, rqResource string) ([]byte, 
 	var err error
 	// ClientID is empty, so we are going to use System assigned MSI
 	if rqClientID == "" {
-		klog.Infof("Fetching token for system assigned MSI")
+		klog.Infof("fetching token for system assigned MSI")
 		token, err = auth.GetServicePrincipalTokenFromMSI(rqResource)
 	} else { // User assigned identity usage.
-		klog.Infof("Fetching token for user assigned MSI for resource: %s", rqResource)
+		klog.Infof("fetching token for user assigned MSI for resource: %s", rqResource)
 		token, err = auth.GetServicePrincipalTokenFromMSIWithUserAssignedID(rqClientID, rqResource)
 	}
 	if err != nil {
-		klog.Errorf("Failed to get service principal token, err: %+v", err)
 		// TODO: return the right status code based on the error we got from adal.
-		return nil, http.StatusForbidden, err
+		return nil, http.StatusForbidden, fmt.Errorf("failed to get service principal token, error: %+v", err)
 	}
 	response, err := json.Marshal(newMSIResponse(*token))
 	if err != nil {
-		klog.Errorf("Failed to marshal service principal token, err: %+v", err)
-		return nil, http.StatusInternalServerError, err
+		return nil, http.StatusInternalServerError, fmt.Errorf("failed to marshal service principal token, error: %+v", err)
 	}
 	return response, http.StatusOK, nil
 }
@@ -340,7 +338,7 @@ func (s *Server) msiHandler(w http.ResponseWriter, r *http.Request) (ns string) 
 
 	podns, podname, rsName, selectors, err := s.KubeClient.GetPodInfo(podIP)
 	if err != nil {
-		klog.Errorf("missing podname for podip:%s, %+v", podIP, err)
+		klog.Errorf("failed to get pod info from pod IP: %s, error %+v", podIP, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -355,10 +353,10 @@ func (s *Server) msiHandler(w http.ResponseWriter, r *http.Request) (ns string) 
 
 	// If its mic, then just directly get the token and pass back.
 	if pod.IsPodExcepted(selectors.MatchLabels, *exceptionList) || s.isMIC(podns, rsName) {
-		klog.Infof("Exception pod %s/%s token handling", podns, podname)
+		klog.Infof("exception pod %s/%s token handling", podns, podname)
 		response, errorCode, err := s.getTokenForExceptedPod(tokenRequest.ClientID, tokenRequest.Resource)
 		if err != nil {
-			klog.Errorf("failed to get service principal token for pod:%s/%s.  Error code: %d. Error: %+v", podns, podname, errorCode, err)
+			klog.Errorf("failed to get service principal token for pod:%s/%s with error code %d, error: %+v", podns, podname, errorCode, err)
 			http.Error(w, err.Error(), errorCode)
 			return
 		}
@@ -481,7 +479,7 @@ func (s *Server) defaultPathHandler(w http.ResponseWriter, r *http.Request) (ns 
 	client := &http.Client{}
 	req, err := http.NewRequest(r.Method, r.URL.String(), r.Body)
 	if err != nil || req == nil {
-		klog.Errorf("failed creating a new request for %s, err: %+v", r.URL.String(), err)
+		klog.Errorf("failed creating a new request for %s, error: %+v", r.URL.String(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -494,7 +492,7 @@ func (s *Server) defaultPathHandler(w http.ResponseWriter, r *http.Request) (ns 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		klog.Errorf("failed executing request for %s, err: %+v", req.URL.String(), err)
+		klog.Errorf("failed executing request for %s, error: %+v", req.URL.String(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -505,7 +503,7 @@ func (s *Server) defaultPathHandler(w http.ResponseWriter, r *http.Request) (ns 
 	}()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		klog.Errorf("failed io operation of reading response body for %s, %+v", req.URL.String(), err)
+		klog.Errorf("failed to read response body for %s, error: %+v", req.URL.String(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 	_, _ = w.Write(body)
@@ -526,19 +524,19 @@ func copyHeader(dst, src http.Header) {
 }
 
 func handleTermination() {
-	klog.Info("Received SIGTERM, shutting down")
+	klog.Info("received SIGTERM, shutting down")
 
 	exitCode := 0
 	// clean up iptables
 	if err := iptables.DeleteCustomChain(); err != nil {
-		klog.Errorf("Error cleaning up during shutdown: %v", err)
+		klog.Errorf("failed to clean up during shutdown, error: %+v", err)
 		exitCode = 1
 	}
 
 	// wait for pod to delete
-	klog.Info("Handled termination, awaiting pod deletion")
+	klog.Info("handled termination, awaiting pod deletion")
 	time.Sleep(10 * time.Second)
 
-	klog.Infof("Exiting with %v", exitCode)
+	klog.Infof("exiting with %v", exitCode)
 	os.Exit(exitCode)
 }

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -65,7 +65,7 @@ type MetadataResponse struct {
 func NewServer(micNamespace string, blockInstanceMetadata bool, metadataHeaderRequired bool) *Server {
 	reporter, err := metrics.NewReporter()
 	if err != nil {
-		klog.Errorf("failed to create new failed to report metrics, error: %+v", err)
+		klog.Errorf("failed to create reporter for metrics, error: %+v", err)
 	} else {
 		// keeping this reference to be used in ServeHTTP, as server is not accessible in ServeHTTP
 		appHandlerReporter = reporter

--- a/pkg/nmi/standard.go
+++ b/pkg/nmi/standard.go
@@ -69,7 +69,7 @@ func (sc *StandardClient) GetIdentities(ctx context.Context, podns, podname, cli
 	// If the client did not request a specific identity, then return the first identity
 	if len(clientID) == 0 && len(resourceID) == 0 {
 		id := filterPodIdentities[0]
-		klog.Infof("No clientID or resourceID in request. %s/%s has been matched with azure identity %s/%s", podns, podname, id.Namespace, id.Name)
+		klog.Infof("no clientID or resourceID in request. %s/%s has been matched with azure identity %s/%s", podns, podname, id.Namespace, id.Name)
 		return &id, nil
 	}
 
@@ -119,7 +119,7 @@ func (sc *StandardClient) listPodIDsWithRetry(ctx context.Context, podns, podnam
 					return idStateMap[aadpodid.AssignedIDAssigned], true, nil
 				}
 				if len(idStateMap[aadpodid.AssignedIDCreated]) == 0 && attempt >= sc.ListPodIDsRetryAttemptsForCreated {
-					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s. Error: %v",
+					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s, error: %+v",
 						podns, podname, sc.ListPodIDsRetryAttemptsForCreated, sc.ListPodIDsRetryIntervalInSeconds, err)
 				}
 			} else {
@@ -145,7 +145,7 @@ func (sc *StandardClient) listPodIDsWithRetry(ctx context.Context, podns, podnam
 					}
 				}
 				if !foundMatch && attempt >= sc.ListPodIDsRetryAttemptsForCreated {
-					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s. Error: %v",
+					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s, error: %+v",
 						podns, podname, sc.ListPodIDsRetryAttemptsForCreated, sc.ListPodIDsRetryIntervalInSeconds, err)
 				}
 			}
@@ -160,7 +160,7 @@ func (sc *StandardClient) listPodIDsWithRetry(ctx context.Context, podns, podnam
 		}
 		klog.V(4).Infof("failed to get assigned ids for pod:%s/%s in ASSIGNED state, retrying attempt: %d", podns, podname, attempt)
 	}
-	return nil, true, fmt.Errorf("getting assigned identities for pod %s/%s in ASSIGNED state failed after %d attempts, retry duration [%d]s. Error: %v",
+	return nil, true, fmt.Errorf("getting assigned identities for pod %s/%s in ASSIGNED state failed after %d attempts, retry duration [%d]s, error: %+v",
 		podns, podname, sc.ListPodIDsRetryAttemptsForCreated+sc.ListPodIDsRetryAttemptsForAssigned, sc.ListPodIDsRetryIntervalInSeconds, err)
 }
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -41,12 +41,12 @@ func addPodHandler(i informersv1.PodInformer, eventCh chan aadpodid.EventType) {
 	i.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				klog.V(6).Infof("Pod Created")
+				klog.V(6).Infof("pod created")
 				eventCh <- aadpodid.PodCreated
 
 			},
 			DeleteFunc: func(obj interface{}) {
-				klog.V(6).Infof("Pod Deleted")
+				klog.V(6).Infof("pod deleted")
 				eventCh <- aadpodid.PodDeleted
 
 			},
@@ -65,19 +65,19 @@ func addPodHandler(i informersv1.PodInformer, eventCh chan aadpodid.EventType) {
 
 func (c *Client) syncCache(exit <-chan struct{}) {
 	cacheSyncStarted := time.Now()
-	klog.V(6).Infof("Wait for cache to sync")
+	klog.V(6).Infof("wait for cache to sync")
 	if !cache.WaitForCacheSync(exit, c.PodWatcher.Informer().HasSynced) {
-		klog.Error("Wait for pod cache sync failed")
+		klog.Error("wait for pod cache sync failed")
 		return
 	}
-	klog.Infof("Pod cache synchronized. Took %s", time.Since(cacheSyncStarted).String())
+	klog.Infof("pod cache synchronized. Took %s", time.Since(cacheSyncStarted).String())
 }
 
 // Start ...
 func (c *Client) Start(exit <-chan struct{}) {
 	go c.PodWatcher.Informer().Run(exit)
 	c.syncCache(exit)
-	klog.Info("Pod watcher started !!")
+	klog.Info("pod watcher started !!")
 }
 
 // GetPods returns list of all pods
@@ -85,7 +85,6 @@ func (c *Client) GetPods() (pods []*v1.Pod, err error) {
 	begin := time.Now()
 	crdReq, err := labels.NewRequirement(aadpodid.CRDLabelKey, selection.Exists, nil)
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 	crdSelector := labels.NewSelector().Add(*crdReq)

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -15,7 +15,7 @@ type TestPodClient struct {
 }
 
 func (c TestPodClient) Start(exit <-chan struct{}) {
-	klog.Info("Start called from the test interface")
+	klog.Info("start called from the test interface")
 }
 
 func (c TestPodClient) GetPods() (pods []*corev1.Pod, err error) {

--- a/pkg/probes/probes.go
+++ b/pkg/probes/probes.go
@@ -24,11 +24,10 @@ func InitHealthProbe(condition *bool) {
 func startAsync(port string) {
 	err := http.ListenAndServe(":"+port, nil)
 	if err != nil {
-		klog.Errorf("Http listen and serve error: %+v", err)
-		panic(err)
-	} else {
-		klog.Info("Http listen and serve started !")
+		klog.Fatalf("http listen and serve error: %+v", err)
 	}
+
+	klog.Info("http listen and serve started !")
 }
 
 //Start - Starts the required http server to start the probe to respond.
@@ -39,8 +38,8 @@ func Start(port string) {
 // InitAndStart - Initialize the default probes and starts the http listening port.
 func InitAndStart(port string, condition *bool) {
 	InitHealthProbe(condition)
-	klog.Infof("Initialized health probe on port %s", port)
+	klog.Infof("initialized health probe on port %s", port)
 	// start the probe.
 	Start(port)
-	klog.Info("Started health probe")
+	klog.Info("started health probe")
 }

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -96,7 +96,7 @@ func UpdateCount(key Type, val int) {
 }
 
 func PrintSync() {
-	klog.Infof("** Stats collected **")
+	klog.Infof("** stats collected **")
 	if GlobalStats != nil {
 		//first we list the
 		Print(PodList)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,7 +20,7 @@ func redact(src, repl string) string {
 func ValidateResourceID(resourceID string) error {
 	isValid := regexp.MustCompile(`(?i)/subscriptions/(.+?)/resourcegroups/(.+?)/providers/Microsoft.ManagedIdentity/userAssignedIdentities/(.+)`).MatchString
 	if !isValid(resourceID) {
-		return fmt.Errorf("Invalid resource id: %q, must match /subscriptions/<subid>/resourcegroups/<resourcegroup>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>", resourceID)
+		return fmt.Errorf("invalid resource id: %q, must match /subscriptions/<subid>/resourcegroups/<resourcegroup>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>", resourceID)
 	}
 	return nil
 }

--- a/test/e2e/identityvalidator/identityvalidator.go
+++ b/test/e2e/identityvalidator/identityvalidator.go
@@ -43,13 +43,13 @@ func main() {
 	podnamespace := os.Getenv("E2E_TEST_POD_NAMESPACE")
 	podip := os.Getenv("E2E_TEST_POD_IP")
 
-	klog.Infof("Starting identity validator pod %s/%s %s", podnamespace, podname, podip)
+	klog.Infof("starting identity validator pod %s/%s with pod IP %s", podnamespace, podname, podip)
 
 	msiEndpoint, err := adal.GetMSIVMEndpoint()
 	if err != nil {
-		klog.Fatalf("Failed to get msiEndpoint: %+v", err)
+		klog.Fatalf("failed to get MSI endpoint, error: %+v", err)
 	}
-	klog.Infof("Successfully obtain MSIEndpoint: %s\n", msiEndpoint)
+	klog.Infof("successfully obtain MSI endpoint: %s\n", msiEndpoint)
 
 	ctx, ctxCancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer ctxCancel()
@@ -88,7 +88,7 @@ func testClusterWideUserAssignedIdentity(ctx context.Context, msiEndpoint, subsc
 		return errors.Wrapf(err, "Failed to verify cluster-wide user assigned identity")
 	}
 
-	klog.Infof("Successfully verified cluster-wide user assigned identity. VM count: %d", len(vmlist.Values()))
+	klog.Infof("successfully verified cluster-wide user assigned identity. VM count: %d", len(vmlist.Values()))
 	return nil
 }
 
@@ -161,7 +161,7 @@ func testUserAssignedIdentityOnPod(ctx context.Context, msiEndpoint, identityCli
 		return errors.Wrapf(err, "Failed to verify user assigned identity on pod")
 	}
 
-	klog.Infof("Successfully verified user assigned identity on pod")
+	klog.Infof("successfully verified user-assigned identity on pod")
 	return nil
 }
 
@@ -181,6 +181,6 @@ func testSystemAssignedIdentity(msiEndpoint string) (*adal.Token, error) {
 		return nil, errors.Errorf("No token found, MSI VM extension, msiEndpoint(%s)", msiEndpoint)
 	}
 
-	klog.Infof("Successfully acquired a token using the MSI, msiEndpoint(%s)", msiEndpoint)
+	klog.Infof("successfully acquired a token using the MSI, msiEndpoint(%s)", msiEndpoint)
 	return &token, nil
 }


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Logging and returning the error are both considered error handling. We should only choose one method to handle the error but not both.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #604.

**Notes for Reviewers**:
