### PR TITLE
Add missing `weight` key in node affinity example

### DIFF
--- a/manifest_staging/charts/aad-pod-identity/values.yaml
+++ b/manifest_staging/charts/aad-pod-identity/values.yaml
@@ -79,11 +79,11 @@ mic:
     #   preferredDuringSchedulingIgnoredDuringExecution:
     #     - weight 1
     #       preference:
-    #       matchExpressions:
-    #         - key: kubernetes.azure.com/mode
-    #           operator: In
-    #           values:
-    #             - system
+    #         matchExpressions:
+    #           - key: kubernetes.azure.com/mode
+    #             operator: In
+    #             values:
+    #               - system
 
   # Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
   # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
@@ -190,11 +190,11 @@ nmi:
     #   preferredDuringSchedulingIgnoredDuringExecution:
     #     - weight 1
     #       preference:
-    #       matchExpressions:
-    #         - key: kubernetes.azure.com/mode
-    #           operator: In
-    #           values:
-    #             - system
+    #         matchExpressions:
+    #           - key: kubernetes.azure.com/mode
+    #             operator: In
+    #             values:
+    #               - system
 
   # Override iptables update interval in seconds (default is 60)
   ipTableUpdateTimeIntervalInSeconds: ""

--- a/manifest_staging/charts/aad-pod-identity/values.yaml
+++ b/manifest_staging/charts/aad-pod-identity/values.yaml
@@ -45,6 +45,7 @@ mic:
   image: mic
   tag: v1.7.4
 
+  # ref: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical
   priorityClassName: ""
 
   # log level. Uses V logs (klog)
@@ -155,6 +156,7 @@ nmi:
   image: nmi
   tag: v1.7.4
 
+  # ref: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical
   priorityClassName: ""
 
   # log level. Uses V logs (klog)

--- a/manifest_staging/charts/aad-pod-identity/values.yaml
+++ b/manifest_staging/charts/aad-pod-identity/values.yaml
@@ -72,10 +72,12 @@ mic:
     # - key: "CriticalAddonsOnly"
     #   operator: "Exists"
 
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   affinity: {}
     # nodeAffinity:
     #   preferredDuringSchedulingIgnoredDuringExecution:
-    #     - preference:
+    #     - weight 1
+    #       preference:
     #       matchExpressions:
     #         - key: kubernetes.azure.com/mode
     #           operator: In
@@ -180,10 +182,12 @@ nmi:
     # - key: "CriticalAddonsOnly"
     #   operator: "Exists"
 
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   affinity: {}
     # nodeAffinity:
     #   preferredDuringSchedulingIgnoredDuringExecution:
-    #     - preference:
+    #     - weight 1
+    #       preference:
     #       matchExpressions:
     #         - key: kubernetes.azure.com/mode
     #           operator: In


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [X] It doesn't contain code from or inspired by another project.

**Notes for Reviewers**:
