### PR TITLE
test: less error-prone identityvalidator 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/coreos/go-iptables v0.3.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/google/go-cmp v0.4.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.2

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -75,7 +75,6 @@ kubectl run identityvalidator --image=mcr.microsoft.com/oss/azure/aad-pod-identi
 
 kubectl exec identityvalidator -- identityvalidator \
                                   --subscription-id "$SUBSCRIPTION_ID" \
-                                  --resource-group "$RESOURCE_GROUP" \
                                   --identity-client-id "$AZURE_CLIENT_ID" \
                                   --keyvault-name "$KEYVAULT_NAME" \
                                   --keyvault-secret-name "$KEYVAULT_SECRET_NAME" \

--- a/test/e2e/framework/identityvalidator/identityvalidator_helpers.go
+++ b/test/e2e/framework/identityvalidator/identityvalidator_helpers.go
@@ -238,8 +238,6 @@ func Validate(input ValidateInput) {
 		"identityvalidator",
 		"--subscription-id",
 		input.Config.SubscriptionID,
-		"--resource-group",
-		input.Config.IdentityResourceGroup,
 		"--identity-client-id",
 		input.IdentityClientID,
 		"--keyvault-name",

--- a/test/image/identityvalidator/identityvalidator.go
+++ b/test/image/identityvalidator/identityvalidator.go
@@ -1,46 +1,49 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
+	"flag"
 	"os"
+	"strings"
+	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
-
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+type assertFunction func() error
+
+const (
+	contextTimeout = 80 * time.Second
 )
 
 var (
-	sleep                 = pflag.Bool("sleep", false, "Set to true to enter sleep mode")
-	subscriptionID        = pflag.String("subscription-id", "", "subscription id for test")
-	identityClientID      = pflag.String("identity-client-id", "", "client id for the msi id")
-	identityResourceID    = pflag.String("identity-resource-id", "", "resource id for the msi id")
-	resourceGroup         = pflag.String("resource-group", "", "any resource group name with reader permission to the aad object")
-	keyvaultName          = pflag.String("keyvault-name", "", "the name of the keyvault to extract the secret from")
-	keyvaultSecretName    = pflag.String("keyvault-secret-name", "", "the name of the keyvault secret we are extracting with pod identity")
-	keyvaultSecretVersion = pflag.String("keyvault-secret-version", "", "the version of the keyvault secret we are extracting with pod identity")
+	sleep                 bool
+	subscriptionID        string
+	identityClientID      string
+	identityResourceID    string
+	keyvaultName          string
+	keyvaultSecretName    string
+	keyvaultSecretVersion string
+	keyvaultSecretValue   string
 )
 
-const (
-	contextTimeout = 150 * time.Second
-)
+func init() {
+	flag.BoolVar(&sleep, "sleep", false, "Set to true to enter sleep mode")
+	flag.StringVar(&subscriptionID, "subscription-id", "", "subscription id for test")
+	flag.StringVar(&identityClientID, "identity-client-id", "", "client id for the msi id")
+	flag.StringVar(&identityResourceID, "identity-resource-id", "", "resource id for the msi id")
+	flag.StringVar(&keyvaultName, "keyvault-name", "", "the name of the keyvault to extract the secret from")
+	flag.StringVar(&keyvaultSecretName, "keyvault-secret-name", "", "the name of the keyvault secret we are extracting with pod identity")
+	flag.StringVar(&keyvaultSecretVersion, "keyvault-secret-version", "", "the version of the keyvault secret we are extracting with pod identity")
+	flag.StringVar(&keyvaultSecretValue, "keyvault-secret-value", "test-value", "the version of the keyvault secret we are extracting with pod identity")
+}
 
 func main() {
-	pflag.Parse()
+	flag.Parse()
 
-	if *sleep {
+	if sleep {
 		klog.Infof("entering sleep mode")
 		for {
 			select {}
@@ -53,153 +56,64 @@ func main() {
 
 	klog.Infof("starting identity validator pod %s/%s with pod IP %s", podnamespace, podname, podip)
 
-	msiEndpoint, err := adal.GetMSIVMEndpoint()
-	if err != nil {
-		klog.Fatalf("failed to get MSI endpoint, error: %+v", err)
+	imdsTokenEndpoint, _ := adal.GetMSIVMEndpoint()
+	kvt := &keyvaultTester{
+		client:             keyvault.New(),
+		subscriptionID:     subscriptionID,
+		identityClientID:   identityClientID,
+		identityResourceID: identityResourceID,
+		keyvaultName:       keyvaultName,
+		secretName:         keyvaultSecretName,
+		secretVersion:      keyvaultSecretVersion,
+		secretValue:        keyvaultSecretValue,
+		imdsTokenEndpoint:  imdsTokenEndpoint,
 	}
-	klog.Infof("successfully obtain MSI endpoint: %s\n", msiEndpoint)
-
-	ctx, ctxCancel := context.WithTimeout(context.Background(), contextTimeout)
-	defer ctxCancel()
-
-	if *keyvaultName != "" && *keyvaultSecretName != "" {
-		// Test if the pod identity is set up correctly
-		if err := testUserAssignedIdentityOnPod(ctx, msiEndpoint, *identityClientID, *identityResourceID, *keyvaultName, *keyvaultSecretName, *keyvaultSecretVersion); err != nil {
-			klog.Fatalf("testUserAssignedIdentityOnPod failed, %+v", err)
-		}
-	} else {
-		// Test if the cluster-wide user assigned identity is set up correctly
-		if err := testClusterWideUserAssignedIdentity(ctx, msiEndpoint, *subscriptionID, *resourceGroup, *identityClientID); err != nil {
-			klog.Fatalf("testClusterWideUserAssignedIdentity failed, %+v", err)
-		}
+	spt := &servicePrincipalTester{
+		imdsTokenEndpoint: imdsTokenEndpoint,
 	}
 
-	// Test if a service principal token can be obtained when using a system assigned identity
-	if t1, err := testSystemAssignedIdentity(msiEndpoint); err != nil || t1 == nil {
-		klog.Fatalf("testSystemAssignedIdentity failed, %+v", err)
+	var wg sync.WaitGroup
+	errCh := make(chan error, 3)
+
+	for _, assert := range []assertFunction{
+		kvt.assertWithIdentityClientID,
+		kvt.assertWithIdentityResourceID,
+		spt.assertWithSystemAssignedIdentity,
+	} {
+		wg.Add(1)
+		go func(assert assertFunction) {
+			defer wg.Done()
+			var err error
+			// allow at most 2 retries if we encounter "Identity not found" error
+			for i := 0; i < 2; i++ {
+				err = assert()
+				if !isIdentityNotFoundError(err) {
+					break
+				}
+				if i < 2 {
+					time.Sleep(10 * time.Second)
+				}
+			}
+			errCh <- err
+		}(assert)
 	}
-}
+	wg.Wait()
 
-// testClusterWideUserAssignedIdentity will verify whether cluster-wide user assigned identity is working properly
-func testClusterWideUserAssignedIdentity(ctx context.Context, msiEndpoint, subscriptionID, resourceGroup, identityClientID string) error {
-	if err := os.Setenv("AZURE_CLIENT_ID", identityClientID); err != nil {
-		return errors.Wrapf(err, "failed to set AZURE_CLIENT_ID environment variable")
-	}
-	defer os.Unsetenv("AZURE_CLIENT_ID")
-	token, err := adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, azure.PublicCloud.ResourceManagerEndpoint, identityClientID)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get service principal token from user assigned identity")
-	}
+	close(errCh)
 
-	vmClient := compute.NewVirtualMachinesClient(subscriptionID)
-	vmClient.Authorizer = autorest.NewBearerAuthorizer(token)
-	vmlist, err := vmClient.List(ctx, resourceGroup)
-	if err != nil {
-		return errors.Wrapf(err, "failed to verify cluster-wide user assigned identity")
-	}
-
-	klog.Infof("successfully verified cluster-wide user assigned identity. VM count: %d", len(vmlist.Values()))
-	return nil
-}
-
-func authenticateWithMsiResourceID(msiEndpoint, resourceID, resource string) (*adal.Token, error) {
-	// Create HTTP request for a managed services for Azure resources token to access Azure Resource Manager
-	msiURL, err := url.Parse(msiEndpoint)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing MSI endpoint %s: %s", msiEndpoint, err)
-	}
-
-	msiParameters := url.Values{}
-	msiParameters.Set("resource", resource)
-	msiParameters.Set("msi_res_id", resourceID)
-	msiURL.RawQuery = msiParameters.Encode()
-	req, err := http.NewRequest("GET", msiURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request to %s: %s", msiURL.String(), err)
-	}
-
-	req.Header.Add("Metadata", "true")
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error executing request to %s: %s", msiURL.String(), err)
-	}
-
-	responseBytes, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
-	if err != nil {
-		return nil, fmt.Errorf("error parsing response body from %s: %s", msiURL.String(), err)
-	}
-
-	var token adal.Token
-	err = json.Unmarshal(responseBytes, &token)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling response from %s: %s", msiURL.String(), err)
-	}
-
-	return &token, nil
-}
-
-// testUserAssignedIdentityOnPod will verify whether a pod identity is working properly
-func testUserAssignedIdentityOnPod(ctx context.Context, msiEndpoint, identityClientID, identityResourceID, keyvaultName, keyvaultSecretName, keyvaultSecretVersion string) error {
-	var authorizers []autorest.Authorizer
-	keyClient := keyvault.New()
-
-	if identityClientID != "" {
-		// When new authorizer is created, azure-sdk-for-go  tries to create data plane authorizer using MSI. It checks the AZURE_CLIENT_ID to get the client id
-		// for the user assigned identity. If client id not found, then NewServicePrincipalTokenFromMSI is invoked instead of using the actual
-		// user assigned identity. Setting this env var ensures we validate GetSecret using the desired user assigned identity.
-		if err := os.Setenv("AZURE_CLIENT_ID", identityClientID); err != nil {
-			return errors.Wrapf(err, "failed to set AZURE_CLIENT_ID environment variable")
-		}
-		defer os.Unsetenv("AZURE_CLIENT_ID")
-
-		authorizer, err := auth.NewAuthorizerFromEnvironment()
+	hasError := false
+	for err := range errCh {
 		if err != nil {
-			return err
+			hasError = true
+			klog.Error(err)
 		}
-		authorizers = append(authorizers, authorizer)
-		klog.Infof("added authorizer with clientID: %s", identityClientID)
-	}
-	if identityResourceID != "" {
-		// The sdk doesn't support authenticating by the resource id, but we can get a token manually
-		token, err := authenticateWithMsiResourceID(msiEndpoint, identityResourceID, "https://vault.azure.net")
-		if err != nil {
-			return err
-		}
-		authorizers = append(authorizers, autorest.NewBearerAuthorizer(token))
-		klog.Infof("added authorizer with resourceID: %s", identityResourceID)
 	}
 
-	klog.Infof("%s %s %s\n", keyvaultName, keyvaultSecretName, keyvaultSecretVersion)
-	for _, authorizer := range authorizers {
-		keyClient.Authorizer = authorizer
-		secret, err := keyClient.GetSecret(ctx, fmt.Sprintf("https://%s.vault.azure.net", keyvaultName), keyvaultSecretName, keyvaultSecretVersion)
-		if err != nil || *secret.Value == "" {
-			return errors.Wrapf(err, "failed to verify user assigned identity on pod")
-		}
+	if hasError {
+		os.Exit(1)
 	}
-	klog.Infof("successfully verified user-assigned identity on pod")
-
-	return nil
 }
 
-// testMSIEndpoint will return a service principal token obtained through a system assigned identity
-func testSystemAssignedIdentity(msiEndpoint string) (*adal.Token, error) {
-	spt, err := adal.NewServicePrincipalTokenFromMSI(msiEndpoint, azure.PublicCloud.ResourceManagerEndpoint)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to acquire a token using the MSI VM extension")
-	}
-
-	if err := spt.Refresh(); err != nil {
-		return nil, errors.Wrapf(err, "failed to refresh ServicePrincipalTokenFromMSI using the MSI VM extension, msiEndpoint(%s)", msiEndpoint)
-	}
-
-	token := spt.Token()
-	if token.IsZero() {
-		return nil, errors.Errorf("No token found, MSI VM extension, msiEndpoint(%s)", msiEndpoint)
-	}
-
-	klog.Infof("successfully acquired a token using the MSI, msiEndpoint(%s)", msiEndpoint)
-	return &token, nil
+func isIdentityNotFoundError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Identity not found")
 }

--- a/test/image/identityvalidator/keyvault.go
+++ b/test/image/identityvalidator/keyvault.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"k8s.io/klog/v2"
+)
+
+const (
+	keyvaultResource = "https://vault.azure.net"
+)
+
+type keyvaultTester struct {
+	client             keyvault.BaseClient
+	subscriptionID     string
+	identityClientID   string
+	identityResourceID string
+	keyvaultName       string
+	secretName         string
+	secretVersion      string
+	secretValue        string
+	imdsTokenEndpoint  string
+}
+
+// assertWithIdentityClientID obtains the secret value from a keyvault using
+// aad-pod-identity and check if is the same as the expected secret values.
+func (kvt *keyvaultTester) assertWithIdentityClientID() error {
+	if kvt.identityClientID == "" {
+		return nil
+	}
+
+	// When new authorizer is created, azure-sdk-for-go  tries to create data plane authorizer using MSI. It checks the AZURE_CLIENT_ID to get the client id
+	// for the user assigned identity. If client id not found, then NewServicePrincipalTokenFromMSI is invoked instead of using the actual
+	// user assigned identity. Setting this env var ensures we validate GetSecret using the desired user assigned identity.
+	if err := os.Setenv("AZURE_CLIENT_ID", kvt.identityClientID); err != nil {
+		return fmt.Errorf("failed to set AZURE_CLIENT_ID environment variable, error: %+v", err)
+	}
+	defer os.Unsetenv("AZURE_CLIENT_ID")
+
+	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	if err != nil {
+		return fmt.Errorf("failed to generate a new authorizer from environment, error: %+v", err)
+	}
+
+	klog.Infof("added authorizer with clientID: %s", kvt.identityClientID)
+
+	secret, err := kvt.getSecret(authorizer)
+	if err != nil {
+		return err
+	}
+
+	if err := kvt.assertSecret(secret); err != nil {
+		return err
+	}
+
+	klog.Info("successfully verified user-assigned identity on pod with identity client ID")
+	return nil
+}
+
+// assertWithIdentityResourceID obtains the secret value from a keyvault using
+// aad-pod-identity and check if is the same as the expected secret values.
+func (kvt *keyvaultTester) assertWithIdentityResourceID() error {
+	if kvt.identityResourceID == "" {
+		return nil
+	}
+
+	token, err := kvt.getADALTokenWithIdentityResourceID()
+	if err != nil {
+		return fmt.Errorf("failed to get ADAL token with identity resource ID, error: %+v", err)
+	}
+
+	klog.Infof("added authorizer with resource ID: %s", kvt.identityResourceID)
+
+	secret, err := kvt.getSecret(autorest.NewBearerAuthorizer(token))
+	if err != nil {
+		return err
+	}
+
+	if err := kvt.assertSecret(secret); err != nil {
+		return err
+	}
+
+	klog.Info("successfully verified user-assigned identity on pod with identity resource ID")
+	return nil
+}
+
+// assertSecret checks if kvt.secretValue == actualSecret.
+func (kvt *keyvaultTester) assertSecret(actualSecret string) error {
+	if kvt.secretValue != actualSecret {
+		return fmt.Errorf("expected %s to be equal to %s", actualSecret, kvt.secretValue)
+	}
+
+	return nil
+}
+
+// getSecret returns the secret value with a specific autorest authorizer.
+func (kvt *keyvaultTester) getSecret(authorizer autorest.Authorizer) (string, error) {
+	kvt.client.Authorizer = authorizer
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	secret, err := kvt.client.GetSecret(ctx, kvt.getKeyvaultURL(), kvt.secretName, kvt.secretVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret, error: %+v", err)
+	}
+
+	return *secret.Value, nil
+}
+
+// getKeyvaultURL returns the FQDN of the Azure Key Vault.
+func (kvt *keyvaultTester) getKeyvaultURL() string {
+	return fmt.Sprintf("https://%s.vault.azure.net", kvt.keyvaultName)
+}
+
+// getADALTokenWithIdentityResourceID returns an ADAL token
+// using the resource ID of a user-assigned identity.
+func (kvt *keyvaultTester) getADALTokenWithIdentityResourceID() (*adal.Token, error) {
+	// Create HTTP request for a managed services for Azure resources token to access Azure Resource Manager
+	imdsTokenURL, err := url.Parse(kvt.imdsTokenEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse IMDS token endpoint (%s), error: %+v", kvt.imdsTokenEndpoint, err)
+	}
+
+	v := url.Values{}
+	v.Set("resource", keyvaultResource)
+	v.Set("msi_res_id", kvt.identityResourceID)
+	imdsTokenURL.RawQuery = v.Encode()
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", imdsTokenURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a new HTTP request, error: %+v", err)
+	}
+	req.Header.Add("Metadata", "true")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send a HTTP request, error: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	responseBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the response body, error: %+v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Status Code = '%d'. Response body: %s", resp.StatusCode, string(responseBytes))
+	}
+
+	var token adal.Token
+	err = json.Unmarshal(responseBytes, &token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %s, error: %+v", string(responseBytes), err)
+	}
+
+	return &token, nil
+}

