### PR TITLE
test: cleanup pods before removing ns and refactor "eventually" calls 

### DIFF
--- a/test/e2e/backward_compat_test.go
+++ b/test/e2e/backward_compat_test.go
@@ -9,7 +9,6 @@ import (
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework"
-	"github.com/Azure/aad-pod-identity/test/e2e/framework/azureassignedidentity"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/azureidentity"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/azureidentitybinding"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/exec"
@@ -38,15 +37,11 @@ var _ = Describe("When upgrading AAD Pod Identity", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
-		})
-
-		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
-			Lister: kubeClient,
-			Len:    0,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 
@@ -65,6 +60,7 @@ var _ = Describe("When upgrading AAD Pod Identity", func() {
 		configOldVersion.MICVersion = "1.5"
 		configOldVersion.NMIVersion = "1.5"
 		configOldVersion.ImmutableUserMSIs = ""
+		configOldVersion.IdentityReconcileInterval = 0
 		configOldVersion.BlockInstanceMetadata = false
 
 		helm.Upgrade(helm.UpgradeInput{

--- a/test/e2e/cleanup.go
+++ b/test/e2e/cleanup.go
@@ -1,0 +1,50 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/aad-pod-identity/test/e2e/framework"
+	"github.com/Azure/aad-pod-identity/test/e2e/framework/namespace"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CleanupInput is the input for Cleanup.
+type CleanupInput struct {
+	Namespace *corev1.Namespace
+	Getter    framework.Getter
+	Lister    framework.Lister
+	Deleter   framework.Deleter
+}
+
+// Cleanup cleans up the test environment after a test case is finished running.
+func Cleanup(input CleanupInput) {
+	Expect(input.Namespace).NotTo(BeNil(), "input.Namespace is required for e2e.Cleanup")
+	Expect(input.Getter).NotTo(BeNil(), "input.Getter is required for e2e.Cleanup")
+	Expect(input.Lister).NotTo(BeNil(), "input.Lister is required for e2e.Cleanup")
+	Expect(input.Deleter).NotTo(BeNil(), "input.Deleter is required for e2e.Cleanup")
+
+	By(fmt.Sprintf("Deleting all pods in %s", input.Namespace.Name))
+
+	podList := &corev1.PodList{}
+	Expect(input.Lister.List(context.TODO(), podList, client.InNamespace(input.Namespace.Name))).Should(Succeed())
+	for _, pod := range podList.Items {
+		Expect(input.Deleter.Delete(context.TODO(), &pod)).Should(Succeed())
+	}
+
+	Eventually(func() bool {
+		podList := &corev1.PodList{}
+		Expect(input.Lister.List(context.TODO(), podList, client.InNamespace(input.Namespace.Name))).Should(Succeed())
+		return len(podList.Items) == 0
+	}, framework.Timeout, framework.Polling).Should(BeTrue())
+
+	namespace.Delete(namespace.DeleteInput{
+		Deleter:   input.Deleter,
+		Getter:    input.Getter,
+		Namespace: input.Namespace,
+	})
+}

--- a/test/e2e/disruptive_test.go
+++ b/test/e2e/disruptive_test.go
@@ -31,10 +31,11 @@ var _ = Describe("When AAD Pod Identity operations are disrupted", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 

--- a/test/e2e/framework/azureassignedidentity/azureassignedidentity_helpers.go
+++ b/test/e2e/framework/azureassignedidentity/azureassignedidentity_helpers.go
@@ -36,18 +36,18 @@ func Wait(input WaitInput) {
 
 	By(fmt.Sprintf("Ensuring that AzureAssignedIdentity \"%s\" is in %s state", name, input.StateToWaitFor))
 
-	Eventually(func() (bool, error) {
+	Eventually(func() bool {
 		azureAssignedIdentity := &aadpodv1.AzureAssignedIdentity{}
 
 		// AzureAssignedIdentity is always in default namespace unless MIC is in namespaced mode
 		if err := input.Getter.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: corev1.NamespaceDefault}, azureAssignedIdentity); err != nil {
-			return false, err
+			return false
 		}
 		if azureAssignedIdentity.Status.Status == input.StateToWaitFor {
-			return true, nil
+			return true
 		}
-		return false, nil
-	}, framework.WaitTimeout, framework.WaitPolling).Should(BeTrue())
+		return false
+	}, framework.Timeout, framework.Polling).Should(BeTrue())
 }
 
 // WaitForLenInput is the input for WaitForLen.
@@ -63,16 +63,11 @@ func WaitForLen(input WaitForLenInput) {
 
 	By(fmt.Sprintf("Ensuring that there exists %d AzureAssignedIdentity", input.Len))
 
-	Eventually(func() (bool, error) {
+	Eventually(func() bool {
 		azureAssignedIdentityList := &aadpodv1.AzureAssignedIdentityList{}
 
 		// AzureAssignedIdentity is always in default namespace unless MIC is in namespaced mode
-		if err := input.Lister.List(context.TODO(), azureAssignedIdentityList, client.InNamespace(corev1.NamespaceDefault)); err != nil {
-			return false, err
-		}
-		if len(azureAssignedIdentityList.Items) == input.Len {
-			return true, nil
-		}
-		return false, nil
-	}, framework.WaitTimeout, framework.WaitPolling).Should(BeTrue())
+		Expect(input.Lister.List(context.TODO(), azureAssignedIdentityList, client.InNamespace(corev1.NamespaceDefault))).Should(Succeed())
+		return len(azureAssignedIdentityList.Items) == input.Len
+	}, framework.Timeout, framework.Polling).Should(BeTrue())
 }

--- a/test/e2e/framework/azureidentity/azureidentity_helpers.go
+++ b/test/e2e/framework/azureidentity/azureidentity_helpers.go
@@ -66,13 +66,9 @@ func Create(input CreateInput) *aadpodv1.AzureIdentity {
 	// For gatekeeper test case
 	if input.InvalidResourceID {
 		azureIdentity.Spec.ResourceID = fmt.Sprintf(invalidResourceIDTemplate, input.Config.SubscriptionID, input.IdentityName)
-		Eventually(func() error {
-			return input.Creator.Create(context.TODO(), azureIdentity)
-		}, framework.CreateTimeout, framework.CreatePolling).ShouldNot(Succeed())
+		Expect(input.Creator.Create(context.TODO(), azureIdentity)).ShouldNot(Succeed())
 	} else {
-		Eventually(func() error {
-			return input.Creator.Create(context.TODO(), azureIdentity)
-		}, framework.CreateTimeout, framework.CreatePolling).Should(Succeed())
+		Expect(input.Creator.Create(context.TODO(), azureIdentity)).Should(Succeed())
 	}
 
 	return azureIdentity
@@ -162,9 +158,7 @@ func Update(input UpdateInput) *aadpodv1.AzureIdentity {
 	input.AzureIdentity.Spec.ClientID = identityClientID
 	input.AzureIdentity.Spec.ResourceID = fmt.Sprintf(azure.ResourceIDTemplate, input.Config.SubscriptionID, input.Config.IdentityResourceGroup, input.UpdatedIdentityName)
 
-	Eventually(func() error {
-		return input.Updater.Update(context.TODO(), input.AzureIdentity)
-	}, framework.UpdateTimeout, framework.UpdatePolling).Should(Succeed())
+	Expect(input.Updater.Update(context.TODO(), input.AzureIdentity)).Should(Succeed())
 
 	return input.AzureIdentity
 }
@@ -181,8 +175,5 @@ func Delete(input DeleteInput) {
 	Expect(input.AzureIdentity).NotTo(BeNil(), "input.AzureIdentity is required for AzureIdentity.Delete")
 
 	By(fmt.Sprintf("Deleting AzureIdentity \"%s\"", input.AzureIdentity.Name))
-
-	Eventually(func() error {
-		return input.Deleter.Delete(context.TODO(), input.AzureIdentity)
-	}, framework.DeleteTimeout, framework.DeletePolling).Should(Succeed())
+	Expect(input.Deleter.Delete(context.TODO(), input.AzureIdentity)).Should(Succeed())
 }

--- a/test/e2e/framework/azureidentitybinding/azureidentitybinding_helpers.go
+++ b/test/e2e/framework/azureidentitybinding/azureidentitybinding_helpers.go
@@ -52,9 +52,7 @@ func Create(input CreateInput) *aadpodv1.AzureIdentityBinding {
 		},
 	}
 
-	Eventually(func() error {
-		return input.Creator.Create(context.TODO(), azureIdentityBinding)
-	}, framework.CreateTimeout, framework.CreatePolling).Should(Succeed())
+	Expect(input.Creator.Create(context.TODO(), azureIdentityBinding)).Should(Succeed())
 
 	return azureIdentityBinding
 }
@@ -126,8 +124,5 @@ func Delete(input DeleteInput) {
 	Expect(input.AzureIdentityBinding).NotTo(BeNil(), "input.AzureIdentityBinding is required for AzureIdentityBinding.Delete")
 
 	By(fmt.Sprintf("Deleting AzureIdentityBinding \"%s\"", input.AzureIdentityBinding.Name))
-
-	Eventually(func() error {
-		return input.Deleter.Delete(context.TODO(), input.AzureIdentityBinding)
-	}, framework.DeleteTimeout, framework.DeletePolling).Should(Succeed())
+	Expect(input.Deleter.Delete(context.TODO(), input.AzureIdentityBinding)).Should(Succeed())
 }

--- a/test/e2e/framework/azurepodidentityexception/azurepodidentityexception_helpers.go
+++ b/test/e2e/framework/azurepodidentityexception/azurepodidentityexception_helpers.go
@@ -41,9 +41,7 @@ func Create(input CreateInput) *aadpodv1.AzurePodIdentityException {
 		},
 	}
 
-	Eventually(func() error {
-		return input.Creator.Create(context.TODO(), azurePodIdentityException)
-	}, framework.CreateTimeout, framework.CreatePolling).Should(Succeed())
+	Expect(input.Creator.Create(context.TODO(), azurePodIdentityException)).Should(Succeed())
 
 	return azurePodIdentityException
 }

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -4,32 +4,34 @@ package framework
 
 import (
 	"strings"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
 
 // Config holds global test configuration translated from environment variables
 type Config struct {
-	SubscriptionID           string `envconfig:"SUBSCRIPTION_ID"`
-	ResourceGroup            string `envconfig:"RESOURCE_GROUP"`
-	IdentityResourceGroup    string `envconfig:"IDENTITY_RESOURCE_GROUP"`
-	ClusterResourceGroup     string `envconfig:"CLUSTER_RESOURCE_GROUP"`
-	AzureClientID            string `envconfig:"AZURE_CLIENT_ID"`
-	AzureClientSecret        string `envconfig:"AZURE_CLIENT_SECRET"`
-	AzureTenantID            string `envconfig:"AZURE_TENANT_ID"`
-	KeyvaultName             string `envconfig:"KEYVAULT_NAME"`
-	KeyvaultSecretName       string `envconfig:"KEYVAULT_SECRET_NAME"`
-	KeyvaultSecretVersion    string `envconfig:"KEYVAULT_SECRET_VERSION"`
-	MICVersion               string `envconfig:"MIC_VERSION" default:"1.6.2"`
-	NMIVersion               string `envconfig:"NMI_VERSION" default:"1.6.2"`
-	Registry                 string `envconfig:"REGISTRY" default:"mcr.microsoft.com/k8s/aad-pod-identity"`
-	IdentityValidatorVersion string `envconfig:"IDENTITY_VALIDATOR_VERSION" default:"1.6.2"`
-	SystemMSICluster         bool   `envconfig:"SYSTEM_MSI_CLUSTER" default:"false"`
-	EnableScaleFeatures      bool   `envconfig:"ENABLE_SCALE_FEATURES" default:"false"`
-	ImmutableUserMSIs        string `envconfig:"IMMUTABLE_IDENTITY_CLIENT_ID"`
-	NMIMode                  string `envconfig:"NMI_MODE" default:"standard"`
-	BlockInstanceMetadata    bool   `envconfig:"BLOCK_INSTANCE_METADATA" default:"true"`
-	IsSoakTest               bool   `envconfig:"IS_SOAK_TEST" default:"false"`
+	SubscriptionID            string        `envconfig:"SUBSCRIPTION_ID"`
+	ResourceGroup             string        `envconfig:"RESOURCE_GROUP"`
+	IdentityResourceGroup     string        `envconfig:"IDENTITY_RESOURCE_GROUP"`
+	ClusterResourceGroup      string        `envconfig:"CLUSTER_RESOURCE_GROUP"`
+	AzureClientID             string        `envconfig:"AZURE_CLIENT_ID"`
+	AzureClientSecret         string        `envconfig:"AZURE_CLIENT_SECRET"`
+	AzureTenantID             string        `envconfig:"AZURE_TENANT_ID"`
+	KeyvaultName              string        `envconfig:"KEYVAULT_NAME"`
+	KeyvaultSecretName        string        `envconfig:"KEYVAULT_SECRET_NAME"`
+	KeyvaultSecretVersion     string        `envconfig:"KEYVAULT_SECRET_VERSION"`
+	MICVersion                string        `envconfig:"MIC_VERSION" default:"1.6.2"`
+	NMIVersion                string        `envconfig:"NMI_VERSION" default:"1.6.2"`
+	Registry                  string        `envconfig:"REGISTRY" default:"mcr.microsoft.com/k8s/aad-pod-identity"`
+	IdentityValidatorVersion  string        `envconfig:"IDENTITY_VALIDATOR_VERSION" default:"1.6.2"`
+	SystemMSICluster          bool          `envconfig:"SYSTEM_MSI_CLUSTER" default:"false"`
+	EnableScaleFeatures       bool          `envconfig:"ENABLE_SCALE_FEATURES" default:"false"`
+	ImmutableUserMSIs         string        `envconfig:"IMMUTABLE_IDENTITY_CLIENT_ID"`
+	NMIMode                   string        `envconfig:"NMI_MODE" default:"standard"`
+	BlockInstanceMetadata     bool          `envconfig:"BLOCK_INSTANCE_METADATA" default:"true"`
+	IsSoakTest                bool          `envconfig:"IS_SOAK_TEST" default:"false"`
+	IdentityReconcileInterval time.Duration `envconfig:"IDENTITY_RECONCILE_INTERVAL" default:"2m"`
 }
 
 func (c *Config) DeepCopy() *Config {

--- a/test/e2e/framework/helm/helm_helpers.go
+++ b/test/e2e/framework/helm/helm_helpers.go
@@ -41,7 +41,6 @@ func Install(input InstallInput) {
 		chartName,
 		"manifest_staging/charts/aad-pod-identity",
 		"--wait",
-		"--debug",
 		fmt.Sprintf("--namespace=%s", framework.NamespaceKubeSystem),
 		"--debug",
 	})
@@ -86,7 +85,6 @@ func Upgrade(input UpgradeInput) {
 		chartName,
 		"manifest_staging/charts/aad-pod-identity",
 		"--wait",
-		"--debug",
 		fmt.Sprintf("--namespace=%s", framework.NamespaceKubeSystem),
 		"--debug",
 	})
