### PR TITLE
docs: Added instructions how to mitigate ARP spoofing on kubenet clusters with OPA/Gatekeeper

### DIFF
--- a/website/content/en/docs/Configure/aad_pod_identity_on_kubenet.md
+++ b/website/content/en/docs/Configure/aad_pod_identity_on_kubenet.md
@@ -56,7 +56,7 @@ spec:
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
-    excludedNamespaces :
+    excludedNamespaces:
       - "kube-system"
   parameters:
     requiredDropCapabilities: ["NET_RAW"]

--- a/website/content/en/docs/Configure/aad_pod_identity_on_kubenet.md
+++ b/website/content/en/docs/Configure/aad_pod_identity_on_kubenet.md
@@ -31,7 +31,35 @@ The recommended steps to take before configuring AAD Pod Identity to run on clus
     ```
   
   This shouldn’t affect most applications, since it's only needed for applications that do deep networking inspection/manipulation. Dropping this capability will make sure even if your application code got compromised, the attacker could not perform such network-based attacks on your cluster.
- 
+
 ## How to run AAD Pod Identity on clusters with Kubenet
 
-Set the `--allow-network-plugin-kubenet=true` arg in the NMI container to continue running on clusters with Kubenet.
+Set the `--allow-network-plugin-kubenet=true` arg in the NMI container (or `--set nmi.allowNetworkPluginKubenet=true` if deploying with Helm) to continue running on clusters with Kubenet.
+
+To mitigate the vulnerability at the cluster level, you can use [OpenPolicyAgent](https://www.openpolicyagent.org/) admission controller together with [Gatekeeper](https://github.com/open-policy-agent/gatekeeper) validating webhook.
+
+Provided you have Gatekeeper already installed in your cluster, add the `ConstraintTemplate` of type `K8sPSPCapabilities`:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/pod-security-policy/capabilities/template.yaml
+```
+
+Add a template to limit the spawning of Pods with the `NET_RAW` capability:
+
+```yaml
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPCapabilities
+metadata:
+  name: prevent-net-raw
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces :
+      - "kube-system"
+  parameters:
+    requiredDropCapabilities: ["NET_RAW"]
+```
+
+You can either [exclude specific namespaces](https://github.com/open-policy-agent/gatekeeper/blob/master/README.md#exempting-namespaces-from-gatekeeper) like in the example above or explicitly include namespaces with `spec.match.namespaces`.


### PR DESCRIPTION
**Reason for Change**:
Since PodSecurityPolicy is on the way to deprecation, we should add instructions on how to mitigate the ARP spoofing vulnerability for kubenet clusters using OPA/Gatekeeper.

**Requirements**

- [X] squashed commits
- [X] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
Fixes #893 

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No

**Notes for Reviewers**:
none