### PR TITLE
fix: ensure backward compability of identityvalidator image

### DIFF
--- a/.pipelines/load-tests-template.yml
+++ b/.pipelines/load-tests-template.yml
@@ -6,6 +6,7 @@ jobs:
   - ${{ each operationMode in parameters.operationModes }}:
     - job:
       displayName: ${{ format('load/{0}', operationMode) }}
+      dependsOn: unit_tests
       strategy:
         matrix:
           test-pod-2000:


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

With the change in the base image to distroless, we introduced `identityvalidator --sleep` instead of using the Linux `sleep` command to allow the pods to enter a hibernated state. This PR ensures the test framework is backward compatible in case of using an older version identityvalidator in our soak test.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
