### PR TITLE
feat: throttling - honor retry after header

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -51,10 +51,6 @@ const (
 	retryAfterHeaderKey = "Retry-After"
 )
 
-var (
-	now = time.Now
-)
-
 // NewCloudProvider returns a azure cloud provider client
 func NewCloudProvider(configFile string, updateUserMSIMaxRetry int, updateUseMSIRetryInterval time.Duration) (c *Client, e error) {
 	client := &Client{
@@ -348,14 +344,6 @@ func extractIdentitiesFromError(err error) []string {
 	return extracted
 }
 
-// IsThrottled returns true the if the request is being throttled.
-func isThrottled(resp *http.Response) bool {
-	if resp == nil {
-		return false
-	}
-	return resp.StatusCode == http.StatusTooManyRequests
-}
-
 // getRetryAfter gets the retryAfter from http response.
 // The value of Retry-After can be either the number of seconds or a date in RFC1123 format.
 func getRetryAfter(resp *http.Response) time.Duration {
@@ -372,7 +360,7 @@ func getRetryAfter(resp *http.Response) time.Duration {
 	if retryAfter, _ := strconv.Atoi(ra); retryAfter > 0 {
 		dur = time.Duration(retryAfter) * time.Second
 	} else if t, err := time.Parse(time.RFC1123, ra); err == nil {
-		dur = t.Sub(now())
+		dur = time.Until(t)
 	}
 	return dur
 }

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -22,6 +22,9 @@ import (
 type VMClient struct {
 	client   compute.VirtualMachinesClient
 	reporter *metrics.Reporter
+	// ARM throttling configures.
+	retryAfterReader time.Time
+	retryAfterWriter time.Time
 }
 
 // VMClientInt is the interface used by "cloudprovider" for interacting with Azure vmas
@@ -77,8 +80,19 @@ func (c *VMClient) Get(rgName string, nodeName string) (compute.VirtualMachine, 
 		}
 	}()
 
+	// Report errors if the client is throttled.
+	if c.retryAfterReader.After(time.Now()) {
+		return compute.VirtualMachine{}, fmt.Errorf("VMGet client throttled, retry after: %v", c.retryAfterReader)
+	}
+
 	vm, err := c.client.Get(ctx, rgName, nodeName, "")
 	if err != nil {
+		resp := vm.Response.Response
+		retryAfterDuration := getRetryAfter(resp)
+		if isThrottled(resp) || retryAfterDuration != 0 {
+			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
+			c.retryAfterReader = now().Add(retryAfterDuration)
+		}
 		return vm, fmt.Errorf("failed to get vm %s in resource group %s, error: %+v", nodeName, rgName, err)
 	}
 	stats.Increment(stats.TotalGetCalls, 1)
@@ -107,7 +121,18 @@ func (c *VMClient) UpdateIdentities(rg, nodeName string, vm compute.VirtualMachi
 		}
 	}()
 
+	// Report errors if the client is throttled.
+	if c.retryAfterWriter.After(time.Now()) {
+		return fmt.Errorf("VMUpdate client throttled, retry after: %v", c.retryAfterWriter)
+	}
+
 	if future, err = c.client.Update(ctx, rg, nodeName, compute.VirtualMachineUpdate{Identity: vm.Identity}); err != nil {
+		resp := future.Response()
+		retryAfterDuration := getRetryAfter(resp)
+		if isThrottled(resp) || retryAfterDuration != 0 {
+			// Update RetryAfterWriter so that no more requests would be sent until RetryAfter expires.
+			c.retryAfterWriter = now().Add(retryAfterDuration)
+		}
 		return fmt.Errorf("failed to update identities for %s in %s, error: %+v", nodeName, rg, err)
 	}
 	if err = future.WaitForCompletionRef(ctx, c.client.Client); err != nil {

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -22,6 +22,9 @@ import (
 type VMSSClient struct {
 	client   compute.VirtualMachineScaleSetsClient
 	reporter *metrics.Reporter
+	// ARM throttling configures.
+	retryAfterReader time.Time
+	retryAfterWriter time.Time
 }
 
 // VMSSClientInt is the interface used by "cloudprovider" for interacting with Azure vmss
@@ -78,7 +81,18 @@ func (c *VMSSClient) UpdateIdentities(rg, vmssName string, vmssIdentities comput
 		}
 	}()
 
+	// Report errors if the client is throttled.
+	if c.retryAfterWriter.After(time.Now()) {
+		return fmt.Errorf("VMSSUpdate client throttled, retry after: %v", c.retryAfterWriter)
+	}
+
 	if future, err = c.client.Update(ctx, rg, vmssName, compute.VirtualMachineScaleSetUpdate{Identity: vmssIdentities.Identity}); err != nil {
+		resp := future.Response()
+		retryAfterDuration := getRetryAfter(resp)
+		if isThrottled(resp) || retryAfterDuration != 0 {
+			// Update RetryAfterWriter so that no more requests would be sent until RetryAfter expires.
+			c.retryAfterWriter = now().Add(retryAfterDuration)
+		}
 		return fmt.Errorf("failed to update identities for %s in %s, error: %+v", vmssName, rg, err)
 	}
 	if err = future.WaitForCompletionRef(ctx, c.client.Client); err != nil {
@@ -107,8 +121,20 @@ func (c *VMSSClient) Get(rgName string, vmssName string) (ret compute.VirtualMac
 			klog.Warningf("failed to report metrics, error: %+v", err)
 		}
 	}()
+
+	// Report errors if the client is throttled.
+	if c.retryAfterReader.After(time.Now()) {
+		return compute.VirtualMachineScaleSet{}, fmt.Errorf("VMSSGet client throttled, retry after: %v", c.retryAfterReader)
+	}
+
 	vmss, err := c.client.Get(ctx, rgName, vmssName)
 	if err != nil {
+		resp := vmss.Response.Response
+		retryAfterDuration := getRetryAfter(resp)
+		if isThrottled(resp) || retryAfterDuration != 0 {
+			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
+			c.retryAfterReader = now().Add(retryAfterDuration)
+		}
 		return vmss, fmt.Errorf("failed to get vmss %s in resource group %s, error: %+v", vmssName, rgName, err)
 	}
 	stats.Increment(stats.TotalGetCalls, 1)


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Exclude `429` from retriable error codes to prevent SDK from making retries.
- Check the response in future/GET result to check if `Retry-After` header exists and cache the back off value in client.

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/677

**Notes for Reviewers**:
