### PR TITLE
fix: check if identity exists before assign in e2e

### DIFF
--- a/test/e2e/framework/azure/vm_manager.go
+++ b/test/e2e/framework/azure/vm_manager.go
@@ -53,7 +53,15 @@ func (m *vmManager) AssignUserAssignedIdentity(vmName, identityToAssign string) 
 		}
 	}
 
-	vm.Identity.UserAssignedIdentities[fmt.Sprintf(ResourceIDTemplate, m.config.SubscriptionID, m.config.IdentityResourceGroup, identityToAssign)] = &compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
+	identityAssignResourceID := fmt.Sprintf(ResourceIDTemplate, m.config.SubscriptionID, m.config.IdentityResourceGroup, identityToAssign)
+	for identity := range vm.Identity.UserAssignedIdentities {
+		// identity already exists and doesn't need to be re-assigned
+		if strings.EqualFold(identity, identityAssignResourceID) {
+			return nil
+		}
+	}
+
+	vm.Identity.UserAssignedIdentities[identityAssignResourceID] = &compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
 	switch vm.Identity.Type {
 	case compute.ResourceIdentityTypeSystemAssigned:
 		vm.Identity.Type = compute.ResourceIdentityTypeSystemAssignedUserAssigned

--- a/test/e2e/framework/azure/vm_manager.go
+++ b/test/e2e/framework/azure/vm_manager.go
@@ -52,6 +52,9 @@ func (m *vmManager) AssignUserAssignedIdentity(vmName, identityToAssign string) 
 			UserAssignedIdentities: map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{},
 		}
 	}
+	if vm.Identity.UserAssignedIdentities == nil {
+		vm.Identity.UserAssignedIdentities = make(map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue)
+	}
 
 	identityAssignResourceID := fmt.Sprintf(ResourceIDTemplate, m.config.SubscriptionID, m.config.IdentityResourceGroup, identityToAssign)
 	for identity := range vm.Identity.UserAssignedIdentities {
@@ -80,7 +83,7 @@ func (m *vmManager) UnassignUserAssignedIdentity(vmName, identityToUnassign stri
 		return err
 	}
 
-	if vm.Identity == nil {
+	if vm.Identity == nil || len(vm.Identity.UserAssignedIdentities) == 0 {
 		return nil
 	}
 

--- a/test/e2e/framework/azure/vmss_manager.go
+++ b/test/e2e/framework/azure/vmss_manager.go
@@ -52,6 +52,9 @@ func (m *vmssManager) AssignUserAssignedIdentity(vmssName, identityToAssign stri
 			UserAssignedIdentities: map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{},
 		}
 	}
+	if vmss.Identity.UserAssignedIdentities == nil {
+		vmss.Identity.UserAssignedIdentities = make(map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue)
+	}
 
 	identityAssignResourceID := fmt.Sprintf(ResourceIDTemplate, m.config.SubscriptionID, m.config.IdentityResourceGroup, identityToAssign)
 	for identity := range vmss.Identity.UserAssignedIdentities {
@@ -80,7 +83,7 @@ func (m *vmssManager) UnassignUserAssignedIdentity(vmssName, identityToUnassign 
 		return err
 	}
 
-	if vmss.Identity == nil {
+	if vmss.Identity == nil || len(vmss.Identity.UserAssignedIdentities) == 0 {
 		return nil
 	}
 

--- a/test/e2e/framework/azure/vmss_manager.go
+++ b/test/e2e/framework/azure/vmss_manager.go
@@ -53,7 +53,15 @@ func (m *vmssManager) AssignUserAssignedIdentity(vmssName, identityToAssign stri
 		}
 	}
 
-	vmss.Identity.UserAssignedIdentities[fmt.Sprintf(ResourceIDTemplate, m.config.SubscriptionID, m.config.IdentityResourceGroup, identityToAssign)] = &compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
+	identityAssignResourceID := fmt.Sprintf(ResourceIDTemplate, m.config.SubscriptionID, m.config.IdentityResourceGroup, identityToAssign)
+	for identity := range vmss.Identity.UserAssignedIdentities {
+		// identity already exists and doesn't need to be re-assigned
+		if strings.EqualFold(identity, identityAssignResourceID) {
+			return nil
+		}
+	}
+
+	vmss.Identity.UserAssignedIdentities[identityAssignResourceID] = &compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
 	switch vmss.Identity.Type {
 	case compute.ResourceIdentityTypeSystemAssigned:
 		vmss.Identity.Type = compute.ResourceIdentityTypeSystemAssignedUserAssigned


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
The case of the `resourceID` returned from the `GET` can differ from the `resourceID` we construct. It's best to check if the identity exists, and if does skip the assignment. This should resolve the flakes we are seeing with assigning identity during the e2e runs.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
