### PR TITLE
chore: add logs for ignored pods

### DIFF
--- a/pkg/nmi/managed.go
+++ b/pkg/nmi/managed.go
@@ -84,12 +84,12 @@ func (mc *ManagedClient) GetToken(ctx context.Context, rqClientID, rqResource st
 	case aadpodid.ServicePrincipal:
 		tenantID := azureID.Spec.TenantID
 		adEndpoint := azureID.Spec.ADEndpoint
-		secretName := &azureID.Spec.ClientPassword
+		secretRef := &azureID.Spec.ClientPassword
 		klog.Infof("matched identityType:%v adendpoint:%s tenantid:%s clientid:%s resource:%s",
 			idType, adEndpoint, tenantID, utils.RedactClientID(clientID), rqResource)
-		secret, err := mc.KubeClient.GetSecret(secretName)
+		secret, err := mc.KubeClient.GetSecret(secretRef)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get Kubernetes secret %s, err: %v", secretName, err)
+			return nil, fmt.Errorf("failed to get Kubernetes secret %s/%s, err: %v", secretRef.Namespace, secretRef.Name, err)
 		}
 		clientSecret := ""
 		for _, v := range secret.Data {
@@ -101,11 +101,12 @@ func (mc *ManagedClient) GetToken(ctx context.Context, rqClientID, rqResource st
 	case aadpodid.ServicePrincipalCertificate:
 		tenantID := azureID.Spec.TenantID
 		adEndpoint := azureID.Spec.ADEndpoint
+		secretRef := &azureID.Spec.ClientPassword
 		klog.Infof("matched identityType:%v adendpoint:%s tenantid:%s clientid:%s resource:%s",
 			idType, adEndpoint, tenantID, utils.RedactClientID(clientID), rqResource)
-		secret, err := mc.KubeClient.GetSecret(&azureID.Spec.ClientPassword)
+		secret, err := mc.KubeClient.GetSecret(secretRef)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get Kubernetes secret %s/%s, err: %v", secretRef.Namespace, secretRef.Name, err)
 		}
 		certificate, password := secret.Data["certificate"], secret.Data["password"]
 		token, err := auth.GetServicePrincipalTokenWithCertificate(adEndpoint, tenantID, clientID,

--- a/pkg/nmi/managed.go
+++ b/pkg/nmi/managed.go
@@ -84,11 +84,12 @@ func (mc *ManagedClient) GetToken(ctx context.Context, rqClientID, rqResource st
 	case aadpodid.ServicePrincipal:
 		tenantID := azureID.Spec.TenantID
 		adEndpoint := azureID.Spec.ADEndpoint
+		secretName := &azureID.Spec.ClientPassword
 		klog.Infof("matched identityType:%v adendpoint:%s tenantid:%s clientid:%s resource:%s",
 			idType, adEndpoint, tenantID, utils.RedactClientID(clientID), rqResource)
-		secret, err := mc.KubeClient.GetSecret(&azureID.Spec.ClientPassword)
+		secret, err := mc.KubeClient.GetSecret(secretName)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get Kubernetes secret %s, err: %v", secretName, err)
 		}
 		clientSecret := ""
 		for _, v := range secret.Data {

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -20,8 +20,8 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"k8s.io/klog"
 
-	auth "github.com/Azure/aad-pod-identity/pkg/auth"
-	k8s "github.com/Azure/aad-pod-identity/pkg/k8s"
+	"github.com/Azure/aad-pod-identity/pkg/auth"
+	"github.com/Azure/aad-pod-identity/pkg/k8s"
 	"github.com/Azure/aad-pod-identity/pkg/metrics"
 	"github.com/Azure/aad-pod-identity/pkg/nmi"
 	"github.com/Azure/aad-pod-identity/pkg/nmi/iptables"
@@ -103,7 +103,7 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) updateIPTableRulesInternal() {
-	klog.V(5).Infof("node(%s) ip(%s) metadataaddress(%s:%s) nmiport(%s)", s.NodeName, localhost, s.MetadataIP, s.MetadataPort, s.NMIPort)
+	klog.V(5).Infof("node(%s) ip(%s) metadata address(%s:%s) nmi port(%s)", s.NodeName, localhost, s.MetadataIP, s.MetadataPort, s.NMIPort)
 
 	if err := iptables.AddCustomChain(s.MetadataIP, s.MetadataPort, localhost, s.NMIPort); err != nil {
 		klog.Fatalf("%s", err)
@@ -180,7 +180,7 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			case error:
 				err = t
 			default:
-				err = errors.New("Unknown error")
+				err = errors.New("unknown error")
 			}
 			klog.Errorf("panic processing request: %+v, file: %s, line: %d, stacktrace: '%s' %s res.status=%d", r, file, line, stack, tracker, http.StatusInternalServerError)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -348,7 +348,7 @@ func (s *Server) msiHandler(w http.ResponseWriter, r *http.Request) (ns string) 
 	ns = podns
 	exceptionList, err := s.KubeClient.ListPodIdentityExceptions(podns)
 	if err != nil {
-		klog.Errorf("getting list of azurepodidentityexceptions in %s namespace failed with error: %+v", podns, err)
+		klog.Errorf("getting list of AzurePodIdentityException in %s namespace failed with error: %+v", podns, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/nmi/standard.go
+++ b/pkg/nmi/standard.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/klog"
 
 	aadpodid "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity"
-	auth "github.com/Azure/aad-pod-identity/pkg/auth"
-	k8s "github.com/Azure/aad-pod-identity/pkg/k8s"
-	utils "github.com/Azure/aad-pod-identity/pkg/utils"
+	"github.com/Azure/aad-pod-identity/pkg/auth"
+	"github.com/Azure/aad-pod-identity/pkg/k8s"
+	"github.com/Azure/aad-pod-identity/pkg/utils"
 )
 
 // StandardClient implements the TokenClient interface
@@ -49,7 +49,7 @@ func (sc *StandardClient) GetIdentities(ctx context.Context, podns, podname, cli
 	}
 
 	// filter out if we are in namespaced mode
-	filterPodIdentities := []aadpodid.AzureIdentity{}
+	var filterPodIdentities []aadpodid.AzureIdentity
 	for _, val := range podIDs {
 		if sc.IsNamespaced || aadpodid.IsNamespacedIdentity(&val) {
 			// namespaced mode
@@ -119,7 +119,7 @@ func (sc *StandardClient) listPodIDsWithRetry(ctx context.Context, podns, podnam
 					return idStateMap[aadpodid.AssignedIDAssigned], true, nil
 				}
 				if len(idStateMap[aadpodid.AssignedIDCreated]) == 0 && attempt >= sc.ListPodIDsRetryAttemptsForCreated {
-					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s, error: %+v",
+					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s, error: %+v. Check MIC pod logs for identity assignment errors",
 						podns, podname, sc.ListPodIDsRetryAttemptsForCreated, sc.ListPodIDsRetryIntervalInSeconds, err)
 				}
 			} else {
@@ -145,7 +145,7 @@ func (sc *StandardClient) listPodIDsWithRetry(ctx context.Context, podns, podnam
 					}
 				}
 				if !foundMatch && attempt >= sc.ListPodIDsRetryAttemptsForCreated {
-					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s, error: %+v",
+					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s, error: %+v. Check MIC pod logs for identity assignment errors",
 						podns, podname, sc.ListPodIDsRetryAttemptsForCreated, sc.ListPodIDsRetryIntervalInSeconds, err)
 				}
 			}
@@ -160,7 +160,7 @@ func (sc *StandardClient) listPodIDsWithRetry(ctx context.Context, podns, podnam
 		}
 		klog.V(4).Infof("failed to get assigned ids for pod:%s/%s in ASSIGNED state, retrying attempt: %d", podns, podname, attempt)
 	}
-	return nil, true, fmt.Errorf("getting assigned identities for pod %s/%s in ASSIGNED state failed after %d attempts, retry duration [%d]s, error: %+v",
+	return nil, true, fmt.Errorf("getting assigned identities for pod %s/%s in ASSIGNED state failed after %d attempts, retry duration [%d]s, error: %+v. Check MIC pod logs for identity assignment errors",
 		podns, podname, sc.ListPodIDsRetryAttemptsForCreated+sc.ListPodIDsRetryAttemptsForAssigned, sc.ListPodIDsRetryIntervalInSeconds, err)
 }
 
@@ -181,11 +181,12 @@ func (sc *StandardClient) GetToken(ctx context.Context, rqClientID, rqResource s
 	case aadpodid.ServicePrincipal:
 		tenantID := azureID.Spec.TenantID
 		adEndpoint := azureID.Spec.ADEndpoint
+		secretName := &azureID.Spec.ClientPassword
 		klog.Infof("matched identityType:%v adendpoint:%s tenantid:%s clientid:%s resource:%s",
 			idType, adEndpoint, tenantID, utils.RedactClientID(clientID), rqResource)
-		secret, err := sc.KubeClient.GetSecret(&azureID.Spec.ClientPassword)
+		secret, err := sc.KubeClient.GetSecret(secretName)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get Kubernetes secret %s, err: %v", secretName, err)
 		}
 		clientSecret := ""
 		for _, v := range secret.Data {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Adds logs for when pods are ignored because of missing labels, misconfigured label or no matching AzureIdentityBinding found for the label.

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #732 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
