### PR TITLE
ci: download the correct version of kubectl in e2e according to cluster version

### DIFF
--- a/.pipelines/deploy-aks-cluster.yml
+++ b/.pipelines/deploy-aks-cluster.yml
@@ -5,6 +5,7 @@ steps:
       az aks create \
         --resource-group ${RESOURCE_GROUP} \
         --name ${RESOURCE_GROUP} \
+        --kubernetes-version $(AKS_CLUSTER_VERSION) \
         --max-pods ${MAX_PODS} \
         --service-principal $(AZURE_CLIENT_ID) \
         --client-secret $(AZURE_CLIENT_SECRET) \
@@ -18,4 +19,11 @@ steps:
       # set CLUSTER_RESOURCE_GROUP for e2e test config
       export CLUSTER_RESOURCE_GROUP="MC_${RESOURCE_GROUP}_${RESOURCE_GROUP}_$(LOCATION)"
       echo "##vso[task.setvariable variable=CLUSTER_RESOURCE_GROUP]${CLUSTER_RESOURCE_GROUP}"
-    displayName: "Deploy an AKS cluster"
+    displayName: "Deploy an AKS cluster "
+
+  - script: |
+      echo "Installing kubectl..."
+      curl -LO https://storage.googleapis.com/kubernetes-release/release/v$(AKS_CLUSTER_VERSION)/bin/linux/amd64/kubectl
+      chmod +x kubectl
+      sudo mv kubectl /usr/local/bin/
+    displayName: "Install kubectl"

--- a/.pipelines/deploy-aks-engine-cluster.yml
+++ b/.pipelines/deploy-aks-engine-cluster.yml
@@ -32,8 +32,11 @@ steps:
 
       # Sleep for 120 seconds to wait for nodes and pods to become ready
       sleep 120
-      kubectl wait --for=condition=ready node --all
-      kubectl wait pod -n kube-system --for=condition=Ready --all
-      kubectl get nodes -owide
-      kubectl cluster-info
-    displayName: "aks-engine deploy"
+    displayName: "Deploy an aks-engine cluster"
+
+  - script: |
+      echo "Installing kubectl..."
+      curl -LO https://storage.googleapis.com/kubernetes-release/release/v$(AKS_ENGINE_CLUSTER_VERSION)/bin/linux/amd64/kubectl
+      chmod +x kubectl
+      sudo mv kubectl /usr/local/bin/
+    displayName: "Install kubectl"

--- a/.pipelines/e2e-tests-template.yml
+++ b/.pipelines/e2e-tests-template.yml
@@ -1,67 +1,56 @@
 parameters:
-  - name: k8sReleases
-    type: object
   - name: clusterConfigs
     type: object
 
 jobs:
-  - ${{ each k8sRelease in parameters.k8sReleases }}:
-    - ${{ each clusterConfig in parameters.clusterConfigs }}:
-      - job:
-        displayName: ${{ format('{0}', clusterConfig) }}
-        dependsOn: unit_tests
-        timeoutInMinutes: 120
-        cancelTimeoutInMinutes: 5
-        workspace:
-          clean: all
-        variables:
-          - group: aad-pod-identity
-          - name: K8S_RELEASE
-            value: ${{ format('{0}', k8sRelease) }}
-          - name: CLUSTER_CONFIG
-            value: ${{ format('{0}', clusterConfig) }}
-        steps:
-          - task: GoTool@0
-            inputs:
-              version: '1.14.1'
+  - ${{ each clusterConfig in parameters.clusterConfigs }}:
+    - job:
+      displayName: ${{ format('{0}', clusterConfig) }}
+      dependsOn: unit_tests
+      timeoutInMinutes: 120
+      cancelTimeoutInMinutes: 5
+      workspace:
+        clean: all
+      variables:
+        - group: aad-pod-identity
+        - name: CLUSTER_CONFIG
+          value: ${{ format('{0}', clusterConfig) }}
+      steps:
+        - task: GoTool@0
+          inputs:
+            version: '1.14.1'
 
-          - template: build-images.yml
+        - template: build-images.yml
 