@@ -113,6 +111,10 @@ func generateValueArgs(config *framework.Config) []string {
 
 	if config.BlockInstanceMetadata {
 		args = append(args, fmt.Sprintf("--set=nmi.blockInstanceMetadata=%t", config.BlockInstanceMetadata))
+	}
+
+	if config.IdentityReconcileInterval != 0 {
+		args = append(args, fmt.Sprintf("--set=mic.identityAssignmentReconcileInterval=%s", config.IdentityReconcileInterval))
 	}
 
 	return args

--- a/test/e2e/framework/interfaces.go
+++ b/test/e2e/framework/interfaces.go
@@ -16,12 +16,12 @@ type Getter interface {
 	Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
 }
 
-// Creator can creates resources.
+// Creator can create resources.
 type Creator interface {
 	Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error
 }
 
-// Lister can lists resources.
+// Lister can list resources.
 type Lister interface {
 	List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error
 }

--- a/test/e2e/framework/node/node_helpers.go
+++ b/test/e2e/framework/node/node_helpers.go
@@ -21,9 +21,7 @@ func List(input ListInput) *corev1.NodeList {
 	Expect(input.Lister).NotTo(BeNil(), "input.Lister is required for Node.List")
 
 	nodes := &corev1.NodeList{}
-	Eventually(func() error {
-		return input.Lister.List(context.TODO(), nodes)
-	}, framework.ListTimeout, framework.ListPolling).Should(Succeed())
+	Expect(input.Lister.List(context.TODO(), nodes)).Should(Succeed())
 
 	return nodes
 }

--- a/test/e2e/framework/pod/pod_helpers.go
+++ b/test/e2e/framework/pod/pod_helpers.go
@@ -28,13 +28,7 @@ func List(input ListInput) *corev1.PodList {
 	By(fmt.Sprintf("Listing pods with labels %v in %s namespace", input.Labels, input.Namespace))
 
 	pods := &corev1.PodList{}
-	Eventually(func() (bool, error) {
-		if err := input.Lister.List(context.TODO(), pods, client.InNamespace(input.Namespace), client.MatchingLabels(input.Labels)); err != nil {
-			return false, err
-		}
-
-		return true, nil
-	}, framework.ListTimeout, framework.ListPolling).Should(BeTrue())
+	Expect(input.Lister.List(context.TODO(), pods, client.InNamespace(input.Namespace), client.MatchingLabels(input.Labels))).Should(Succeed())
 
 	return pods
 }

--- a/test/e2e/framework/timeout.go
+++ b/test/e2e/framework/timeout.go
@@ -5,39 +5,9 @@ import (
 )
 
 const (
-	// CreateTimeout represents the duration it waits until a create operation times out.
-	CreateTimeout = 10 * time.Second
+	// Timeout represents the duration it waits until a long-running operation times out.
+	Timeout = 5 * time.Minute
 
-	// CreatePolling represents the polling interval for a create operation.
-	CreatePolling = 1 * time.Second
-
-	// DeleteTimeout represents the duration it waits until a delete operation times out.
-	DeleteTimeout = 1 * time.Minute
-
-	// DeletePolling represents the polling interval for a delete operation.
-	DeletePolling = 5 * time.Second
-
-	// ListTimeout represents the duration it waits until a list operation times out.
-	ListTimeout = 10 * time.Second
-
-	// ListPolling represents the polling interval for a list operation.
-	ListPolling = 1 * time.Second
-
-	// GetTimeout represents the duration it waits until a get operation times out.
-	GetTimeout = 1 * time.Minute
-
-	// GetPolling represents the polling interval for a get operation.
-	GetPolling = 5 * time.Second
-
-	// UpdateTimeout represents the duration it waits until an update operation times out.
-	UpdateTimeout = 10 * time.Second
-
-	// UpdatePolling represents the polling interval for an update operation.
-	UpdatePolling = 1 * time.Second
-
-	// WaitTimeout represents the duration it waits until a wait operation times out.
-	WaitTimeout = 5 * time.Minute
-
-	// WaitPolling represents the polling interval for a wait operation.
-	WaitPolling = 5 * time.Second
+	// Polling represents the polling interval for a long-running operation.
+	Polling = 5 * time.Second
 )

--- a/test/e2e/gatekeeper_test.go
+++ b/test/e2e/gatekeeper_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
-	"github.com/Azure/aad-pod-identity/test/e2e/framework/azureassignedidentity"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/azureidentity"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/exec"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/namespace"
@@ -76,15 +75,11 @@ var _ = Describe("When using AAD Pod Identity with Gatekeeper", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
-		})
-
-		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
-			Lister: kubeClient,
-			Len:    0,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 

--- a/test/e2e/identity_exception_test.go
+++ b/test/e2e/identity_exception_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	"github.com/Azure/aad-pod-identity/test/e2e/framework/azureassignedidentity"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/azurepodidentityexception"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/identityvalidator"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/namespace"
@@ -28,15 +27,11 @@ var _ = Describe("When deploying AzurePodIdentityException", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
-		})
-
-		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
-			Lister: kubeClient,
-			Len:    0,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 

--- a/test/e2e/init_containers_test.go
+++ b/test/e2e/init_containers_test.go
@@ -65,15 +65,11 @@ var _ = Describe("When init containers are enabled", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
-		})
-
-		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
-			Lister: kubeClient,
-			Len:    0,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 

--- a/test/e2e/invalid_identities_test.go
+++ b/test/e2e/invalid_identities_test.go
@@ -52,15 +52,11 @@ var _ = Describe("When deploying invalid identities", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
-		})
-
-		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
-			Lister: kubeClient,
-			Len:    0,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 

--- a/test/e2e/liveness_probe_test.go
+++ b/test/e2e/liveness_probe_test.go
@@ -21,13 +21,7 @@ import (
 var _ = Describe("When liveness probe is enabled", func() {
 	It("should pass liveness probe test", func() {
 		pods := &corev1.PodList{}
-		Eventually(func() (bool, error) {
-			if err := kubeClient.List(context.TODO(), pods, client.InNamespace(framework.NamespaceKubeSystem)); err != nil {
-				return false, err
-			}
-
-			return true, nil
-		}, framework.ListTimeout, framework.ListPolling).Should(BeTrue())
+		Expect(kubeClient.List(context.TODO(), pods, client.InNamespace(framework.NamespaceKubeSystem))).Should(Succeed())
 
 		micPods := pod.List(pod.ListInput{
 			Lister:    kubeClient,

--- a/test/e2e/multiple_identities_test.go
+++ b/test/e2e/multiple_identities_test.go
@@ -56,15 +56,11 @@ var _ = Describe("When deploying multiple identities", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
-		})
-
-		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
-			Lister: kubeClient,
-			Len:    0,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -64,15 +64,11 @@ var _ = Describe("When managing identities from the underlying nodes", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
-		})
-
-		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
-			Lister: kubeClient,
-			Len:    0,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 
@@ -389,10 +385,10 @@ var _ = Describe("When managing identities from the underlying nodes", func() {
 		Expect(err).To(BeNil())
 
 		By("Waiting for identity assignment to be reconciled")
-		Eventually(func() (bool, error) {
+		Eventually(func() bool {
 			userAssignedIdentities := azureClient.ListUserAssignedIdentities(node.Spec.ProviderID)
-			return isUserAssignedIdentityExist(userAssignedIdentities, keyvaultIdentity), nil
-		}, framework.WaitTimeout, framework.WaitPolling).Should(BeTrue())
+			return isUserAssignedIdentityExist(userAssignedIdentities, keyvaultIdentity)
+		}, framework.Timeout, framework.Polling).Should(BeTrue())
 
 		identityvalidator.Validate(identityvalidator.ValidateInput{
 			Getter:             kubeClient,

--- a/test/e2e/single_identity_test.go
+++ b/test/e2e/single_identity_test.go
@@ -71,15 +71,11 @@ var _ = Describe("When deploying one identity", func() {
 	})
 
 	AfterEach(func() {
-		namespace.Delete(namespace.DeleteInput{
-			Deleter:   kubeClient,
-			Getter:    kubeClient,
+		Cleanup(CleanupInput{
 			Namespace: ns,
-		})
-
-		azureassignedidentity.WaitForLen(azureassignedidentity.WaitForLenInput{
-			Lister: kubeClient,
-			Len:    0,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
 		})
 	})
 


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->


**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
