### PR TITLE
fix: decrease length of RG name to allow cluster creation in eastus2euap

### DIFF
--- a/.pipelines/e2e-tests-template.yml
+++ b/.pipelines/e2e-tests-template.yml
@@ -23,7 +23,7 @@ jobs:
         - template: build-images.yml
 
         - script: |
-            export RESOURCE_GROUP="aad-pod-identity-e2e-$(openssl rand -hex 6)"
+            export RESOURCE_GROUP="aad-pod-identity-e2e-$(openssl rand -hex 2)"
             echo "##vso[task.setvariable variable=RESOURCE_GROUP]${RESOURCE_GROUP}"
           displayName: "Generate resource group name"
 


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

The MC resource group is too long when the cluster location is in eastus2euap:

```
Operation failed with status: 'Bad Request'. Details: The length of the node resource group name is too long. The maximum length is 80 and the length of the value provided is 82. Please see https://aka.ms/aks-naming-rules for more details.
```

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
