### PR TITLE
docs: initial layout for static site

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,31 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: "0.75.1"
+          extended: true
+
+      - name: Build
+        run: |
+          make -C website production-build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/public

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,7 @@ __pycache__/
 
 # cover profile
 coverage.txt
+
+# website
+website/public
+website/resources

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "website/themes/book"]
+	path = website/themes/book
+	url = https://github.com/alex-shpak/hugo-book

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+base = "website/"
+publish = "/public"
+
+[context.deploy-preview]
+command = "make preview-build"
+
+[context.deploy-preview.environment]
+HUGO_VERSION = "0.75.1"
+HUGO_ENABLEGITINFO = "true"

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,0 +1,15 @@
+serve:
+	hugo server \
+		--buildDrafts \
+		--buildFuture \
+		--disableFastRender
+
+production-build:
+	hugo --minify
+
+preview-build:
+	hugo \
+		--baseURL $(DEPLOY_PRIME_URL) \
+		--buildDrafts \
+		--buildFuture \
+		--minify

--- a/website/config.toml
+++ b/website/config.toml
@@ -1,0 +1,68 @@
+# Basic site config
+title           = "AAD Pod Identity"
+baseURL         = "https://azure.github.io/aad-pod-identity"
+languageCode    = "en-us"
+enableRobotsTxt = true
+
+# Syntax highlighting config
+pygmentsCodeFences = true
+pygmentsStyle      = "fruity"
+
+theme = "book"
+
+[params]
+  # (Optional, default light) Sets color theme: light, dark or auto.
+  # Theme 'auto' switches between dark and light modes based on browser/os preferences
+  BookTheme = 'light'
+
+  # (Optional, default true) Controls table of contents visibility on right side of pages.
+  # Start and end levels can be controlled with markup.tableOfContents setting.
+  # You can also specify this parameter per page in front matter.
+  BookToC = true
+
+  # (Optional, default none) Set the path to a logo for the book. If the logo is
+  # /static/logo.png then the path would be 'logo.png'
+  BookLogo = ''
+
+  # (Optional, default none) Set leaf bundle to render as side menu
+  # When not specified file structure and weights will be used
+  BookMenuBundle = '/menu'
+
+  # (Optional, default docs) Specify section of content to render as menu
+  # You can also set value to "*" to render all sections to menu
+  BookSection = 'docs'
+
+  # Set source repository location.
+  # Used for 'Last Modified' and 'Edit this page' links.
+  BookRepo = 'https://github.com/Azure/aad-pod-identity'
+
+  # Enable 'Edit this page' links for 'doc' page type.
+  # Disabled by default. Uncomment to enable. Requires 'BookRepo' param.
+  # Path must point to the site directory.
+  BookEditPath = 'edit/master/website/content'
+
+  # (Optional, default January 2, 2006) Configure the date format used on the pages
+  # - In git information
+  # - In blog posts
+  BookDateFormat = 'January 2, 2006'
+
+  # (Optional, default true) Enables search function with flexsearch,
+  # Index is built on fly, therefore it might slowdown your website.
+  # Configuration for indexing can be adjusted in i18n folder per language.
+  BookSearch = true
+
+  # (Optional, default true) Enables comments template on pages
+  # By default partials/docs/comments.html includes Disqus template
+  # See https://gohugo.io/content-management/comments/#configure-disqus
+  # Can be overwritten by same param in page frontmatter
+  BookComments = false
+
+  # /!\ This is an experimental feature, might be removed or changed at any time
+  # (Optional, experimental, default false) Enables portable links and link checks in markdown pages.
+  # Portable links meant to work with text editors and let you write markdown without {{< relref >}} shortcode
+  # Theme will print warning if page referenced in markdown does not exists.
+  BookPortableLinks = true
+
+  # /!\ This is an experimental feature, might be removed or changed at any time
+  # (Optional, experimental, default false) Enables service worker that caches visited pages and resources for offline use.
+  BookServiceWorker = true

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,0 +1,10 @@
+---
+title: Introduction
+type: docs
+---
+
+# AAD Pod Identity
+
+AAD Pod Identity enables Kubernetes applications to access cloud resources securely with [Azure Active Directory](AAD).
+
+Using Kubernetes primitives, administrators configure identities and bindings to match pods. Then without any code modifications, your containerized applications can leverage any resource in the cloud that depends on AAD as an identity provider.

--- a/website/content/best-practices/_index.md
+++ b/website/content/best-practices/_index.md
@@ -1,0 +1,6 @@
+---
+title: Best Practices
+type: docs
+---
+
+# Best Practices

--- a/website/content/code-of-conduct/_index.md
+++ b/website/content/code-of-conduct/_index.md
@@ -1,0 +1,6 @@
+---
+title: Code of Conduct
+type: docs
+---
+
+# Code of Conduct

--- a/website/content/concepts/_index.md
+++ b/website/content/concepts/_index.md
@@ -1,0 +1,6 @@
+---
+title: Concepts
+type: docs
+---
+
+# Concepts

--- a/website/content/concepts/azureassignedidentity.md
+++ b/website/content/concepts/azureassignedidentity.md
@@ -1,0 +1,6 @@
+---
+title: AzureAssignedIdentity
+type: docs
+---
+
+# `AzureAssignedIdentity`

--- a/website/content/concepts/azureidentity.md
+++ b/website/content/concepts/azureidentity.md
@@ -1,0 +1,6 @@
+---
+title: AzureIdentity
+type: docs
+---
+
+# `AzureIdentity`

--- a/website/content/concepts/azureidentitybinding.md
+++ b/website/content/concepts/azureidentitybinding.md
@@ -1,0 +1,6 @@
+---
+title: AzureIdentityBinding
+type: docs
+---
+
+# `AzureIdentityBinding`

--- a/website/content/concepts/azurepodidentityexception.md
+++ b/website/content/concepts/azurepodidentityexception.md
@@ -1,0 +1,6 @@
+---
+title: AzurePodIdentityException
+type: docs
+---
+
+# `AzurePodIdentityException`

--- a/website/content/concepts/mic.md
+++ b/website/content/concepts/mic.md
@@ -1,0 +1,6 @@
+---
+title: Managed Identity Controller
+type: docs
+---
+
+# Managed Identity Controller (MIC)

--- a/website/content/concepts/nmi.md
+++ b/website/content/concepts/nmi.md
@@ -1,0 +1,6 @@
+---
+title: Node-Managed Identity
+type: docs
+---
+
+# Node-Managed Identity (NMI)

--- a/website/content/concepts/role-assignments.md
+++ b/website/content/concepts/role-assignments.md
@@ -1,0 +1,6 @@
+---
+title: Role Assignments
+type: docs
+---
+
+# Role Assignments

--- a/website/content/demo/_index.md
+++ b/website/content/demo/_index.md
@@ -1,0 +1,6 @@
+---
+title: Demo
+type: docs
+---
+
+# Demo

--- a/website/content/development/_index.md
+++ b/website/content/development/_index.md
@@ -1,0 +1,6 @@
+---
+title: Development
+type: docs
+---
+
+# Development

--- a/website/content/features/_index.md
+++ b/website/content/features/_index.md
@@ -1,0 +1,6 @@
+---
+title: Features
+type: docs
+---
+
+# Features

--- a/website/content/features/feature-flags.md
+++ b/website/content/features/feature-flags.md
@@ -1,0 +1,6 @@
+---
+title: Feature Flags
+type: docs
+---
+
+# Feature Flags

--- a/website/content/features/managed-mode.md
+++ b/website/content/features/managed-mode.md
@@ -1,0 +1,6 @@
+---
+title: Managed Mode
+type: docs
+---
+
+# Managed Mode

--- a/website/content/features/monitoring-with-prometheus.md
+++ b/website/content/features/monitoring-with-prometheus.md
@@ -1,0 +1,6 @@
+---
+title: Monitoring with Prometheus
+type: docs
+---
+
+# Monitoring with Prometheus

--- a/website/content/features/namespaced-mode.md
+++ b/website/content/features/namespaced-mode.md
@@ -1,0 +1,6 @@
+---
+title: Namespaced Mode
+type: docs
+---
+
+# Namespaced Mode

--- a/website/content/features/non-cluster-credentials-for-mic.md
+++ b/website/content/features/non-cluster-credentials-for-mic.md
@@ -1,0 +1,6 @@
+---
+title: Non-Cluster Credentials for MIC
+type: docs
+---
+
+# Non-Cluster Credentials for MIC

--- a/website/content/features/validation-using-gatekeeper.md
+++ b/website/content/features/validation-using-gatekeeper.md
@@ -1,0 +1,6 @@
+---
+title: Validation Using Gatekeeper
+type: docs
+---
+
+# Validation Using Gatekeeper

--- a/website/content/getting-started/_index.md
+++ b/website/content/getting-started/_index.md
@@ -1,0 +1,16 @@
+---
+title: Getting Started
+type: docs
+---
+
+# Getting Started
+
+## Installation
+
+### Prerequisites
+
+## Role Assignments
+
+## Next Steps
+
+Try out the demo

--- a/website/content/known-issues/_index.md
+++ b/website/content/known-issues/_index.md
@@ -1,0 +1,6 @@
+---
+title: Known Issues
+type: docs
+---
+
+# Known Issues

--- a/website/content/menu/index.md
+++ b/website/content/menu/index.md
@@ -1,0 +1,28 @@
++++
+headless = false
++++
+
+- [Introduction]({{< relref "/" >}})
+- [Release Notes]({{< relref "/release-notes" >}})
+- [Getting Started]({{< relref "/getting-started" >}})
+- [1 Concepts]({{< relref "/concepts" >}})
+  - [1.1 AzureIdentity]({{< relref "/concepts/azureidentity" >}})
+  - [1.2 AzureIdentityBinding]({{< relref "/concepts/azureidentitybinding" >}})
+  - [1.3 AzureAssignedIdentity]({{< relref "/concepts/azureassignedidentity" >}})
+  - [1.4 AzurePodIdentityException]({{< relref "/concepts/azurepodidentityexception" >}})
+  - [1.5 Managed Identity Controller (MIC)]({{< relref "/concepts/mic" >}})
+  - [1.6 Node-Managed Identity (NMI)]({{< relref "/concepts/nmi" >}})
+- [2 Features]({{< relref "/features" >}})
+  - [2.1 Feature Flags]({{< relref "/features/feature-flags" >}})
+  - [2.2 Managed Mode]({{< relref "/features/managed-mode" >}})
+  - [2.3 Monitoring With Prometheus]({{< relref "/features/monitoring-with-prometheus" >}})
+  - [2.4 Namespaced Mode]({{< relref "/features/namespaced-mode" >}})
+  - [2.5 Non-Cluster Credentials for MIC]({{< relref "/features/non-cluster-credentials-for-mic" >}})
+  - [2.6 Validation Using Gatekeeper]({{< relref "/features/validation-using-gatekeeper" >}})
+- [3 Best Practices]({{< relref "/best-practices" >}})
+- [4 Troubleshooting]({{< relref "/troubleshooting" >}})
+- [5 Known Issues]({{< relref "/known-issues" >}})
+- [6 Uninstall Note]({{< relref "/uninstall-note" >}})
+- [7 Development]({{< relref "/development" >}})
+- [8 Code of Conduct]({{< relref "/code-of-conduct" >}})
+- [9 Support]({{< relref "/support" >}})

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -1,0 +1,6 @@
+---
+title: Release Notes
+type: docs
+---
+
+# Release Notes

--- a/website/content/support/_index.md
+++ b/website/content/support/_index.md
@@ -1,0 +1,6 @@
+---
+title: Support
+type: docs
+---
+
+# Support

--- a/website/content/troubleshooting/_index.md
+++ b/website/content/troubleshooting/_index.md
@@ -1,0 +1,6 @@
+---
+title: Troubleshooting
+type: docs
+---
+
+# Troubleshooting

--- a/website/content/uninstall-note/_index.md
+++ b/website/content/uninstall-note/_index.md
@@ -1,0 +1,6 @@
+---
+title: Uninstall Note
+type: docs
+---
+
+# Uninstall Note


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Used Hugo for generating the static site for aad-pod-identity documentation and GitHub Pages to host the contents.  This PR only includes the initial layout of the website. I will open additional PRs in the future to copy contents from GitHub READMEs to the website.

Used GitHub Actions to continuously deploy docs changes made to the master branch to `gh-pages`, which is the branch where the contents are hosted.

Integrated with Netlify to allow page preview before merging PRs.

Preview: https://chewong.github.io/aad-pod-identity or click `Details` besides the `netlify/aad-pod-identity/deploy-preview` CI status below.

refs: #795 

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
