### PR TITLE
deployment-rbac.yaml - update deprecated RBAC API

### DIFF
--- a/deploy/infra/deployment-rbac.yaml
+++ b/deploy/infra/deployment-rbac.yaml
@@ -75,7 +75,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-nmi-binding
@@ -195,7 +195,7 @@ rules:
   resources: ["azureassignedidentities"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: aad-pod-id-mic-binding


### PR DESCRIPTION
**Reason for Change**:
rbac.authorization.k8s.io/v1beta1 is on a deprecation path

