### PR TITLE
fix: set max pods and assign empty map for system-assigned identity cleanup

### DIFF
--- a/.pipelines/soak-tests-template.yml
+++ b/.pipelines/soak-tests-template.yml
@@ -6,7 +6,7 @@ jobs:
   - ${{ each clusterConfig in parameters.clusterConfigs }}:
     - job:
       displayName: ${{ format('soak/{0}', clusterConfig) }}
-      # dependsOn: unit_tests
+      dependsOn: unit_tests
       timeoutInMinutes: 120
       cancelTimeoutInMinutes: 5
       workspace:

--- a/test/e2e/cluster_configs/vmas.json
+++ b/test/e2e/cluster_configs/vmas.json
@@ -10,7 +10,10 @@
                         "name": "aad-pod-identity",
                         "enabled": false
                     }
-                ]
+                ],
+                "kubeletConfig": {
+                    "--max-pods": "${MAX_PODS}"
+                }
             }
         },
         "masterProfile": {

--- a/test/e2e/cluster_configs/vmss.json
+++ b/test/e2e/cluster_configs/vmss.json
@@ -10,7 +10,10 @@
                         "name": "aad-pod-identity",
                         "enabled": false
                     }
-                ]
+                ],
+                "kubeletConfig": {
+                    "--max-pods": "${MAX_PODS}"
+                }
             }
         },
         "masterProfile": {

--- a/test/e2e/framework/azure/vm_manager.go
+++ b/test/e2e/framework/azure/vm_manager.go
@@ -125,6 +125,8 @@ func (m *vmManager) EnableSystemAssignedIdentity(vmName string) error {
 		}
 	} else {
 		switch vm.Identity.Type {
+		case compute.ResourceIdentityTypeSystemAssigned, compute.ResourceIdentityTypeSystemAssignedUserAssigned:
+			return nil
 		case compute.ResourceIdentityTypeUserAssigned:
 			vm.Identity.Type = compute.ResourceIdentityTypeSystemAssignedUserAssigned
 		default:
@@ -148,9 +150,12 @@ func (m *vmManager) DisableSystemAssignedIdentity(vmName string) error {
 	}
 
 	switch vm.Identity.Type {
+	case compute.ResourceIdentityTypeNone, compute.ResourceIdentityTypeUserAssigned:
+		return nil
 	case compute.ResourceIdentityTypeSystemAssignedUserAssigned:
 		vm.Identity.Type = compute.ResourceIdentityTypeUserAssigned
 	default:
+		vm.Identity.UserAssignedIdentities = nil
 		vm.Identity.Type = compute.ResourceIdentityTypeNone
 	}
 

--- a/test/e2e/framework/azure/vmss_manager.go
+++ b/test/e2e/framework/azure/vmss_manager.go
@@ -125,6 +125,8 @@ func (m *vmssManager) EnableSystemAssignedIdentity(vmssName string) error {
 		}
 	} else {
 		switch vmss.Identity.Type {
+		case compute.ResourceIdentityTypeSystemAssigned, compute.ResourceIdentityTypeSystemAssignedUserAssigned:
+			return nil
 		case compute.ResourceIdentityTypeUserAssigned:
 			vmss.Identity.Type = compute.ResourceIdentityTypeSystemAssignedUserAssigned
 		default:
@@ -148,9 +150,12 @@ func (m *vmssManager) DisableSystemAssignedIdentity(vmssName string) error {
 	}
 
 	switch vmss.Identity.Type {
+	case compute.ResourceIdentityTypeNone, compute.ResourceIdentityTypeUserAssigned:
+		return nil
 	case compute.ResourceIdentityTypeSystemAssignedUserAssigned:
 		vmss.Identity.Type = compute.ResourceIdentityTypeUserAssigned
 	default:
+		vmss.Identity.UserAssignedIdentities = nil
 		vmss.Identity.Type = compute.ResourceIdentityTypeNone
 	}
 

--- a/test/e2e/identity_exception_test.go
+++ b/test/e2e/identity_exception_test.go
@@ -50,8 +50,12 @@ var _ = Describe("[PR] When deploying AzurePodIdentityException", func() {
 
 		err := azureClient.AssignUserAssignedIdentity(node.Spec.ProviderID, keyvaultIdentity)
 		Expect(err).To(BeNil())
+		err = azureClient.EnableSystemAssignedIdentity(node.Spec.ProviderID)
+		Expect(err).To(BeNil())
 		defer func() {
 			err := azureClient.UnassignUserAssignedIdentity(node.Spec.ProviderID, keyvaultIdentity)
+			Expect(err).To(BeNil())
+			err = azureClient.DisableSystemAssignedIdentity(node.Spec.ProviderID)
 			Expect(err).To(BeNil())
 		}()
 


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
