### PR TITLE
dockerfile: upgrade debian-iptables to buster-v1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,8 @@ RUN go mod download
 ARG IMAGE_VERSION
 RUN make build
 
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-iptables-amd64:v12.1.2 AS nmi
-# upgrading apt &libapt-pkg5.0 due to CVE-2020-27350
-# upgrading libssl1.1 due to CVE-2020-1971
-# upgrading libp11-kit0 due to CVE-2020-29362, CVE-2020-29363 and CVE-2020-29361
-RUN apt-mark unhold apt && \
-    clean-install ca-certificates apt libapt-pkg5.0 libssl1.1 libp11-kit0
+FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.4.0 AS nmi
+RUN clean-install ca-certificates
 COPY --from=builder /go/src/github.com/Azure/aad-pod-identity/bin/aad-pod-identity/nmi /bin/
 RUN useradd -u 10001 nonroot
 USER nonroot


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

ref: #923

Upgrading NMI's base image from debian-iptables v12.1.2 to buster-v1.4.0 should fix all known CVEs. Also, iptables version got bumped from v1.8.3 to v1.8.5. 


<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
