### PR TITLE
feat: add cluster identity to immutable list

### DIFF
--- a/.pipelines/templates/e2e-test.yml
+++ b/.pipelines/templates/e2e-test.yml
@@ -44,6 +44,7 @@ jobs:
         - template: role-assignment.yml
           parameters:
             identity_resource_group: $(IDENTITY_RESOURCE_GROUP)
+            keyvault_resource_group: $(IDENTITY_RESOURCE_GROUP)
 
         - script: |
             kubectl wait --for=condition=ready node --all

--- a/.pipelines/templates/role-assignment.yml
+++ b/.pipelines/templates/role-assignment.yml
@@ -17,12 +17,23 @@ parameters:
   - name: registry_name
     type: string
     default: $(REGISTRY_NAME)
+  - name: keyvault_name
+    type: string
+    default: $(KEYVAULT_NAME)
+  - name: keyvault_resource_group
+    type: string
+    default: ""
 
 steps:
   - script: |
       ASSIGNEE_OBJECT_ID="$(az identity show -g ${{ parameters.node_resource_group }} -n ${{ parameters.resource_group }}-agentpool --query principalId -otsv)"
       az role assignment create --assignee-object-id "${ASSIGNEE_OBJECT_ID}" --role "Virtual Machine Contributor" --scope "/subscriptions/${{ parameters.subscription_id }}/resourcegroups/${{ parameters.node_resource_group }}"
       az role assignment create --assignee-object-id "${ASSIGNEE_OBJECT_ID}" --role "Managed Identity Operator" --scope "/subscriptions/${{ parameters.subscription_id }}/resourcegroups/${{ parameters.node_resource_group }}"
+
+      if [[ -n "${{ parameters.keyvault_resource_group }}" ]]; then
+        az role assignment create --assignee-object-id "${ASSIGNEE_OBJECT_ID}" --role "Reader" --scope "/subscriptions/${{ parameters.subscription_id }}/resourcegroups/${{ parameters.keyvault_resource_group }}/providers/Microsoft.KeyVault/vaults/${{ parameters.keyvault_name }}"
+        az keyvault set-policy -n ${{ parameters.keyvault_name }} --secret-permissions get --object-id "${ASSIGNEE_OBJECT_ID}"
+      fi
 
       if [[ -n "${{ parameters.identity_resource_group }}" ]]; then
         az role assignment create --assignee-object-id "${ASSIGNEE_OBJECT_ID}" --role "Managed Identity Operator" --scope "/subscriptions/${{ parameters.subscription_id }}/resourcegroups/${{ parameters.identity_resource_group }}"

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -364,3 +364,9 @@ func getRetryAfter(resp *http.Response) time.Duration {
 	}
 	return dur
 }
+
+// GetClusterIdentity returns the cluster identity that MIC will use for all
+// cloud provider operations. This is userAssignedIdentityID configured in the azure.json
+func (c *Client) GetClusterIdentity() string {
+	return c.Config.UserAssignedIdentityID
+}

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -579,3 +579,49 @@ func TestGetRetryAfter(t *testing.T) {
 		})
 	}
 }
+
+func TestGetClusterIdentity(t *testing.T) {
+	cases := []struct {
+		desc             string
+		config           config.AzureConfig
+		expectedClientID string
+	}{
+		{
+			desc: "cluster using service principal",
+			config: config.AzureConfig{
+				ClientID:               "clientid",
+				ClientSecret:           "clientsecret",
+				UserAssignedIdentityID: "",
+			},
+			expectedClientID: "",
+		},
+		{
+			desc: "cluster using system-assigned managed identity",
+			config: config.AzureConfig{
+				ClientID:               "msi",
+				ClientSecret:           "msi",
+				UserAssignedIdentityID: "",
+			},
+			expectedClientID: "",
+		},
+		{
+			desc: "cluster using user-assigned managed identity",
+			config: config.AzureConfig{
+				ClientID:               "msi",
+				ClientSecret:           "msi",
+				UserAssignedIdentityID: "userAssignedIdentityID",
+			},
+			expectedClientID: "userAssignedIdentityID",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			client := NewTestCloudClient(tc.config)
+			actualClientID := client.GetClusterIdentity()
+			if tc.expectedClientID != actualClientID {
+				t.Fatalf("expected clientID: %s, got: %s", tc.expectedClientID, actualClientID)
+			}
+		})
+	}
+}

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -1618,7 +1618,7 @@ func TestSyncExit(t *testing.T) {
 	micClient.testRunSync()(t)
 }
 
-func TestMicAddDelVMSSwithImmutableIdentities(t *testing.T) {
+func TestMicAddDelVMSSWithImmutableIdentities(t *testing.T) {
 	eventCh := make(chan internalaadpodid.EventType, 100)
 	cloudClient := NewTestCloudClient(config.AzureConfig{VMType: "vmss"})
 	crdClient := NewTestCrdClient(nil)

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -3,10 +3,12 @@ TEST_E2E_DIR := $(REPO_ROOT)/test/e2e
 GINKGO_FOCUS ?=
 GINKGO_SKIP ?=
 GINKGO_FAIL_FAST ?= true
+GINKGO_DRY_RUN ?= false
 
 .PHONY: run
 run:
 	cd $(TEST_E2E_DIR); go test -tags=e2e -timeout=90m -v -ginkgo.v \
 		-ginkgo.focus=$(GINKGO_FOCUS) \
 		-ginkgo.skip=$(GINKGO_SKIP) \
-		-ginkgo.failFast=$(GINKGO_FAIL_FAST)
+		-ginkgo.failFast=$(GINKGO_FAIL_FAST) \
+		-ginkgo.dryRun=$(GINKGO_DRY_RUN)

--- a/test/e2e/framework/azure/azure_client.go
+++ b/test/e2e/framework/azure/azure_client.go
@@ -19,7 +19,7 @@ import (
 // Client defines the behavior of a type that acts as an intermediary with ARM.
 type Client interface {
 	// GetIdentityClientID returns the client ID of a user-assigned identity.
-	GetIdentityClientID(identityName string) string
+	GetIdentityClientID(resourceGroup, identityName string) string
 
 	// ListUserAssignedIdentities returns a list of user-assigned identities assigned to the node.
 	ListUserAssignedIdentities(providerID string) map[string]bool
@@ -75,12 +75,12 @@ func NewClient(config *framework.Config) Client {
 }
 
 // GetIdentityClientID returns the client ID of a user-assigned identity.
-func (c *client) GetIdentityClientID(identityName string) string {
+func (c *client) GetIdentityClientID(resourceGroup, identityName string) string {
 	if clientID, ok := c.identityClientIDMap[identityName]; ok {
 		return clientID
 	}
 
-	result, err := c.msiClient.Get(context.TODO(), c.config.IdentityResourceGroup, identityName)
+	result, err := c.msiClient.Get(context.TODO(), resourceGroup, identityName)
 	if err != nil {
 		// Dummy client ID
 		return "00000000-0000-0000-0000-000000000000"

--- a/test/e2e/identity_exception_test.go
+++ b/test/e2e/identity_exception_test.go
@@ -65,7 +65,7 @@ var _ = Describe("When deploying AzurePodIdentityException", func() {
 			PodLabels: podLabels,
 		})
 
-		identityClientID := azureClient.GetIdentityClientID(keyvaultIdentity)
+		identityClientID := azureClient.GetIdentityClientID(config.IdentityResourceGroup, keyvaultIdentity)
 		identityValidator := identityvalidator.Create(identityvalidator.CreateInput{
 			Creator:   kubeClient,
 			Config:    config,


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
If the cluster identity is used with the application pod, then when all pods using the identity are deleted, the cluster identity will get cleaned up by MIC. This will cause subsequent cloud provider operations to fail because the cluster identity no longer exists. The user would need to manually go and fix it by assigning the identity back. Instead this PR adds the cluster identity to the immutable identity list. The cluster identity will never be deleted by MIC.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #979 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
