### PR TITLE
chore: bump debian-base to v2.1.3 and debian-iptables to v12.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0
+ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.3
 
 FROM golang:1.15 AS build
 WORKDIR /go/src/github.com/Azure/aad-pod-identity

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ deepcopy-gen:
 
 .PHONY: image-nmi
 image-nmi:
-	docker build -t "$(REGISTRY)/$(NMI_IMAGE)" --build-arg NMI_VERSION="$(NMI_VERSION)" --build-arg BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables-amd64:v12.1.0 --target=nmi .
+	docker build -t "$(REGISTRY)/$(NMI_IMAGE)" --build-arg NMI_VERSION="$(NMI_VERSION)" --build-arg BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables-amd64:v12.1.2 --target=nmi .
 
 .PHONY: image-mic
 image-mic:


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Fixes #771
Fixes the following vulnerabilities:
- https://lists.debian.org/debian-security-announce/2020/msg00101.html by bumping libgnutls30 from 3.6.7-4+deb10u3 to 3.6.7-4+deb10u5
- https://lists.debian.org/debian-security-announce/2020/msg00089.html by bumping apt version from 1.8.2 to 1.8.2.1. 


**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