--- a/test/image/identityvalidator/sp.go
+++ b/test/image/identityvalidator/sp.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"k8s.io/klog/v2"
+)
+
+type servicePrincipalTester struct {
+	imdsTokenEndpoint string
+}
+
+// assertWithSystemAssignedIdentity obtains a service principal token with system-assigned identity.
+func (spt *servicePrincipalTester) assertWithSystemAssignedIdentity() error {
+	spToken, err := adal.NewServicePrincipalTokenFromMSI(spt.imdsTokenEndpoint, azure.PublicCloud.ResourceManagerEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to acquire a service principal token with %s, error: %+v", spt.imdsTokenEndpoint, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	if err := spToken.RefreshWithContext(ctx); err != nil {
+		return fmt.Errorf("failed to refresh the service principal token, error: %+v", err)
+	}
+
+	token := spToken.Token()
+	if token.IsZero() {
+		return fmt.Errorf("%+v is a zero token", token)
+	}
+
+	klog.Infof("successfully acquired a service principal token from %s", spt.imdsTokenEndpoint)
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Made the following enhancements to identity validator:
- decrease context timeout from 150s to 80s to match the retry duration in NMI
- separated into `keyvaultTester` and `servicePrincipalTester` for modularity
- removed `--resource-group` flag since it is no used
- when generating an ADAL token with resource ID of a user-assigned identity, only parse response body from `http://169.254.169.254/metadata/identity/oauth2/token?resource=<resource>&msi_res_id=<msi_res_id>` when the status code is 200 and limited the request duration to 80 seconds
- check the secret obtained from the keyvault against the expected secret value
- clearer error messages
- add retry logic if we encounter "Identity not found" error (related to IMDS caching issue)

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

fix #806 
fix #871

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? no


**Notes for Reviewers**:
