### PR TITLE
fix: assign empty struct to user-assigned identities when enabling system-assigned identity

### DIFF
--- a/test/e2e/framework/azure/vm_manager.go
+++ b/test/e2e/framework/azure/vm_manager.go
@@ -129,6 +129,9 @@ func (m *vmManager) EnableSystemAssignedIdentity(vmName string) error {
 			return nil
 		case compute.ResourceIdentityTypeUserAssigned:
 			vm.Identity.Type = compute.ResourceIdentityTypeSystemAssignedUserAssigned
+			for identity := range vm.Identity.UserAssignedIdentities {
+				vm.Identity.UserAssignedIdentities[identity] = &compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
+			}
 		default:
 			vm.Identity.Type = compute.ResourceIdentityTypeSystemAssigned
 		}
@@ -154,6 +157,9 @@ func (m *vmManager) DisableSystemAssignedIdentity(vmName string) error {
 		return nil
 	case compute.ResourceIdentityTypeSystemAssignedUserAssigned:
 		vm.Identity.Type = compute.ResourceIdentityTypeUserAssigned
+		for identity := range vm.Identity.UserAssignedIdentities {
+			vm.Identity.UserAssignedIdentities[identity] = &compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
+		}
 	default:
 		vm.Identity.UserAssignedIdentities = nil
 		vm.Identity.Type = compute.ResourceIdentityTypeNone

--- a/test/e2e/framework/azure/vmss_manager.go
+++ b/test/e2e/framework/azure/vmss_manager.go
@@ -129,6 +129,9 @@ func (m *vmssManager) EnableSystemAssignedIdentity(vmssName string) error {
 			return nil
 		case compute.ResourceIdentityTypeUserAssigned:
 			vmss.Identity.Type = compute.ResourceIdentityTypeSystemAssignedUserAssigned
+			for identity := range vmss.Identity.UserAssignedIdentities {
+				vmss.Identity.UserAssignedIdentities[identity] = &compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
+			}
 		default:
 			vmss.Identity.Type = compute.ResourceIdentityTypeSystemAssigned
 		}
@@ -154,6 +157,9 @@ func (m *vmssManager) DisableSystemAssignedIdentity(vmssName string) error {
 		return nil
 	case compute.ResourceIdentityTypeSystemAssignedUserAssigned:
 		vmss.Identity.Type = compute.ResourceIdentityTypeUserAssigned
+		for identity := range vmss.Identity.UserAssignedIdentities {
+			vmss.Identity.UserAssignedIdentities[identity] = &compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
+		}
 	default:
 		vmss.Identity.UserAssignedIdentities = nil
 		vmss.Identity.Type = compute.ResourceIdentityTypeNone


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Fixes https://dev.azure.com/azure/aad-pod-identity/_build/results?buildId=12452&view=logs&jobId=d34132c9-c567-574e-81c3-10e22b0eb456&j=d34132c9-c567-574e-81c3-10e22b0eb456&t=4f1c18c1-9aa8-5644-f886-bb4554109216

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
