### PR TITLE
fix: allow overwriting NODE_RESOURCE_GROUP in role-assignment.sh

### DIFF
--- a/hack/role-assignment.sh
+++ b/hack/role-assignment.sh
@@ -7,11 +7,17 @@ set -o pipefail
 [[ ! -z "${SUBSCRIPTION_ID:-}" ]] || (echo 'Must specify SUBSCRIPTION_ID' && exit 1)
 [[ ! -z "${RESOURCE_GROUP:-}" ]] || (echo 'Must specify RESOURCE_GROUP' && exit 1)
 [[ ! -z "${CLUSTER_NAME:-}" ]] || (echo 'Must specify CLUSTER_NAME' && exit 1)
-[[ ! -z "${CLUSTER_LOCATION:-}" ]] || (echo 'Must specify CLUSTER_LOCATION' && exit 1)
 
-echo "az login as a user and set the appropriate subscription ID"
-az login
-az account set -s "${SUBSCRIPTION_ID}"
+if ! az account set -s "${SUBSCRIPTION_ID}"; then
+  echo "az login as a user and set the appropriate subscription ID"
+  az login
+  az account set -s "${SUBSCRIPTION_ID}"
+fi
+
+if [[ -z "${NODE_RESOURCE_GROUP:-}" ]]; then
+  echo "Retrieving your node resource group"
+  NODE_RESOURCE_GROUP="$(az aks show -g ${RESOURCE_GROUP} -n ${CLUSTER_NAME} --query nodeResourceGroup -otsv)"
+fi
 
 echo "Retrieving your cluster identity ID, which will be used for role assignment"
 ID="$(az aks show -g ${RESOURCE_GROUP} -n ${CLUSTER_NAME} --query servicePrincipalProfile.clientId -otsv)"
@@ -21,12 +27,15 @@ if [[ "${ID:-}" == "msi" ]]; then
   ID="$(az aks show -g ${RESOURCE_GROUP} -n ${CLUSTER_NAME} --query identityProfile.kubeletidentity.clientId -otsv)"
 fi
 
-echo "Performing role assignments"
-az role assignment create --role "Managed Identity Operator" --assignee "${ID}" --scope "/subscriptions/${SUBSCRIPTION_ID}/resourcegroups/MC_${RESOURCE_GROUP}_${CLUSTER_NAME}_${CLUSTER_LOCATION}"
-az role assignment create --role "Virtual Machine Contributor" --assignee "${ID}" --scope "/subscriptions/${SUBSCRIPTION_ID}/resourcegroups/MC_${RESOURCE_GROUP}_${CLUSTER_NAME}_${CLUSTER_LOCATION}"
+echo "Assigning 'Managed Identity Operator' role to ${ID}"
+az role assignment create --role "Managed Identity Operator" --assignee "${ID}" --scope "/subscriptions/${SUBSCRIPTION_ID}/resourcegroups/${NODE_RESOURCE_GROUP}"
+
+echo "Assigning 'Virtual Machine Contributor' role to ${ID}"
+az role assignment create --role "Virtual Machine Contributor" --assignee "${ID}" --scope "/subscriptions/${SUBSCRIPTION_ID}/resourcegroups/${NODE_RESOURCE_GROUP}"
 
 # your resource group that is used to store your user-assigned identities
 # assuming it is within the same subscription as your AKS node resource group
 if [[ -n "${IDENTITY_RESOURCE_GROUP:-}" ]]; then
+  echo "Assigning 'Managed Identity Operator' role to ${ID} with ${IDENTITY_RESOURCE_GROUP} resource group scope"
   az role assignment create --role "Managed Identity Operator" --assignee "${ID}" --scope "/subscriptions/${SUBSCRIPTION_ID}/resourcegroups/${IDENTITY_RESOURCE_GROUP}"
 fi


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->


**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

fixes #872

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Notes for Reviewers**:
