### PR TITLE
test: add load test pipeline to nightly job

### DIFF
--- a/.pipelines/build-images.yml
+++ b/.pipelines/build-images.yml
@@ -18,7 +18,11 @@ steps:
       fi
 
       # Generate image version
-      IMAGE_VERSION="$(git describe --tags --always --dirty)-$(CLUSTER_CONFIG)"
+      if [[ -n "${OPERATION_MODE:-}" ]]; then
+        IMAGE_VERSION="$(git describe --tags --always --dirty)-$(OPERATION_MODE)"
+      else
+        IMAGE_VERSION="$(git describe --tags --always --dirty)-$(CLUSTER_CONFIG)"
+      fi
       echo "Image version: ${IMAGE_VERSION}"
 
       export MIC_VERSION="${IMAGE_VERSION}"

--- a/.pipelines/cleanup-images.yml
+++ b/.pipelines/cleanup-images.yml
@@ -7,6 +7,7 @@ steps:
 
       # Allow errors in case the images do not exist
       set +e
+      az account set -s=$(SUBSCRIPTION_ID)
       az acr login -n $(REGISTRY_NAME)
       az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/mic:${MIC_VERSION} --yes || true
       az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/nmi:${NMI_VERSION} --yes || true

--- a/.pipelines/deploy-aks-cluster.yml
+++ b/.pipelines/deploy-aks-cluster.yml
@@ -2,14 +2,39 @@ steps:
   - script: |
       az group create --name ${RESOURCE_GROUP} --location $(LOCATION)
 
-      az aks create \
-        --resource-group ${RESOURCE_GROUP} \
-        --name ${RESOURCE_GROUP} \
-        --kubernetes-version $(AKS_CLUSTER_VERSION) \
-        --max-pods ${MAX_PODS} \
-        --service-principal $(AZURE_CLIENT_ID) \
-        --client-secret $(AZURE_CLIENT_SECRET) \
-        --generate-ssh-keys > /dev/null
+      if [[ ${LARGE_CLUSTER:-} == "true" ]]; then
+        az aks create \
+          -g ${RESOURCE_GROUP} \
+          -n ${RESOURCE_GROUP} \
+          --node-count $(AGENT_COUNT) \
+          --nodepool-name nodepool1 \
+          --kubernetes-version $(AKS_CLUSTER_VERSION) \
+          --node-vm-size Standard_DS2_v2 \
+          --location ${LOCATION} \
+          --service-principal $(AZURE_CLIENT_ID) \
+          --client-secret $(AZURE_CLIENT_SECRET) \
+          --no-ssh-key \
+          --load-balancer-sku standard \
+          --network-plugin azure \
+          --max-pods ${MAX_PODS} \
+          --load-balancer-managed-outbound-ip-count 6
+
+          MASTERIP=$(az aks show \
+            -g ${RESOURCE_GROUP} \
+            -n ${RESOURCE_GROUP} \
+            --query 'fqdn' -o tsv)
+          echo "##vso[task.setvariable variable=MASTERIP]${MASTERIP}"
+          echo "##vso[task.setvariable variable=MASTERINTERNALIP]${MASTERIP}"
+      else
+        az aks create \
+          --resource-group ${RESOURCE_GROUP} \
+          --name ${RESOURCE_GROUP} \
+          --kubernetes-version $(AKS_CLUSTER_VERSION) \
+          --max-pods ${MAX_PODS} \
+          --service-principal $(AZURE_CLIENT_ID) \
+          --client-secret $(AZURE_CLIENT_SECRET) \
+          --generate-ssh-keys > /dev/null
+      fi
 
       # store kubeconfig to ~/.kube/config
       az aks get-credentials \

--- a/.pipelines/load-tests-template.yml
+++ b/.pipelines/load-tests-template.yml
@@ -1,0 +1,159 @@
+parameters:
+  - name: operationModes
+    type: object
+
+jobs:
+  - ${{ each operationMode in parameters.operationModes }}:
+    - job:
+      displayName: ${{ format('load/{0}', operationMode) }}
+      strategy:
+        matrix:
+          test-pod-2000:
+            POD_COUNT_PER_DEPLOYMENT: 20
+        maxParallel: 1
+      timeoutInMinutes: 360
+      cancelTimeoutInMinutes: 30
+      workspace:
+        clean: all
+      variables:
+      - name: HOME
+        value: $(System.DefaultWorkingDirectory)
+      - name: GOPATH
+        value: $(HOME)/go
+      - name: perf-tests.repo.path
+        value: $(GOPATH)/src/k8s.io/perf-tests
+      - group: aad-pod-identity-load
+      - name: OPERATION_MODE
+        value: ${{ format('{0}', operationMode) }}
+      steps:
+        - task: GoTool@0
+          inputs:
+            version: '1.14.1'
+
+        - bash: |
+            git clone -b $(checkout.branch) $(checkout.repo) $(perf-tests.repo.path)
+          displayName: Checkout $(checkout.repo) @ $(checkout.branch)
+
+        - template: build-images.yml
+
+        - script: |
+            az account set -s=$(LOAD_TEST_SUBSCRIPTION_ID)
+          displayName: "Set subscription for load tests"
+
+        - script: |
+            export RESOURCE_GROUP="pi-load-e2e-$(openssl rand -hex 6)"
+            echo "##vso[task.setvariable variable=RESOURCE_GROUP]${RESOURCE_GROUP}"
+          displayName: "Generate resource group name"
+
+        - template: deploy-aks-cluster.yml
+
+        - script: |
+            # Create assigned identity to be used for test
+            POD_IDENTITY_CLIENT_ID=$(az identity create -n ${POD_IDENTITY_ID_NAME} -g MC_${RESOURCE_GROUP}_${RESOURCE_GROUP}_${LOCATION} --query clientId -otsv)
+            echo "##vso[task.setvariable variable=POD_IDENTITY_CLIENT_ID]${POD_IDENTITY_CLIENT_ID}"
+
+            if [[ $OPERATION_MODE == "managed" ]]; then
+              VMSS_NAME=$(az vmss list -g MC_${RESOURCE_GROUP}_${RESOURCE_GROUP}_$(LOCATION) --query "[].name" -o tsv)
+              echo "Assigning /subscriptions/$(LOAD_TEST_SUBSCRIPTION_ID)/resourcegroups/MC_${RESOURCE_GROUP}_${RESOURCE_GROUP}_$(LOCATION)/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${POD_IDENTITY_ID_NAME} to ${VMSS_NAME}"
+
+              # Assign user assigned identity to the VMSS
+              az vmss identity assign -g MC_${RESOURCE_GROUP}_${RESOURCE_GROUP}_$(LOCATION) -n $VMSS_NAME \
+               --identities /subscriptions/$(LOAD_TEST_SUBSCRIPTION_ID)/resourcegroups/MC_${RESOURCE_GROUP}_${RESOURCE_GROUP}_$(LOCATION)/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${POD_IDENTITY_ID_NAME} >> /dev/null
+            fi
+          displayName: "Create and assign identity to AKS cluster"
+          workingDirectory: "$(System.DefaultWorkingDirectory)"
+
+        - script: |
+            echo "Installing helm..."
+            curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+          displayName: "Install helm"        
+
+        - script: |
+            kubectl wait --for=condition=ready node --all
+            kubectl wait pod -n kube-system --for=condition=Ready --all
+            kubectl get nodes -owide
+            kubectl cluster-info
+          displayName: "Check cluster's health"
+
+        - script: |
+            export REGISTRY="${REGISTRY:-$(REGISTRY_NAME).azurecr.io/k8s/aad-pod-identity}"
+
+            # substitute aad-pod-identity variables
+            helm install pi manifest_staging/charts/aad-pod-identity --namespace $NAMESPACE --wait --timeout=10m -v=5 --debug \
+              --set operationMode=${OPERATION_MODE} \
+              --set image.repository=${REGISTRY} \
+              --set mic.tag=${MIC_VERSION} \
+              --set nmi.tag=${NMI_VERSION} \
+              --set enableScaleFeatures=true
+
+            envsubst < test/load/azureidentity-template.yml > test/load/azureidentity.yml
+            envsubst < test/load/azureidentitybinding-template.yml > test/load/azureidentitybinding.yml
+            envsubst < test/load/config-deployment-template.yml > test/load/config.yml
+            envsubst < test/load/deployment-template.yml > test/load/deployment.yml
+
+            kubectl -n $NAMESPACE wait --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/component=nmi
+            if [[ "${OPERATION_MODE:-}" == "standard" ]]; then
+              kubectl -n $NAMESPACE wait --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/component=mic
+            fi
+          displayName: "Deploy aad-pod-identity"
+          workingDirectory: "$(system.defaultWorkingDirectory)"
+          env:
+            NAMESPACE: "kube-system"
+            SUBSCRIPTION_ID: $(LOAD_TEST_SUBSCRIPTION_ID)
+            POD_IDENTITY_RESOURCE_GROUP: $(CLUSTER_RESOURCE_GROUP)
+
+        - script: |
+            echo "--- CONFIG ---"
+            cat test/load/config.yml
+            echo "--- DEPLOYMENT ---"
+            cat test/load/deployment.yml
+            echo "--- AZURE IDENTITY ---"
+            cat test/load/azureidentity.yml
+            echo "--- AZURE IDENTITY BINDING ---"
+            cat test/load/azureidentitybinding.yml
+          workingDirectory: "$(system.defaultWorkingDirectory)"
+          displayName: "Get yaml"
+
+        - script: |
+            let NODE_COUNT=${AGENT_COUNT}*${NODE_POOL_COUNT}
+            ./run-e2e.sh cluster-loader2 \
+              --nodes=${NODE_COUNT} \
+              --provider=local \
+              --report-dir="$(perf-tests.repo.path)/_artifacts" \
+              --masterip=${MASTERIP} \
+              --master-internal-ip=${MASTERINTERNALIP} \
+              --testconfig="$(system.defaultWorkingDirectory)/test/load/config.yml"
+          workingDirectory: "$(perf-tests.repo.path)"
+          displayName: "Run clusterloader2 test"
+
+        - script: |
+            echo "--- GET NODES ---"
+            kubectl get nodes
+            echo "--- GET NS ---"
+            kubectl get ns
+            echo "--- GET PODS ---"
+            kubectl get pods --all-namespaces
+            echo "--- TOP PODS ---"
+            kubectl top pods -n kube-system
+          workingDirectory: "$(perf-tests.repo.path)"
+          condition: succeededOrFailed()
+          displayName: "Get stats"
+
+        - script: |
+            echo "--- MIC LOGS ---"
+            kubectl logs -n kube-system -l app.kubernetes.io/component=mic --tail 5000
+            echo "--- NMI LOGS ---"
+            kubectl logs -n kube-system -l app.kubernetes.io/component=nmi --tail 5000
+          workingDirectory: "$(perf-tests.repo.path)"
+          condition: succeededOrFailed()
+          displayName: "Get logs"
+
+        - template: publish-load-test-result.yml
+
+        - script: |
+            az aks delete -g ${RESOURCE_GROUP} -n ${RESOURCE_GROUP} --yes --no-wait
+            az group delete -g ${RESOURCE_GROUP} --yes --no-wait
+          displayName: "Delete resource group"
+          condition: always()
+
+        - template: cleanup-images.yml

--- a/.pipelines/nightly.yml
+++ b/.pipelines/nightly.yml
@@ -26,3 +26,8 @@ jobs:
         - "pi-vmas-e2e-daily"
         - "pi-vmss-e2e-daily"
         - "pi-aks-e2e-daily"
+  - template: load-tests-template.yml
+    parameters:
+      operationModes:
+        - "managed"
+        - "standard"

--- a/.pipelines/publish-load-test-result.yml
+++ b/.pipelines/publish-load-test-result.yml
@@ -1,0 +1,20 @@
+steps:
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    inputs:
+      testResultsFormat: "JUnit"
+      testResultsFiles: $(perf-tests.repo.path)/_artifacts/junit.xml
+    condition: succeededOrFailed()
+
+  - script: |
+      # rename : to -
+      for f in *:*; do mv -v "$f" $(echo "$f" | tr ':' '-'); done
+      mkdir -p $(Build.ArtifactStagingDirectory)/${POD_COUNT}
+      cp * $(Build.ArtifactStagingDirectory)/${POD_COUNT}
+    workingDirectory: "$(perf-tests.repo.path)/_artifacts"
+    displayName: Copy artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishBuildArtifacts@1
+    displayName: Save artifacts
+    condition: succeededOrFailed()

--- a/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -42,7 +42,7 @@ spec:
         image: "{{ .Values.image.repository }}/{{ .Values.nmi.image }}:{{ .Values.nmi.tag }}"
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
         args:
-          {{- if semverCompare "<= 1.6.1" .Values.nmi.tag }}
+          {{- if semverCompare "<= 1.6.1-0" .Values.nmi.tag }}
           - "--host-ip=$(HOST_IP)"
           {{- end }}
           - "--node=$(NODE_NAME)"
@@ -76,14 +76,14 @@ spec:
           {{- if .Values.nmi.metadataHeaderRequired}}
           - --metadata-header-required={{ .Values.nmi.metadataHeaderRequired }}
           {{- end }}
-          {{- if semverCompare ">= 1.6.0" .Values.nmi.tag }}
+          {{- if semverCompare ">= 1.6.0-0" .Values.nmi.tag }}
           - --operation-mode={{ .Values.operationMode }}
           {{- end}}
           {{- if eq .Values.operationMode "managed" }}
           - --forceNamespaced
           {{- end }}
         env:
-          {{- if semverCompare "<= 1.6.1" .Values.nmi.tag }}
+          {{- if semverCompare "<= 1.6.1-0" .Values.nmi.tag }}
           - name: HOST_IP
             valueFrom:
               fieldRef:

--- a/test/load/azureidentity-template.yml
+++ b/test/load/azureidentity-template.yml
@@ -1,0 +1,8 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: {{.Name}}
+spec:
+  type: 0
+  resourceID: /subscriptions/$SUBSCRIPTION_ID/resourceGroups/$POD_IDENTITY_RESOURCE_GROUP/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$POD_IDENTITY_ID_NAME
+  clientID: $POD_IDENTITY_CLIENT_ID

--- a/test/load/azureidentitybinding-template.yml
+++ b/test/load/azureidentitybinding-template.yml
@@ -1,0 +1,7 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: {{.Name}}
+spec:
+  azureIdentity: {{.Name}}
+  selector: loadtest

--- a/test/load/config-deployment-template.yml
+++ b/test/load/config-deployment-template.yml
@@ -1,0 +1,93 @@
+name: pi-deployment
+automanagedNamespaces: 100
+tuningSets:
+  - name: Uniform5qps
+    qpsLoad:
+      qps: 500
+steps:
+  - name: Starting measurements
+    measurements:
+      - Identifier: ResourceUsageSummary
+        Method: ResourceUsageSummary
+        Params:
+          action: start
+      - Identifier: PodStartupLatency
+        Method: PodStartupLatency
+        Params:
+          action: start
+          labelSelector: group = deployment
+          threshold: 40m
+  - name: Starting measurement for waiting for pods
+    measurements:
+      - Identifier: WaitForRunningDeployments
+        Method: WaitForControlledPodsRunning
+        Params:
+          action: start
+          apiVersion: apps/v1
+          kind: Deployment
+          labelSelector: group = deployment
+          operationTimeout: 360m
+  - name: Creating objects
+    phases:
+      - namespaceRange:
+          min: 1
+          max: 100
+        replicasPerNamespace: 1
+        tuningSet: Uniform5qps
+        objectBundle:
+          - basename: pi
+            objectTemplatePath: azureidentity.yml
+          - basename: pi
+            objectTemplatePath: azureidentitybinding.yml
+          - basename: deployment
+            objectTemplatePath: deployment.yml
+            templateFillMap:
+              Replicas: $POD_COUNT_PER_DEPLOYMENT
+              Group: deployment
+  - name: Waiting for pods to be running
+    measurements:
+      - Identifier: WaitForRunningDeployments
+        Method: WaitForControlledPodsRunning
+        Params:
+          action: gather
+  - name: Collecting measurements
+    measurements:
+      - Identifier: ResourceUsageSummary
+        Method: ResourceUsageSummary
+        Params:
+          action: gather
+  - name: Wait 2min
+    measurements:
+      - Identifier: Wait
+        Method: Sleep
+        Params:
+          duration: 2m
+  - name: Deleting objects
+    phases:
+      - namespaceRange:
+          min: 1
+          max: 100
+        replicasPerNamespace: 0
+        tuningSet: Uniform5qps
+        objectBundle:
+          - basename: pi
+            objectTemplatePath: azureidentity.yml
+          - basename: pi
+            objectTemplatePath: azureidentitybinding.yml
+          - basename: deployment
+            objectTemplatePath: deployment.yml
+  - measurements:
+      - Identifier: WaitForRunningDeployments
+        Method: WaitForControlledPodsRunning
+        Params:
+          action: gather
+  - measurements:
+      - Identifier: ResourceUsageSummary
+        Method: ResourceUsageSummary
+        Params:
+          action: gather
+  - measurements:
+      - Identifier: PodStartupLatency
+        Method: PodStartupLatency
+        Params:
+          action: gather

--- a/test/load/deployment-template.yml
+++ b/test/load/deployment-template.yml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+    aadpodidbinding: loadtest
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        group: {{.Group}}
+        aadpodidbinding: loadtest
+    spec:
+      terminationGracePeriodSeconds: 0
+      initContainers:
+        - name: init
+          image: mcr.microsoft.com/azure-cli
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - az login --identity --allow-no-subscriptions && az login -i -u $POD_IDENTITY_CLIENT_ID --allow-no-subscriptions
+      containers:
+      - image: k8s.gcr.io/pause-amd64:3.1
+        imagePullPolicy: IfNotPresent
+        name: {{.Name}}
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Adds load test pipelines to nightly job for `managed` and `standard` mode with AKS clusters

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/714

**Notes for Reviewers**:
