### PR TITLE
ci: include image scanning as part of CI & use distroless/static:nonroot as the base images

### DIFF
--- a/.pipelines/build-images.yml
+++ b/.pipelines/build-images.yml
@@ -11,9 +11,6 @@ steps:
   - script: |
       if [[ -n "${IMAGE_VERSION:-}" ]]; then
         echo "Image version: ${IMAGE_VERSION}"
-        echo "##vso[task.setvariable variable=MIC_VERSION]${IMAGE_VERSION}"
-        echo "##vso[task.setvariable variable=NMI_VERSION]${IMAGE_VERSION}"
-        echo "##vso[task.setvariable variable=IDENTITY_VALIDATOR_VERSION]${IMAGE_VERSION}"
         exit 0
       fi
 
@@ -23,16 +20,10 @@ steps:
       else
         IMAGE_VERSION="$(git describe --tags --always --dirty)-$(CLUSTER_CONFIG)"
       fi
+      export IMAGE_VERSION
+      echo "##vso[task.setvariable variable=IMAGE_VERSION]${IMAGE_VERSION}"
       echo "Image version: ${IMAGE_VERSION}"
 
-      export MIC_VERSION="${IMAGE_VERSION}"
-      echo "##vso[task.setvariable variable=MIC_VERSION]${MIC_VERSION}"
-      export NMI_VERSION="${IMAGE_VERSION}"
-      echo "##vso[task.setvariable variable=NMI_VERSION]${NMI_VERSION}"
-      export IDENTITY_VALIDATOR_VERSION="${IMAGE_VERSION}"
-      echo "##vso[task.setvariable variable=IDENTITY_VALIDATOR_VERSION]${IDENTITY_VALIDATOR_VERSION}"
-
       az acr login -n $(REGISTRY_NAME)
-      make image-mic image-nmi image-identity-validator
-      make push-mic push-nmi push-identity-validator
-    displayName: "Build and push MIC, NMI and identity-validator"
+      make images push
+    displayName: "Build and push MIC, NMI and identity-validator images"

--- a/.pipelines/cleanup-images.yml
+++ b/.pipelines/cleanup-images.yml
@@ -1,16 +1,12 @@
 steps:
   - script: |
-      if [[ -n "${IMAGE_VERSION:-}" ]]; then
-        echo "Not deleting custom images"
-        exit 0
-      fi
-
       # Allow errors in case the images do not exist
       set +e
       az account set -s=$(SUBSCRIPTION_ID)
       az acr login -n $(REGISTRY_NAME)
-      az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/mic:${MIC_VERSION} --yes || true
-      az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/nmi:${NMI_VERSION} --yes || true
-      az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/identityvalidator:${IDENTITY_VALIDATOR_VERSION} --yes || true
+      az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/mic:${IMAGE_VERSION} --yes || true
+      az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/nmi:${IMAGE_VERSION} --yes || true
+      az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/identityvalidator:${IMAGE_VERSION} --yes || true
+      az acr repository delete --name $(REGISTRY_NAME) --image k8s/aad-pod-identity/demo:${IMAGE_VERSION} --yes || true
     condition: always()
     displayName: "Cleanup"

--- a/.pipelines/e2e-tests-template.yml
+++ b/.pipelines/e2e-tests-template.yml
@@ -50,6 +50,9 @@ jobs:
 
         - script: |
             export REGISTRY="${REGISTRY:-$(REGISTRY_NAME).azurecr.io/k8s/aad-pod-identity}"
+            export MIC_VERSION="${IMAGE_VERSION}"
+            export NMI_VERSION="${IMAGE_VERSION}"
+            export IDENTITY_VALIDATOR_VERSION="${IMAGE_VERSION}"
             make e2e
           env:
             SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)

--- a/.pipelines/load-tests-template.yml
+++ b/.pipelines/load-tests-template.yml
@@ -82,8 +82,8 @@ jobs:
             helm install pi manifest_staging/charts/aad-pod-identity --namespace $NAMESPACE --wait --timeout=10m -v=5 --debug \
               --set operationMode=${OPERATION_MODE} \
               --set image.repository=${REGISTRY} \
-              --set mic.tag=${MIC_VERSION} \
-              --set nmi.tag=${NMI_VERSION} \
+              --set mic.tag=${IMAGE_VERSION} \
+              --set nmi.tag=${IMAGE_VERSION} \
               --set enableScaleFeatures=true
 
             envsubst < test/load/azureidentity-template.yml > test/load/azureidentity.yml

--- a/.pipelines/scan-images.yml
+++ b/.pipelines/scan-images.yml
@@ -1,0 +1,13 @@
+steps:
+  - script: |
+      export REGISTRY="e2e"
+      export IMAGE_VERSION="test"
+      make images
+
+      wget https://github.com/aquasecurity/trivy/releases/download/v0.11.0/trivy_0.11.0_Linux-64bit.tar.gz
+      tar zxvf trivy_0.11.0_Linux-64bit.tar.gz
+      ./trivy --exit-code 1 --ignore-unfixed --no-progress "${REGISTRY}/mic:${IMAGE_VERSION}"
+      ./trivy --exit-code 1 --ignore-unfixed --no-progress "${REGISTRY}/nmi:${IMAGE_VERSION}"
+      ./trivy --exit-code 1 --ignore-unfixed --no-progress "${REGISTRY}/identityvalidator:${IMAGE_VERSION}"
+      ./trivy --exit-code 1 --ignore-unfixed --no-progress "${REGISTRY}/demo:${IMAGE_VERSION}"
+    displayName: "Scan images for vulnerability"

--- a/.pipelines/soak-tests-template.yml
+++ b/.pipelines/soak-tests-template.yml
@@ -64,13 +64,10 @@ jobs:
           displayName: "Check cluster's health"
 
         - script: |
-            if [[ -n "${IMAGE_VERSION:-}" ]]; then
-              echo "Image version: ${IMAGE_VERSION}"
-              export MIC_VERSION="${IMAGE_VERSION}"
-              export NMI_VERSION="${IMAGE_VERSION}"
-              export IDENTITY_VALIDATOR_VERSION="${IMAGE_VERSION}"
-            fi
             export REGISTRY="${REGISTRY:-$(REGISTRY_NAME).azurecr.io/k8s/aad-pod-identity}"
+            export MIC_VERSION="${IMAGE_VERSION}"
+            export NMI_VERSION="${IMAGE_VERSION}"
+            export IDENTITY_VALIDATOR_VERSION="${IMAGE_VERSION}"
             make e2e
           env:
             SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)

--- a/.pipelines/unit-tests-template.yml
+++ b/.pipelines/unit-tests-template.yml
@@ -8,8 +8,6 @@ jobs:
       - task: GoTool@0
         inputs:
           version: 1.15
-      - script: make build
-        displayName: Build
       - script: make unit-test
         displayName: Run unit tests
       - script: bash <(curl -s https://codecov.io/bash)
@@ -20,3 +18,4 @@ jobs:
         displayName: Run lint
       - script: make helm-lint
         displayName: Run helm lint
+      - template: scan-images.yml

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,8 @@ GOOS ?= linux
 TEST_GOOS ?= linux
 IDENTITY_VALIDATOR_BINARY_NAME := identityvalidator
 
-DEFAULT_VERSION := 0.0.0-dev
-NMI_VERSION ?= $(DEFAULT_VERSION)
-MIC_VERSION ?= $(DEFAULT_VERSION)
-DEMO_VERSION ?= $(DEFAULT_VERSION)
-IDENTITY_VALIDATOR_VERSION ?= $(DEFAULT_VERSION)
+DEFAULT_VERSION := v0.0.0-dev
+IMAGE_VERSION ?= $(DEFAULT_VERSION)
 
 NMI_VERSION_VAR := $(REPO_PATH)/version.NMIVersion
 MIC_VERSION_VAR := $(REPO_PATH)/version.MICVersion
@@ -34,20 +31,24 @@ else
 	endif
 endif
 
-GO_BUILD_OPTIONS := --tags "netgo osusergo"  -ldflags "-s -X $(NMI_VERSION_VAR)=$(NMI_VERSION) -X $(MIC_VERSION_VAR)=$(MIC_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
+GO_BUILD_OPTIONS := --tags "netgo osusergo"  -ldflags "-s -X $(NMI_VERSION_VAR)=$(IMAGE_VERSION) -X $(MIC_VERSION_VAR)=$(IMAGE_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
 E2E_TEST_OPTIONS := -count=1 -v -timeout 24h -ginkgo.progress $(E2E_TEST_OPTIONS_EXTRA)
 
 # useful for other docker repos
 REGISTRY_NAME ?= upstreamk8sci
-REGISTRY ?= $(REGISTRY_NAME).azurecr.io
 REPO_PREFIX ?= k8s/aad-pod-identity
-NMI_IMAGE ?= $(REPO_PREFIX)/$(NMI_BINARY_NAME):$(NMI_VERSION)
-MIC_IMAGE ?= $(REPO_PREFIX)/$(MIC_BINARY_NAME):$(MIC_VERSION)
-DEMO_IMAGE ?= $(REPO_PREFIX)/$(DEMO_BINARY_NAME):$(DEMO_VERSION)
-IDENTITY_VALIDATOR_IMAGE ?= $(REPO_PREFIX)/$(IDENTITY_VALIDATOR_BINARY_NAME):$(IDENTITY_VALIDATOR_VERSION)
+REGISTRY ?= $(REGISTRY_NAME).azurecr.io/$(REPO_PREFIX)
+NMI_IMAGE := $(NMI_BINARY_NAME):$(IMAGE_VERSION)
+MIC_IMAGE := $(MIC_BINARY_NAME):$(IMAGE_VERSION)
+DEMO_IMAGE := $(DEMO_BINARY_NAME):$(IMAGE_VERSION)
+IDENTITY_VALIDATOR_IMAGE := $(IDENTITY_VALIDATOR_BINARY_NAME):$(IMAGE_VERSION)
 ALL_DOCS := $(shell find . -name '*.md' -type f | sort)
 TOOLS_MOD_DIR := ./tools
 TOOLS_DIR := $(abspath ./.tools)
+
+# docker env var
+DOCKER_BUILDKIT = 1
+export DOCKER_BUILDKIT
 
 $(TOOLS_DIR)/golangci-lint: $(TOOLS_MOD_DIR)/go.mod $(TOOLS_MOD_DIR)/go.sum $(TOOLS_MOD_DIR)/tools.go
 	cd $(TOOLS_MOD_DIR) && \
@@ -123,40 +124,52 @@ deepcopy-gen:
 
 .PHONY: image-nmi
 image-nmi:
-	docker build -t "$(REGISTRY)/$(NMI_IMAGE)" --build-arg NMI_VERSION="$(NMI_VERSION)" --build-arg BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables-amd64:v12.1.2 --target=nmi .
+	docker build \
+		--target nmi \
+		--build-arg IMAGE_VERSION=$(IMAGE_VERSION) \
+		-t $(REGISTRY)/$(NMI_IMAGE) .
 
 .PHONY: image-mic
 image-mic:
-	docker build -t "$(REGISTRY)/$(MIC_IMAGE)" --build-arg MIC_VERSION="$(MIC_VERSION)" --target=mic .
+	docker build \
+		--target mic \
+		--build-arg IMAGE_VERSION=$(IMAGE_VERSION) \
+		-t "$(REGISTRY)/$(MIC_IMAGE)" .
 
 .PHONY: image-demo
 image-demo:
-	docker build -t $(REGISTRY)/$(DEMO_IMAGE) --build-arg DEMO_VERSION="$(DEMO_VERSION)" --target=demo .
+	docker build \
+		--target demo \
+		--build-arg IMAGE_VERSION=$(IMAGE_VERSION) \
+		-t "$(REGISTRY)/$(DEMO_IMAGE)" .
 
 .PHONY: image-identity-validator
 image-identity-validator:
-	docker build -t $(REGISTRY)/$(IDENTITY_VALIDATOR_IMAGE) --build-arg IDENTITY_VALIDATOR_VERSION="$(IDENTITY_VALIDATOR_VERSION)" --target=identityvalidator .
+	docker build \
+		--target identityvalidator \
+		--build-arg IMAGE_VERSION=$(IMAGE_VERSION) \
+		-t "$(REGISTRY)/$(IDENTITY_VALIDATOR_IMAGE)" .
 
-.PHONY: image
-image:image-nmi image-mic image-demo image-identity-validator
+.PHONY: images
+images: image-nmi image-mic image-demo image-identity-validator
 
 .PHONY: push-nmi
-push-nmi: validate-version-NMI
+push-nmi: validate-version
 	az acr repository show --name $(REGISTRY_NAME) --image $(NMI_IMAGE) > /dev/null 2>&1; if [ $$? -eq 0 ]; then echo "$(NMI_IMAGE) already exists" && exit 0; fi
 	docker push $(REGISTRY)/$(NMI_IMAGE)
 
 .PHONY: push-mic
-push-mic: validate-version-MIC
+push-mic: validate-version
 	az acr repository show --name $(REGISTRY_NAME) --image $(MIC_IMAGE) > /dev/null 2>&1; if [ $$? -eq 0 ]; then echo "$(MIC_IMAGE) already exists" && exit 0; fi
 	docker push $(REGISTRY)/$(MIC_IMAGE)
 
 .PHONY: push-demo
-push-demo: validate-version-DEMO
+push-demo: validate-version
 	az acr repository show --name $(REGISTRY_NAME) --image $(DEMO_IMAGE) > /dev/null 2>&1; if [ $$? -eq 0 ]; then echo "$(DEMO_IMAGE) already exists" && exit 0; fi
 	docker push $(REGISTRY)/$(DEMO_IMAGE)
 
 .PHONY: push-identity-validator
-push-identity-validator: validate-version-IDENTITY_VALIDATOR
+push-identity-validator: validate-version
 	az acr repository show --name $(REGISTRY_NAME) --image $(IDENTITY_VALIDATOR_IMAGE) > /dev/null 2>&1; if [ $$? -eq 0 ]; then echo "$(IDENTITY_VALIDATOR_IMAGE) already exists" && exit 0; fi
 	docker push $(REGISTRY)/$(IDENTITY_VALIDATOR_IMAGE)
 
@@ -172,12 +185,8 @@ unit-test:
 	GOOS=$(TEST_GOOS) CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic -count=1 $(shell go list ./... | grep -v /test/e2e) -v
 
 .PHONY: validate-version
-validate-version: validate-version-NMI validate-version-MIC validate-version-IDENTITY_VALIDATOR validate-version-DEMO
-
-.PHONY: validate-version-%
-validate-version-%:
-	@echo $(*)_VERSION=$($(*)_VERSION)
-	@DEFAULT_VERSION=$(DEFAULT_VERSION) CHECK_VERSION="$($(*)_VERSION)" scripts/validate_version.sh
+validate-version:
+	@DEFAULT_VERSION=$(DEFAULT_VERSION) CHECK_VERSION="$(IMAGE_VERSION)" scripts/validate_version.sh
 
 .PHONY: mod
 mod:

--- a/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
@@ -83,6 +83,8 @@ spec:
           {{- if .Values.mic.identityAssignmentReconcileInterval }}
           - --identity-assignment-reconcile-interval={{ .Values.mic.identityAssignmentReconcileInterval }}
           {{- end }}
+        securityContext:
+          runAsUser: 0
         env:
           - name: MIC_POD_NAMESPACE
             valueFrom:

--- a/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -109,6 +109,7 @@ spec:
             protocol: TCP
         {{- end }}
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/manifest_staging/deploy/infra/deployment-rbac.yaml
+++ b/manifest_staging/deploy/infra/deployment-rbac.yaml
@@ -144,6 +144,7 @@ spec:
             cpu: 100m
             memory: 256Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN
@@ -238,6 +239,8 @@ spec:
         args:
           - "--cloudconfig=/etc/kubernetes/azure.json"
           - "--logtostderr"
+        securityContext:
+          runAsUser: 0
         env:
         - name: MIC_POD_NAMESPACE
           valueFrom:

--- a/manifest_staging/deploy/infra/deployment.yaml
+++ b/manifest_staging/deploy/infra/deployment.yaml
@@ -93,6 +93,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN
@@ -140,6 +141,8 @@ spec:
           - "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
           - "--cloudconfig=/etc/kubernetes/azure.json"
           - "--logtostderr"
+        securityContext:
+          runAsUser: 0
         env:
         - name: MIC_POD_NAMESPACE
           valueFrom:

--- a/manifest_staging/deploy/infra/managed-mode-deployment.yaml
+++ b/manifest_staging/deploy/infra/managed-mode-deployment.yaml
@@ -131,6 +131,7 @@ spec:
             cpu: 100m
             memory: 256Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/manifest_staging/deploy/infra/noazurejson/deployment-rbac.yaml
+++ b/manifest_staging/deploy/infra/noazurejson/deployment-rbac.yaml
@@ -142,6 +142,7 @@ spec:
             cpu: 100m
             memory: 256Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN
@@ -247,6 +248,8 @@ spec:
         imagePullPolicy: Always
         args:
           - "--logtostderr"
+        securityContext:
+          runAsUser: 0
         env:
           - name: MIC_POD_NAMESPACE
             valueFrom:

--- a/manifest_staging/deploy/infra/noazurejson/deployment.yaml
+++ b/manifest_staging/deploy/infra/noazurejson/deployment.yaml
@@ -98,6 +98,7 @@ spec:
             cpu: 100m
             memory: 256Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN
@@ -151,6 +152,8 @@ spec:
         args:
           - "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
           - "--logtostderr"
+        securityContext:
+          runAsUser: 0
         env:
           - name: MIC_POD_NAMESPACE
             valueFrom:

--- a/test/e2e/framework/identityvalidator/identityvalidator_helpers.go
+++ b/test/e2e/framework/identityvalidator/identityvalidator_helpers.go
@@ -56,10 +56,10 @@ func Create(input CreateInput) *corev1.Pod {
 				{
 					Name:  "identity-validator",
 					Image: fmt.Sprintf("%s/identityvalidator:%s", input.Config.Registry, input.Config.IdentityValidatorVersion),
-					Command: []string{
-						"sleep",
-						"3600",
+					Args: []string{
+						"--sleep",
 					},
+					ImagePullPolicy: corev1.PullAlways,
 					Env: []corev1.EnvVar{
 						{
 							Name: "E2E_TEST_POD_NAME",

--- a/test/e2e/liveness_probe_test.go
+++ b/test/e2e/liveness_probe_test.go
@@ -3,55 +3,19 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
 	"github.com/Azure/aad-pod-identity/test/e2e/framework"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/exec"
-	"github.com/Azure/aad-pod-identity/test/e2e/framework/mic"
 	"github.com/Azure/aad-pod-identity/test/e2e/framework/pod"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("When liveness probe is enabled", func() {
 	It("should pass liveness probe test", func() {
-		pods := &corev1.PodList{}
-		Expect(kubeClient.List(context.TODO(), pods, client.InNamespace(framework.NamespaceKubeSystem))).Should(Succeed())
-
-		micPods := pod.List(pod.ListInput{
-			Lister:    kubeClient,
-			Namespace: framework.NamespaceKubeSystem,
-			Labels: map[string]string{
-				"app.kubernetes.io/component": "mic",
-			},
-		})
-
-		micLeader := mic.GetLeader(mic.GetLeaderInput{
-			Getter: kubeClient,
-		})
-
-		for _, micPod := range micPods.Items {
-			cmd := "clean-install wget"
-			_, err := exec.KubectlExec(kubeconfigPath, micPod.Name, framework.NamespaceKubeSystem, strings.Split(cmd, " "))
-			Expect(err).To(BeNil())
-
-			cmd = "wget http://127.0.0.1:8080/healthz -q -O -"
-			stdout, err := exec.KubectlExec(kubeconfigPath, micPod.Name, framework.NamespaceKubeSystem, strings.Split(cmd, " "))
-			Expect(err).To(BeNil())
-			if micPod.Name == micLeader.Name {
-				By(fmt.Sprintf("Ensuring that %s's health probe is active", micPod.Name))
-				Expect(strings.EqualFold(stdout, "Active")).To(BeTrue())
-			} else {
-				By(fmt.Sprintf("Ensuring that %s's health probe is not active", micPod.Name))
-				Expect(strings.EqualFold(stdout, "Not Active")).To(BeTrue())
-			}
-		}
-
 		nmiPods := pod.List(pod.ListInput{
 			Lister:    kubeClient,
 			Namespace: framework.NamespaceKubeSystem,

--- a/test/image/identityvalidator/identityvalidator.go
+++ b/test/image/identityvalidator/identityvalidator.go
@@ -23,6 +23,7 @@ import (
 )
 
 var (
+	sleep                 = pflag.Bool("sleep", false, "Set to true to enter sleep mode")
 	subscriptionID        = pflag.String("subscription-id", "", "subscription id for test")
 	identityClientID      = pflag.String("identity-client-id", "", "client id for the msi id")
 	identityResourceID    = pflag.String("identity-resource-id", "", "resource id for the msi id")
@@ -38,6 +39,13 @@ const (
 
 func main() {
 	pflag.Parse()
+
+	if *sleep {
+		klog.Infof("entering sleep mode")
+		for {
+			select {}
+		}
+	}
 
 	podname := os.Getenv("E2E_TEST_POD_NAME")
 	podnamespace := os.Getenv("E2E_TEST_POD_NAMESPACE")


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

- Continuously monitoring for any image vulnerabilities with [trivy](https://github.com/aquasecurity/trivy)
- enabled docker buildkit for faster image building process (5 minutes -> under 2 minutes for building mic, nmi, identityvalidator and demo images)
- added "User" field to aad-pod-identity images and run MIC & NMI as root when deploying.

Fixes #794.
FIxes #805.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
