### PR TITLE
ci: remove aks cluster version in e2e

### DIFF
--- a/.pipelines/deploy-aks-cluster.yml
+++ b/.pipelines/deploy-aks-cluster.yml
@@ -8,7 +8,6 @@ steps:
           -n ${RESOURCE_GROUP} \
           --node-count $(AGENT_COUNT) \
           --nodepool-name nodepool1 \
-          --kubernetes-version $(AKS_CLUSTER_VERSION) \
           --node-vm-size Standard_DS2_v2 \
           --location ${LOCATION} \
           --service-principal $(AZURE_CLIENT_ID) \
@@ -29,7 +28,6 @@ steps:
         az aks create \
           --resource-group ${RESOURCE_GROUP} \
           --name ${RESOURCE_GROUP} \
-          --kubernetes-version $(AKS_CLUSTER_VERSION) \
           --max-pods ${MAX_PODS} \
           --service-principal $(AZURE_CLIENT_ID) \
           --client-secret $(AZURE_CLIENT_SECRET) \
@@ -44,11 +42,15 @@ steps:
       # set CLUSTER_RESOURCE_GROUP for e2e test config
       export CLUSTER_RESOURCE_GROUP="MC_${RESOURCE_GROUP}_${RESOURCE_GROUP}_$(LOCATION)"
       echo "##vso[task.setvariable variable=CLUSTER_RESOURCE_GROUP]${CLUSTER_RESOURCE_GROUP}"
+
+      AKS_CLUSTER_VERSION=$(az aks show -g ${RESOURCE_GROUP} -n ${RESOURCE_GROUP} --query 'kubernetesVersion' -o tsv)
+      # set AKS_CLUSTER_VERSION for e2e test config
+      echo "##vso[task.setvariable variable=AKS_CLUSTER_VERSION]${AKS_CLUSTER_VERSION}"
     displayName: "Deploy an AKS cluster "
 
   - script: |
       echo "Installing kubectl..."
-      curl -LO https://storage.googleapis.com/kubernetes-release/release/v$(AKS_CLUSTER_VERSION)/bin/linux/amd64/kubectl
+      curl -LO https://storage.googleapis.com/kubernetes-release/release/v${AKS_CLUSTER_VERSION}/bin/linux/amd64/kubectl
       chmod +x kubectl
       sudo mv kubectl /usr/local/bin/
     displayName: "Install kubectl"


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Removes setting for `AKS_CLUSTER_VERSION` as the versions can go stale over time. Use the latest default in AKS for testing.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
