### PR TITLE
 fix: use single quotes when performing string comparsion in ADO

### DIFF
--- a/.pipelines/soak-tests-template.yml
+++ b/.pipelines/soak-tests-template.yml
@@ -17,12 +17,6 @@ jobs:
         - name: CLUSTER_CONFIG
           value: ${{ format('{0}', clusterConfig) }}
       steps:
-        - task: DownloadSecureFile@1
-          name: kubeconfig
-          inputs:
-            secureFile: ${{ format('{0}', clusterConfig) }}
-          displayName: "Download KUBECONFIG"
-
         - task: GoTool@0
           inputs:
             version: '1.14.1'
@@ -36,13 +30,20 @@ jobs:
             sudo mv kubectl /usr/local/bin/
           displayName: "Install tools"
 
-        - ${{ if eq(clusterConfig, "pi-aks-e2e-daily") }}:
+        - ${{ if eq(clusterConfig, 'pi-aks-e2e-daily') }}:
           - script: |
               az aks get-credentials \
                 --resource-group $(CLUSTER_CONFIG) \
                 --name $(CLUSTER_CONFIG)
             displayName: "Set KUBECONFIG"
-        - ${{ if not(eq(clusterConfig, "pi-aks-e2e-daily")) }}:
+
+        - ${{ if not(eq(clusterConfig, 'pi-aks-e2e-daily')) }}:
+          - task: DownloadSecureFile@1
+            name: kubeconfig
+            inputs:
+              secureFile: ${{ format('{0}', clusterConfig) }}
+            displayName: "Download KUBECONFIG"
+
           - script: |
               export KUBECONFIG=$(kubeconfig.secureFilePath)
               echo "##vso[task.setvariable variable=KUBECONFIG]${KUBECONFIG}"


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->


**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
