### PR TITLE
fix: ensure stats collector doesn't aggregate stats from multiple runs

### DIFF
--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -82,7 +82,7 @@ func (c *VMClient) Get(rgName string, nodeName string) (compute.VirtualMachine, 
 		return vm, fmt.Errorf("failed to get vm %s in resource group %s, error: %+v", nodeName, rgName, err)
 	}
 	stats.Increment(stats.TotalGetCalls, 1)
-	stats.Aggregate(stats.CloudGet, time.Since(begin))
+	stats.AggregateConcurrent(stats.CloudGet, begin, time.Now())
 	return vm, nil
 }
 
@@ -114,7 +114,7 @@ func (c *VMClient) UpdateIdentities(rg, nodeName string, vm compute.VirtualMachi
 		return fmt.Errorf("failed to wait for identity update completion for vm %s in resource group %s, error: %+v", nodeName, rg, err)
 	}
 	stats.Increment(stats.TotalPatchCalls, 1)
-	stats.Aggregate(stats.CloudPatch, time.Since(begin))
+	stats.AggregateConcurrent(stats.CloudPatch, begin, time.Now())
 	return nil
 }
 

--- a/pkg/cloudprovider/vm.go
+++ b/pkg/cloudprovider/vm.go
@@ -81,8 +81,8 @@ func (c *VMClient) Get(rgName string, nodeName string) (compute.VirtualMachine, 
 	if err != nil {
 		return vm, fmt.Errorf("failed to get vm %s in resource group %s, error: %+v", nodeName, rgName, err)
 	}
-	stats.UpdateCount(stats.TotalGetCalls, 1)
-	stats.Update(stats.CloudGet, time.Since(begin))
+	stats.Increment(stats.TotalGetCalls, 1)
+	stats.Aggregate(stats.CloudGet, time.Since(begin))
 	return vm, nil
 }
 
@@ -113,8 +113,8 @@ func (c *VMClient) UpdateIdentities(rg, nodeName string, vm compute.VirtualMachi
 	if err = future.WaitForCompletionRef(ctx, c.client.Client); err != nil {
 		return fmt.Errorf("failed to wait for identity update completion for vm %s in resource group %s, error: %+v", nodeName, rg, err)
 	}
-	stats.UpdateCount(stats.TotalUpdateCalls, 1)
-	stats.Update(stats.CloudUpdate, time.Since(begin))
+	stats.Increment(stats.TotalPatchCalls, 1)
+	stats.Aggregate(stats.CloudPatch, time.Since(begin))
 	return nil
 }
 

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -84,8 +84,8 @@ func (c *VMSSClient) UpdateIdentities(rg, vmssName string, vmssIdentities comput
 	if err = future.WaitForCompletionRef(ctx, c.client.Client); err != nil {
 		return fmt.Errorf("failed to wait for identity update completion for vmss %s in resource group %s, error: %+v", vmssName, rg, err)
 	}
-	stats.UpdateCount(stats.TotalUpdateCalls, 1)
-	stats.Update(stats.CloudUpdate, time.Since(begin))
+	stats.Increment(stats.TotalPatchCalls, 1)
+	stats.Aggregate(stats.CloudPatch, time.Since(begin))
 	return nil
 }
 
@@ -111,8 +111,8 @@ func (c *VMSSClient) Get(rgName string, vmssName string) (ret compute.VirtualMac
 	if err != nil {
 		return vmss, fmt.Errorf("failed to get vmss %s in resource group %s, error: %+v", vmssName, rgName, err)
 	}
-	stats.UpdateCount(stats.TotalGetCalls, 1)
-	stats.Update(stats.CloudGet, time.Since(begin))
+	stats.Increment(stats.TotalGetCalls, 1)
+	stats.Aggregate(stats.CloudGet, time.Since(begin))
 	return vmss, nil
 }
 

--- a/pkg/cloudprovider/vmss.go
+++ b/pkg/cloudprovider/vmss.go
@@ -85,7 +85,7 @@ func (c *VMSSClient) UpdateIdentities(rg, vmssName string, vmssIdentities comput
 		return fmt.Errorf("failed to wait for identity update completion for vmss %s in resource group %s, error: %+v", vmssName, rg, err)
 	}
 	stats.Increment(stats.TotalPatchCalls, 1)
-	stats.Aggregate(stats.CloudPatch, time.Since(begin))
+	stats.AggregateConcurrent(stats.CloudPatch, begin, time.Now())
 	return nil
 }
 
@@ -112,7 +112,7 @@ func (c *VMSSClient) Get(rgName string, vmssName string) (ret compute.VirtualMac
 		return vmss, fmt.Errorf("failed to get vmss %s in resource group %s, error: %+v", vmssName, rgName, err)
 	}
 	stats.Increment(stats.TotalGetCalls, 1)
-	stats.Aggregate(stats.CloudGet, time.Since(begin))
+	stats.AggregateConcurrent(stats.CloudGet, begin, time.Now())
 	return vmss, nil
 }
 

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -505,7 +505,7 @@ func (c *Client) RemoveAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 	}
 
 	klog.V(5).Infof("deleting %s took: %v", assignedIdentity.Name, time.Since(begin))
-	stats.Update(stats.AssignedIDDel, time.Since(begin))
+	stats.AggregateConcurrent(stats.DeleteAzureAssignedIdentity, begin, time.Now())
 	return err
 }
 
@@ -539,7 +539,7 @@ func (c *Client) CreateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 	}
 
 	klog.V(5).Infof("time taken to create %s/%s: %v", assignedIdentity.Namespace, assignedIdentity.Name, time.Since(begin))
-	stats.Update(stats.AssignedIDAdd, time.Since(begin))
+	stats.AggregateConcurrent(stats.CreateAzureAssignedIdentiy, begin, time.Now())
 	return nil
 }
 
@@ -567,7 +567,7 @@ func (c *Client) UpdateAssignedIdentity(assignedIdentity *aadpodid.AzureAssigned
 	}
 
 	klog.V(5).Infof("time taken to update %s/%s: %v", assignedIdentity.Namespace, assignedIdentity.Name, time.Since(begin))
-	stats.Update(stats.AssignedIDAdd, time.Since(begin))
+	stats.AggregateConcurrent(stats.UpdateAzureAssignedIdentity, begin, time.Now())
 	return nil
 }
 
@@ -596,7 +596,7 @@ func (c *Client) ListBindings() (res *[]aadpodid.AzureIdentityBinding, err error
 		klog.V(6).Infof("appending binding: %s/%s to list.", o.Namespace, o.Name)
 	}
 
-	stats.Update(stats.BindingList, time.Since(begin))
+	stats.Aggregate(stats.AzureIdentityBindingList, time.Since(begin))
 	return &resList, nil
 }
 
@@ -623,7 +623,7 @@ func (c *Client) ListAssignedIDs() (res *[]aadpodid.AzureAssignedIdentity, err e
 		klog.V(6).Infof("appending AzureAssignedIdentity: %s/%s to list.", o.Namespace, o.Name)
 	}
 
-	stats.Update(stats.AssignedIDList, time.Since(begin))
+	stats.Aggregate(stats.AzureAssignedIdentityList, time.Since(begin))
 	return &resList, nil
 }
 
@@ -653,7 +653,7 @@ func (c *Client) ListAssignedIDsInMap() (map[string]aadpodid.AzureAssignedIdenti
 		klog.V(6).Infof("added to map with key: %s", o.Name)
 	}
 
-	stats.Update(stats.AssignedIDList, time.Since(begin))
+	stats.Aggregate(stats.AzureAssignedIdentityList, time.Since(begin))
 	return result, nil
 }
 
@@ -682,7 +682,7 @@ func (c *Client) ListIds() (res *[]aadpodid.AzureIdentity, err error) {
 		klog.V(6).Infof("appending AzureIdentity %s/%s to list.", o.Namespace, o.Name)
 	}
 
-	stats.Update(stats.IDList, time.Since(begin))
+	stats.Aggregate(stats.AzureIdentityList, time.Since(begin))
 	return &resList, nil
 }
 
@@ -712,7 +712,7 @@ func (c *Client) ListPodIdentityExceptions(ns string) (res *[]aadpodid.AzurePodI
 		}
 	}
 
-	stats.Update(stats.ExceptionList, time.Since(begin))
+	stats.Aggregate(stats.AzurePodIdentityExceptionList, time.Since(begin))
 	return &resList, nil
 }
 

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -758,7 +758,7 @@ func (c *Client) getAzureAssignedIDsToCreate(old, new map[string]aadpodid.AzureA
 			create[assignedIDName] = newAssignedID
 		}
 	}
-	stats.Put(stats.FindAssignedIDCreate, time.Since(begin))
+	stats.Put(stats.FindAzureAssignedIdentitiesToCreate, time.Since(begin))
 	return create, nil
 }
 
@@ -789,7 +789,7 @@ func (c *Client) getAzureAssignedIDsToDelete(old, new map[string]aadpodid.AzureA
 		// list. So we will add it to the delete list.
 		delete[assignedIDName] = oldAssignedID
 	}
-	stats.Put(stats.FindAssignedIDDel, time.Since(begin))
+	stats.Put(stats.FindAzureAssignedIdentitiesToDelete, time.Since(begin))
 	return delete, nil
 }
 
@@ -1116,9 +1116,9 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 				}
 			}
 			if isCreateOperation {
-				stats.UpdateCount(stats.TotalAssignedIDsCreated, 1)
+				stats.Increment(stats.TotalAzureAssignedIdentitiesCreated, 1)
 			} else {
-				stats.UpdateCount(stats.TotalAssignedIDsUpdated, 1)
+				stats.Increment(stats.TotalAzureAssignedIdentitiesUpdated, 1)
 			}
 		}
 
@@ -1152,9 +1152,9 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 				continue
 			}
 			klog.Infof("deleted assigned identity %s/%s", delID.Namespace, delID.Name)
-			stats.UpdateCount(stats.TotalAssignedIDsDeleted, 1)
+			stats.Increment(stats.TotalAzureAssignedIdentitiesDeleted, 1)
 		}
-		stats.Put(stats.TotalCreateOrUpdate, time.Since(beginAdding))
+		stats.Put(stats.TotalAzureAssignedIdentitiesCreateOrUpdate, time.Since(beginAdding))
 		return
 	}
 
@@ -1221,10 +1221,10 @@ func (c *Client) updateUserMSI(newAssignedIDs map[string]aadpodid.AzureAssignedI
 		return
 	}
 
-	stats.UpdateCount(stats.TotalAssignedIDsCreated, len(nodeTrackList.assignedIDsToCreate))
-	stats.UpdateCount(stats.TotalAssignedIDsUpdated, len(nodeTrackList.assignedIDsToUpdate))
-	stats.UpdateCount(stats.TotalAssignedIDsDeleted, len(nodeTrackList.assignedIDsToDelete))
-	stats.Put(stats.TotalCreateOrUpdate, time.Since(beginAdding))
+	stats.Increment(stats.TotalAzureAssignedIdentitiesCreated, len(nodeTrackList.assignedIDsToCreate))
+	stats.Increment(stats.TotalAzureAssignedIdentitiesUpdated, len(nodeTrackList.assignedIDsToUpdate))
+	stats.Increment(stats.TotalAzureAssignedIdentitiesDeleted, len(nodeTrackList.assignedIDsToDelete))
+	stats.Put(stats.TotalAzureAssignedIdentitiesCreateOrUpdate, time.Since(beginAdding))
 }
 
 // cleanUpAllAssignedIdentitiesOnNode deletes all assigned identities associated with a the node


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Ensure stats collector doesn't aggregate stats from multiple runs.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

fixes #749

**Notes for Reviewers**:
