### PR TITLE
chore: set dnspolicy to clusterfirstwithhostnet for NMI

### DIFF
--- a/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -32,6 +32,7 @@ spec:
       priorityClassName: {{ .Values.nmi.priorityClassName | quote }}
       {{- end }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
       - hostPath:
           path: /run/xtables.lock

--- a/manifest_staging/deploy/infra/deployment-rbac.yaml
+++ b/manifest_staging/deploy/infra/deployment-rbac.yaml
@@ -114,6 +114,7 @@ spec:
     spec:
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
       - hostPath:
           path: /run/xtables.lock

--- a/manifest_staging/deploy/infra/deployment.yaml
+++ b/manifest_staging/deploy/infra/deployment.yaml
@@ -70,6 +70,7 @@ spec:
         tier: node
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
       - hostPath:
           path: /run/xtables.lock

--- a/manifest_staging/deploy/infra/managed-mode-deployment.yaml
+++ b/manifest_staging/deploy/infra/managed-mode-deployment.yaml
@@ -99,6 +99,7 @@ spec:
     spec:
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
       - hostPath:
           path: /run/xtables.lock

--- a/manifest_staging/deploy/infra/noazurejson/deployment-rbac.yaml
+++ b/manifest_staging/deploy/infra/noazurejson/deployment-rbac.yaml
@@ -112,6 +112,7 @@ spec:
     spec:
       serviceAccountName: aad-pod-id-nmi-service-account
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
       - hostPath:
           path: /run/xtables.lock

--- a/manifest_staging/deploy/infra/noazurejson/deployment.yaml
+++ b/manifest_staging/deploy/infra/noazurejson/deployment.yaml
@@ -48,7 +48,7 @@ spec:
     plural: azurepodidentityexceptions
   scope: Namespaced
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -68,6 +68,7 @@ spec:
         tier: node
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
       - hostPath:
           path: /run/xtables.lock
@@ -126,7 +127,7 @@ metadata:
   name: aadpodidentity-admin-secret
   namespace: default
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/test/e2e/framework/iptables/iptables_helpers.go
+++ b/test/e2e/framework/iptables/iptables_helpers.go
@@ -63,6 +63,7 @@ func WaitForRules(input WaitForRulesInput) {
 					},
 					Spec: corev1.PodSpec{
 						HostNetwork:                   true,
+						DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
 						TerminationGracePeriodSeconds: to.Int64Ptr(int64(0)),
 						Containers: []corev1.Container{
 							{


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Adds `dnsPolicy: ClusterFirstWithHostNet` for NMI daemonset as that's the recommended policy for pods running on host network

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/775

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
