### PR TITLE
fix: add release namespace to chart manifests

### DIFF
--- a/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: mic

--- a/manifest_staging/charts/aad-pod-identity/templates/mic-exception.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/mic-exception.yaml
@@ -3,6 +3,7 @@ apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzurePodIdentityException
 metadata:
   name: mic
+  namespace: {{ .Release.Namespace }}
 spec:
   podLabels:
     app: mic

--- a/manifest_staging/charts/aad-pod-identity/templates/mic-secret.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/mic-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: mic

--- a/manifest_staging/charts/aad-pod-identity/templates/mic-serviceaccount.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/mic-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: mic

--- a/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "aad-pod-identity.nmi.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: nmi

--- a/manifest_staging/charts/aad-pod-identity/templates/nmi-serviceaccount.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/nmi-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aad-pod-identity.nmi.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aad-pod-identity.labels" . | nindent 4 }}
     app.kubernetes.io/component: nmi


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Adds `namespace: {{ .Release.Namespace }}` to helm charts as helm template doesn't automatically generate it.

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #737 

**Notes for Reviewers**:
