### PR TITLE
test: add e2e tests with resource id

### DIFF
--- a/test/e2e/disruptive_test.go
+++ b/test/e2e/disruptive_test.go
@@ -86,12 +86,13 @@ var _ = Describe("[PR] When AAD Pod Identity operations are disrupted", func() {
 			})
 
 			identityvalidator.Validate(identityvalidator.ValidateInput{
-				Getter:           kubeClient,
-				Config:           config,
-				KubeconfigPath:   kubeconfigPath,
-				PodName:          identityValidator.Name,
-				Namespace:        ns.Name,
-				IdentityClientID: azureIdentity.Spec.ClientID,
+				Getter:             kubeClient,
+				Config:             config,
+				KubeconfigPath:     kubeconfigPath,
+				PodName:            identityValidator.Name,
+				Namespace:          ns.Name,
+				IdentityClientID:   azureIdentity.Spec.ClientID,
+				IdentityResourceID: azureIdentity.Spec.ResourceID,
 			})
 		}()
 

--- a/test/e2e/framework/identityvalidator/identityvalidator_helpers.go
+++ b/test/e2e/framework/identityvalidator/identityvalidator_helpers.go
@@ -212,14 +212,15 @@ func Delete(input DeleteInput) {
 
 // ValidateInput is the input for Validate.
 type ValidateInput struct {
-	Getter           framework.Getter
-	Config           *framework.Config
-	KubeconfigPath   string
-	PodName          string
-	Namespace        string
-	IdentityClientID string
-	ExpectError      bool
-	InitContainer    bool
+	Getter             framework.Getter
+	Config             *framework.Config
+	KubeconfigPath     string
+	PodName            string
+	Namespace          string
+	IdentityClientID   string
+	IdentityResourceID string
+	ExpectError        bool
+	InitContainer      bool
 }
 
 // Validate performs validation against an identity-validator pod.
@@ -263,6 +264,10 @@ func Validate(input ValidateInput) {
 		input.Config.KeyvaultSecretName,
 		"--keyvault-secret-version",
 		input.Config.KeyvaultSecretVersion,
+	}
+
+	if input.IdentityResourceID != "" {
+		args = append(args, "--identity-resource-id", input.IdentityResourceID)
 	}
 
 	_, err := exec.KubectlExec(input.KubeconfigPath, input.PodName, input.Namespace, args)

--- a/test/e2e/init_containers_test.go
+++ b/test/e2e/init_containers_test.go
@@ -79,13 +79,14 @@ var _ = Describe("[PR] When init containers are enabled", func() {
 
 	It("should assign identity with init container", func() {
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
-			InitContainer:    true,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
+			InitContainer:      true,
 		})
 	})
 })

--- a/test/e2e/invalid_identities_test.go
+++ b/test/e2e/invalid_identities_test.go
@@ -102,12 +102,13 @@ var _ = Describe("[PR] When deploying invalid identities", func() {
 
 			if tc.noError {
 				identityvalidator.Validate(identityvalidator.ValidateInput{
-					Getter:           kubeClient,
-					Config:           config,
-					KubeconfigPath:   kubeconfigPath,
-					PodName:          identityValidators[i].Name,
-					Namespace:        ns.Name,
-					IdentityClientID: azureIdentities[i].Spec.ClientID,
+					Getter:             kubeClient,
+					Config:             config,
+					KubeconfigPath:     kubeconfigPath,
+					PodName:            identityValidators[i].Name,
+					Namespace:          ns.Name,
+					IdentityClientID:   azureIdentities[i].Spec.ClientID,
+					IdentityResourceID: azureIdentities[i].Spec.ResourceID,
 				})
 			}
 		}
@@ -130,12 +131,13 @@ var _ = Describe("[PR] When deploying invalid identities", func() {
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          validIdentityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentities[0].Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            validIdentityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentities[0].Spec.ClientID,
+			IdentityResourceID: azureIdentities[0].Spec.ResourceID,
 		})
 
 		invalidIdentityValidators := identityvalidator.CreateBatch(identityvalidator.CreateBatchInput{
@@ -156,12 +158,13 @@ var _ = Describe("[PR] When deploying invalid identities", func() {
 		}
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          validIdentityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentities[0].Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            validIdentityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentities[0].Spec.ClientID,
+			IdentityResourceID: azureIdentities[0].Spec.ResourceID,
 		})
 	})
 })

--- a/test/e2e/multiple_identities_test.go
+++ b/test/e2e/multiple_identities_test.go
@@ -97,12 +97,13 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 			})
 
 			identityvalidator.Validate(identityvalidator.ValidateInput{
-				Getter:           kubeClient,
-				Config:           config,
-				KubeconfigPath:   kubeconfigPath,
-				PodName:          identityValidators[i].Name,
-				Namespace:        ns.Name,
-				IdentityClientID: azureIdentities[i].Spec.ClientID,
+				Getter:             kubeClient,
+				Config:             config,
+				KubeconfigPath:     kubeconfigPath,
+				PodName:            identityValidators[i].Name,
+				Namespace:          ns.Name,
+				IdentityClientID:   azureIdentities[i].Spec.ClientID,
+				IdentityResourceID: azureIdentities[i].Spec.ResourceID,
 			})
 
 			// Break when finish checking the entire list
