### PR TITLE
cleanup: refactor demo code

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	contextTimeout = 80 * time.Second
+	timeout = 80 * time.Second
 )
 
 var (
@@ -49,9 +49,7 @@ func main() {
 	ticker := time.NewTicker(period)
 	defer ticker.Stop()
 
-	for {
-		<-ticker.C
-
+	for ; true; <-ticker.C {
 		curlIMDSMetadataInstanceEndpoint()
 		listVMSSInstances()
 		t1 := getTokenFromIMDS(imdsTokenEndpoint)
@@ -72,7 +70,7 @@ func listVMSSInstances() {
 	vmssClient := compute.NewVirtualMachineScaleSetsClient(subscriptionID)
 	vmssClient.Authorizer = authorizer
 
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	vmssList, err := vmssClient.List(ctx, resourceGroup)
@@ -96,7 +94,7 @@ func getTokenFromIMDS(imdsTokenEndpoint string) *adal.Token {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	if err := spt.RefreshWithContext(ctx); err != nil {
@@ -121,7 +119,7 @@ func getTokenFromIMDSWithUserAssignedID(imdsTokenEndpoint string) *adal.Token {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	if err := spt.RefreshWithContext(ctx); err != nil {
@@ -141,7 +139,7 @@ func getTokenFromIMDSWithUserAssignedID(imdsTokenEndpoint string) *adal.Token {
 
 func curlIMDSMetadataInstanceEndpoint() {
 	client := &http.Client{
-		Timeout: 2 * time.Second,
+		Timeout: timeout,
 	}
 	req, err := http.NewRequest("GET", "http://169.254.169.254/metadata/instance?api-version=2017-08-01", nil)
 	if err != nil {

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -11,132 +12,156 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 )
 
+const (
+	contextTimeout = 80 * time.Second
+)
+
 var (
-	retryWaitTime  = pflag.Int("retry-wait-time", 20, "retry wait time in seconds")
-	resource       = pflag.String("aad-resourcename", "https://management.azure.com/", "name of resource to grant token")
-	subscriptionID = pflag.String("subscriptionid", "", "subscription id for test")
-	clientID       = pflag.String("clientid", "", "client id for the msi id")
-	resourceGroup  = pflag.String("resourcegroup", "", "any resource group name with reader permission to the aad object")
+	period           time.Duration
+	resourceName     string
+	subscriptionID   string
+	resourceGroup    string
+	identityClientID string
 )
 
 func main() {
-	pflag.Parse()
+	flag.DurationVar(&period, "period", 100*time.Second, "The period that the demo is being executed")
+	flag.StringVar(&resourceName, "resource-name", "https://management.azure.com/", "The resource name to grant the access token")
+	flag.StringVar(&subscriptionID, "subscription-id", "", "The Azure subscription ID")
+	flag.StringVar(&resourceGroup, "resource-group", "", "The resource group name which the user-assigned identity read access to")
+	flag.StringVar(&identityClientID, "identity-client-id", "", "The user-assigned identity client ID")
+	flag.Parse()
 
 	podname := os.Getenv("MY_POD_NAME")
 	podnamespace := os.Getenv("MY_POD_NAMESPACE")
 	podip := os.Getenv("MY_POD_IP")
 
-	klog.Infof("starting demo pod %s/%s %s", podnamespace, podname, podip)
+	klog.Infof("starting aad-pod-identity demo pod (namespace: %s, name: %s, IP: %s)", podnamespace, podname, podip)
 
-	msiEndpoint, err := adal.GetMSIVMEndpoint()
+	imdsTokenEndpoint, err := adal.GetMSIVMEndpoint()
 	if err != nil {
-		klog.Fatalf("failed to get MSI endpoint, error: %+v", err)
+		klog.Fatalf("failed to get IMDS token endpoint, error: %+v", err)
 	}
 
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+
 	for {
-		doARMOperations(*subscriptionID, *resourceGroup)
+		<-ticker.C
 
-		t1 := testMSIEndpoint(msiEndpoint, *resource)
-		if t1 == nil {
-			continue
+		curlIMDSMetadataInstanceEndpoint()
+		listVMSSInstances()
+		t1 := getTokenFromIMDS(imdsTokenEndpoint)
+		t2 := getTokenFromIMDSWithUserAssignedID(imdsTokenEndpoint)
+		if t1 == nil || t2 == nil || !strings.EqualFold(t1.AccessToken, t2.AccessToken) {
+			klog.Error("Tokens acquired from IMDS with and without identity client ID do not match")
 		}
-
-		t2 := testMSIEndpointFromUserAssignedID(msiEndpoint, *clientID, *resource)
-		if t2 == nil {
-			continue
-		}
-
-		if !strings.EqualFold(t1.AccessToken, t2.AccessToken) {
-			klog.Errorf("msi, emsi test failed with t1(%+v) and t2(%+v)", t1, t2)
-		}
-
-		testInstanceMetadataRequests()
-
-		time.Sleep(time.Duration(*retryWaitTime) * time.Second)
 	}
 }
 
-func doARMOperations(subscriptionID, resourceGroup string) {
+func listVMSSInstances() {
 	authorizer, err := auth.NewAuthorizerFromEnvironment()
 	if err != nil {
 		klog.Errorf("failed to get authorizer from environment, error: %+v", err)
 		return
 	}
-	vmClient := compute.NewVirtualMachinesClient(subscriptionID)
-	vmClient.Authorizer = authorizer
-	vmlist, err := vmClient.List(context.Background(), resourceGroup)
+
+	vmssClient := compute.NewVirtualMachineScaleSetsClient(subscriptionID)
+	vmssClient.Authorizer = authorizer
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	vmssList, err := vmssClient.List(ctx, resourceGroup)
 	if err != nil {
-		klog.Errorf("failed list all vm, error: %+v", err)
+		klog.Errorf("failed to list all VMSS instances, error: %+v", err)
 		return
 	}
 
-	klog.Infof("successfully counted VM from ARM: %d", len(vmlist.Values()))
+	vmssNames := []string{}
+	for _, vmss := range vmssList.Values() {
+		vmssNames = append(vmssNames, *vmss.Name)
+	}
+
+	klog.Infof("successfully listed VMSS instances via ARM with AAD Pod Identity: %+v", vmssNames)
 }
 
-func testMSIEndpoint(msiEndpoint, resource string) *adal.Token {
-	spt, err := adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource)
+func getTokenFromIMDS(imdsTokenEndpoint string) *adal.Token {
+	spt, err := adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(imdsTokenEndpoint, resourceName, identityClientID)
 	if err != nil {
-		klog.Errorf("failed to acquire a token using the MSI VM extension, error: %+v", err)
+		klog.Errorf("failed to acquire a token from IMDS using user-assigned identity, error: %+v", err)
 		return nil
 	}
-	if err := spt.Refresh(); err != nil {
-		klog.Errorf("failed to refresh ServicePrincipalTokenFromMSI using the MSI endpoint (%s), error: %+v", msiEndpoint, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	if err := spt.RefreshWithContext(ctx); err != nil {
+		klog.Errorf("failed to refresh the service principal token, error: %+v", err)
 		return nil
 	}
+
 	token := spt.Token()
 	if token.IsZero() {
-		klog.Errorf("zero token found using the MSI endpoint (%s)", msiEndpoint)
+		klog.Errorf("%+v is a zero token", token)
 		return nil
 	}
-	klog.Infof("successfully acquired a token using the MSI, msiEndpoint(%s)", msiEndpoint)
+
+	klog.Infof("successfully acquired a service principal token from %s", imdsTokenEndpoint)
 	return &token
 }
 
-func testMSIEndpointFromUserAssignedID(msiEndpoint, userAssignedID, resource string) *adal.Token {
-	spt, err := adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource, userAssignedID)
+func getTokenFromIMDSWithUserAssignedID(imdsTokenEndpoint string) *adal.Token {
+	spt, err := adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(imdsTokenEndpoint, resourceName, identityClientID)
 	if err != nil {
-		klog.Errorf("failed NewServicePrincipalTokenFromMSIWithUserAssignedID, clientID: %s, error: %+v", userAssignedID, err)
+		klog.Errorf("failed to acquire a token from IMDS using user-assigned identity, error: %+v", err)
 		return nil
 	}
-	if err := spt.Refresh(); err != nil {
-		klog.Errorf("failed to refresh ServicePrincipalToken userAssignedID MSI, msiEndpoint(%s)", msiEndpoint)
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	if err := spt.RefreshWithContext(ctx); err != nil {
+		klog.Errorf("failed to refresh the service principal token, error: %+v", err)
 		return nil
 	}
+
 	token := spt.Token()
 	if token.IsZero() {
-		klog.Errorf("zero token found, userAssignedID MSI, msiEndpoint(%s) clientID(%s)", msiEndpoint, userAssignedID)
+		klog.Errorf("%+v is a zero token", token)
 		return nil
 	}
-	klog.Infof("successfully acquired a token, userAssignedID MSI, msiEndpoint(%s) clientID(%s)", msiEndpoint, userAssignedID)
+
+	klog.Infof("successfully acquired a service principal token from %s using a user-assigned identity (%s)", imdsTokenEndpoint, identityClientID)
 	return &token
 }
 
-// simulates health probe of non MSI instance metadata requests
-// e.g. curl -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01" --header "X-Forwarded-For: 192.168.0.2"
-func testInstanceMetadataRequests() {
+func curlIMDSMetadataInstanceEndpoint() {
 	client := &http.Client{
-		Timeout: time.Duration(2) * time.Second,
+		Timeout: 2 * time.Second,
 	}
 	req, err := http.NewRequest("GET", "http://169.254.169.254/metadata/instance?api-version=2017-08-01", nil)
 	if err != nil {
-		klog.Errorf("failed to create new http request, error: %+v", err)
+		klog.Errorf("failed to create a new HTTP request, error: %+v", err)
 		return
 	}
 	req.Header.Add("Metadata", "true")
+
 	resp, err := client.Do(req)
 	if err != nil {
 		klog.Error(err)
 		return
 	}
 	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		klog.Errorf("failed to read response body, error: %+v", err)
 		return
 	}
-	klog.Infof("successfully made GET on instance metadata, %s", body)
+
+	klog.Infof(`curl -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01": %s`, body)
 }


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

ref: #918
 
New demo output:
```log
I0107 23:54:23.215900       1 main.go:42] starting aad-pod-identity demo pod default/demo 10.244.0.73
I0107 23:56:03.223398       1 main.go:167] curl -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01": {"compute":{"location":"westus2","name":"aks-nodepool1-55282659-0","offer":"aks","osType":"Linux","placementGroupId":"","platformFaultDomain":"0","platformUpdateDomain":"0","publisher":"microsoft-aks","resourceGroupName":"MC_chuwon-aks_chuwon_westus2","sku":"aks-ubuntu-1604-202004","subscriptionId":"2d31b5ab-0ddc-4991-bf8d-61b6ad196f5a","tags":"aksEngineVersion:aks-release-v0.47.0-1-aks;creationSource:aks-aks-nodepool1-55282659-0;orchestrator:Kubernetes:1.15.10;poolName:nodepool1;resourceNameSuffix:55282659","version":"2020.04.16","vmId":"33b6a978-a2ad-4bbe-8331-f7e08c48e175","vmSize":"Standard_DS2_v2"},"network":{"interface":[{"ipv4":{"ipAddress":[{"privateIpAddress":"10.240.0.4","publicIpAddress":""}],"subnet":[{"address":"10.240.0.0","prefix":"16"}]},"ipv6":{"ipAddress":[]},"macAddress":"000D3AC47E7D"}]}}
I0107 23:56:03.816403       1 main.go:90] successfully listed VMSS instances from ARM via AAD Pod Identity: []
I0107 23:56:03.825676       1 main.go:114] successfully acquired a service principal token from http://169.254.169.254/metadata/identity/oauth2/token
I0107 23:56:03.834516       1 main.go:139] successfully acquired a service principal token from http://169.254.169.254/metadata/identity/oauth2/token using a user-assigned identity (91ff0ee7-35fc-46d0-9cd0-51a7ea9ec7f2)
```

I will open a separate PR to update the documentation when we are about to cut a new release.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
