### PR TITLE
chore: make runAsUser conditional for MIC in helm

### DIFF
--- a/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
@@ -83,8 +83,10 @@ spec:
           {{- if .Values.mic.identityAssignmentReconcileInterval }}
           - --identity-assignment-reconcile-interval={{ .Values.mic.identityAssignmentReconcileInterval }}
           {{- end }}
+        {{- if not .Values.adminsecret }}
         securityContext:
           runAsUser: 0
+        {{- end }}
         env:
           - name: MIC_POD_NAMESPACE
             valueFrom:


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Make `runAsUser: 0` conditional for MIC
  - only run when access to `/etc/kubernetes/azure.json` is required.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

fixes #836 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