-          - script: |
-              echo "Installing kubectl..."
-              curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-              chmod +x kubectl
-              sudo mv kubectl /usr/local/bin/
-            displayName: "Install kubectl"
+        - script: |
+            export RESOURCE_GROUP="aad-pod-identity-e2e-$(openssl rand -hex 6)"
+            echo "##vso[task.setvariable variable=RESOURCE_GROUP]${RESOURCE_GROUP}"
+          displayName: "Generate resource group name"
 
-          - script: |
-              export RESOURCE_GROUP="aad-pod-identity-e2e-$(openssl rand -hex 6)"
-              echo "##vso[task.setvariable variable=RESOURCE_GROUP]${RESOURCE_GROUP}"
-            displayName: "Generate resource group name"
+        - ${{ if eq(clusterConfig, 'aks') }}:
+          - template: deploy-aks-cluster.yml
 
-          - ${{ if eq(clusterConfig, 'aks') }}:
-            - template: deploy-aks-cluster.yml
-          - ${{ if not(eq(clusterConfig, 'aks')) }}:
-            - template: deploy-aks-engine-cluster.yml
+        - ${{ if not(eq(clusterConfig, 'aks')) }}:
+          - template: deploy-aks-engine-cluster.yml
 
-          - script: |
-              kubectl wait --for=condition=ready node --all
-              kubectl wait pod -n kube-system --for=condition=Ready --all
-              kubectl get nodes -owide
-              kubectl cluster-info
-            displayName: "Check cluster's health"
+        - script: |
+            kubectl wait --for=condition=ready node --all
+            kubectl wait pod -n kube-system --for=condition=Ready --all
+            kubectl get nodes -owide
+            kubectl cluster-info
+          displayName: "Check cluster's health"
 
-          - script: |
-              export REGISTRY="${REGISTRY:-$(REGISTRY_NAME).azurecr.io/k8s/aad-pod-identity}"
-              make e2e
-            env:
-              SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
-              AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-              AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-              AZURE_TENANT_ID: $(AZURE_TENANT_ID)
-            displayName: "Run E2E tests"
+        - script: |
+            export REGISTRY="${REGISTRY:-$(REGISTRY_NAME).azurecr.io/k8s/aad-pod-identity}"
+            make e2e
+          env:
+            SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+            AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+            AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+            AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+          displayName: "Run E2E tests"
 
-          - script: az group delete -g ${RESOURCE_GROUP} --yes --no-wait
-            displayName: "Delete resource group"
+        - script: az group delete -g ${RESOURCE_GROUP} --yes --no-wait
+          displayName: "Delete resource group"
 
-          - template: cleanup-images.yml
+        - template: cleanup-images.yml

--- a/.pipelines/nightly.yml
+++ b/.pipelines/nightly.yml
@@ -15,8 +15,6 @@ jobs:
   - template: unit-tests-template.yml
   - template: e2e-tests-template.yml
     parameters:
-      k8sReleases:
-        - "1.18"
       clusterConfigs:
         - "aks"
         # File names in test/e2e/cluster_configs without file extension

--- a/.pipelines/pr.yml
+++ b/.pipelines/pr.yml
@@ -15,8 +15,6 @@ jobs:
   - template: unit-tests-template.yml
   - template: e2e-tests-template.yml
     parameters:
-      k8sReleases:
-        - "1.18"
       clusterConfigs:
         - "aks"
         # File names in test/e2e/cluster_configs without file extension

--- a/test/e2e/cluster_configs/vmas.json
+++ b/test/e2e/cluster_configs/vmas.json
@@ -3,7 +3,7 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "${K8S_RELEASE}",
+            "orchestratorVersion": "${AKS_ENGINE_CLUSTER_VERSION}",
             "kubernetesConfig": {
                 "addons": [
                     {

--- a/test/e2e/cluster_configs/vmss.json
+++ b/test/e2e/cluster_configs/vmss.json
@@ -3,7 +3,7 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "${K8S_RELEASE}",
+            "orchestratorVersion": "${AKS_ENGINE_CLUSTER_VERSION}",
             "kubernetesConfig": {
                 "addons": [
                     {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

- Created `AKS_CLUSTER_VERSION` and `AKS_ENGINE_CLUSTER_VERSION` pipeline variables so we could download the correct version of kubectl during e2e
- Removed `parameters.k8sReleases` from `e2e-tests-template.yml` since we are only testing 1.18 and there is no plan to expand to other K8s versions

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

fixes #718.

**Notes for Reviewers**:
