### PR TITLE
docs: add note about specifying which identity to use

### DIFF
--- a/website/content/en/docs/Best Practices/_index.md
+++ b/website/content/en/docs/Best Practices/_index.md
@@ -100,7 +100,8 @@ metadata:
 ...
 ```
 
-Note: if you do not specify which managed identity to use (e.g. `az login -i`) then one of the managed identities matching the `aadpodidbinding` selector will be selected at random. To make sure the right managed identity is used for a particular workload, make sure you specify the manage identity's `clientId` when authenticating (e.g. `az login -i -u CLIENTID`).
+Note: if you do not specify which managed identity to use (e.g. `az login -i`) then one of the managed identities matching the `aadpodidbinding` selector will be selected at random. To make sure the right managed identity is used for a particular workload, make sure you specify the managed identity's `clientId`  (e.g. `az login -i -u <CLIENT ID>`) or `resourceID` (e.g `az login -i -u <RESOURCE ID>`) when authenticating.
+
 
 ## Pods using unauthorized AzureIdentities
 

--- a/website/content/en/docs/Best Practices/_index.md
+++ b/website/content/en/docs/Best Practices/_index.md
@@ -100,6 +100,8 @@ metadata:
 ...
 ```
 
+Note: if you do not specify which managed identity to use (e.g. `az login -i`) then one of the managed identities matching the `aadpodidbinding` selector will be selected at random. To make sure the right managed identity is used for a particular workload, make sure you specify the manage identity's `clientId` when authenticating (e.g. `az login -i -u CLIENTID`).
+
 ## Pods using unauthorized AzureIdentities
 
 By default, aad-pod-identity matches pods with `AzureIdentities` across all namespaces. That means that a malicious pod could assign itself an unauthorized pod identity label and acquire a token with that particular `AzureIdentity`. This scenario can be mitigated by performing the following:


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
I've added an additional note to the bottom of the section `A pod using multiple AzureIdentities` found in [Best Practices](https://azure.github.io/aad-pod-identity/docs/best-practices/#a-pod-using-multiple-azureidentities). We found that although it is possible to allow a pod to utilise multiple identities, the documentation fails to mention you need to specify which identity should be use for a particular workload.  


**Requirements**

- [ ] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**: N/A.
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**: 

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No.

**Notes for Reviewers**:

N/A.