@@ -126,12 +127,13 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 				})
 
 				identityvalidator.Validate(identityvalidator.ValidateInput{
-					Getter:           kubeClient,
-					Config:           config,
-					KubeconfigPath:   kubeconfigPath,
-					PodName:          identityValidators[j].Name,
-					Namespace:        ns.Name,
-					IdentityClientID: azureIdentities[j].Spec.ClientID,
+					Getter:             kubeClient,
+					Config:             config,
+					KubeconfigPath:     kubeconfigPath,
+					PodName:            identityValidators[j].Name,
+					Namespace:          ns.Name,
+					IdentityClientID:   azureIdentities[j].Spec.ClientID,
+					IdentityResourceID: azureIdentities[j].Spec.ResourceID,
 				})
 			}
 		}
@@ -166,12 +168,13 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 			})
 
 			identityvalidator.Validate(identityvalidator.ValidateInput{
-				Getter:           kubeClient,
-				Config:           config,
-				KubeconfigPath:   kubeconfigPath,
-				PodName:          identityValidators[i].Name,
-				Namespace:        ns.Name,
-				IdentityClientID: azureIdentities[i%size].Spec.ClientID,
+				Getter:             kubeClient,
+				Config:             config,
+				KubeconfigPath:     kubeconfigPath,
+				PodName:            identityValidators[i].Name,
+				Namespace:          ns.Name,
+				IdentityClientID:   azureIdentities[i%size].Spec.ClientID,
+				IdentityResourceID: azureIdentities[i%size].Spec.ResourceID,
 			})
 		}
 		Expect(time.Since(start) <= 150*time.Second).To(BeTrue(), "Creation and validation of 40 AzureAssignedIdentities took more than 150 seconds")
@@ -194,12 +197,13 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentities[0].Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentities[0].Spec.ClientID,
+			IdentityResourceID: azureIdentities[0].Spec.ResourceID,
 		})
 
 		identityvalidator.UpdatePodLabel(identityvalidator.UpdatePodLabelInput{
@@ -219,12 +223,13 @@ var _ = Describe("[PR] When deploying multiple identities", func() {
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentities[1].Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentities[1].Spec.ClientID,
+			IdentityResourceID: azureIdentities[1].Spec.ResourceID,
 		})
 	})
 })

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -159,12 +159,13 @@ var _ = Describe("[PR] When managing identities from the underlying nodes", func
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
 		})
 
 		// Since we don't know where the identity-validator is scheduled to,
@@ -219,12 +220,13 @@ var _ = Describe("[PR] When managing identities from the underlying nodes", func
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
 		})
 
 		By("Verifying that the Principal ID and Tenant ID of the system-assigned identity haven't been altered")
@@ -261,12 +263,13 @@ var _ = Describe("[PR] When managing identities from the underlying nodes", func
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
 		})
 
 		By(fmt.Sprintf("Ensuring both keyvault-identity and cluster-identity are assigned to %s", node.Name))
@@ -329,12 +332,13 @@ var _ = Describe("[PR] When managing identities from the underlying nodes", func
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
 		})
 
 		identityvalidator.Delete(identityvalidator.DeleteInput{

--- a/test/e2e/single_identity_test.go
+++ b/test/e2e/single_identity_test.go
@@ -85,12 +85,13 @@ var _ = Describe("[PR] When deploying one identity", func() {
 
 	It("should pass the identity validation", func() {
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
 		})
 	})
 
@@ -118,13 +119,14 @@ var _ = Describe("[PR] When deploying one identity", func() {
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
-			ExpectError:      true,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
+			ExpectError:        true,
 		})
 	})
 
@@ -140,13 +142,14 @@ var _ = Describe("[PR] When deploying one identity", func() {
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
-			ExpectError:      true,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
+			ExpectError:        true,
 		})
 	})
 
@@ -168,12 +171,13 @@ var _ = Describe("[PR] When deploying one identity", func() {
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
 		})
 	})
 
@@ -210,22 +214,24 @@ var _ = Describe("[PR] When deploying one identity", func() {
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentity.Spec.ClientID,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentity.Spec.ClientID,
+			IdentityResourceID: azureIdentity.Spec.ResourceID,
 		})
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
-			Getter:           kubeClient,
-			Config:           config,
-			KubeconfigPath:   kubeconfigPath,
-			PodName:          identityValidator.Name,
-			Namespace:        ns.Name,
-			IdentityClientID: azureIdentityWithoutGetPermission.Spec.ClientID,
-			ExpectError:      true,
+			Getter:             kubeClient,
+			Config:             config,
+			KubeconfigPath:     kubeconfigPath,
+			PodName:            identityValidator.Name,
+			Namespace:          ns.Name,
+			IdentityClientID:   azureIdentityWithoutGetPermission.Spec.ClientID,
+			IdentityResourceID: azureIdentityWithoutGetPermission.Spec.ResourceID,
+			ExpectError:        true,
 		})
 	})
 })


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Enhances e2e tests to validate with `resourceID` along with `clientID`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #679 

**Notes for Reviewers**:
