### PR TITLE
Expose metrics port

### DIFF
--- a/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
@@ -123,6 +123,12 @@ spec:
                 key: ClientSecret
                 name: {{ template "aad-pod-identity.mic.fullname" . }}
           {{- end }}
+        {{- if .Values.mic.prometheusPort }}
+        ports:
+          - containerPort: {{ .Values.mic.prometheusPort }}
+            name: metrics
+            protocol: TCP
+        {{- end }}
         {{- if not .Values.adminsecret }}
         volumeMounts:
           - name: k8s-azure-file

--- a/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -98,6 +98,12 @@ spec:
           - name: FORCENAMESPACED
             value: "{{ .Values.forceNameSpaced }}"
           {{- end }}
+        {{- if .Values.nmi.prometheusPort }}
+        ports:
+          - containerPort: {{ .Values.nmi.prometheusPort }}
+            name: metrics
+            protocol: TCP
+        {{- end }}
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
Currently, even though AAD Pod Identity support exposing metrics, it is not possible to create a `PodMonitor` object as the containers do not expose the metrics port.
This PR fixes this.


**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

no

**Notes for Reviewers**:
