### PR TITLE
fix: skip kubenet check if allowed is true

### DIFF
--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -73,12 +73,14 @@ func main() {
 	}
 
 	// check if the cni is kubenet from the --network-plugin defined in kubelet config
-	isKubenet, err := utils.IsKubenetCNI(*kubeletConfig)
-	if err != nil {
-		klog.Fatalf("failed to check if CNI plugin is kubenet, error: %+v", err)
-	}
-	if !*allowNetworkPluginKubenet && isKubenet {
-		klog.Fatalf("AAD Pod Identity is not supported for Kubenet. Review https://azure.github.io/aad-pod-identity/docs/configure/aad_pod_identity_on_kubenet/ for more details.")
+	if !*allowNetworkPluginKubenet {
+		isKubenet, err := utils.IsKubenetCNI(*kubeletConfig)
+		if err != nil {
+			klog.Fatalf("failed to check if CNI plugin is kubenet, error: %+v", err)
+		}
+		if isKubenet {
+			klog.Fatalf("AAD Pod Identity is not supported for Kubenet. Review https://azure.github.io/aad-pod-identity/docs/configure/aad_pod_identity_on_kubenet/ for more details.")
+		}
 	}
 
 	klog.Infof("starting nmi process. Version: %v. Build date: %v.", version.NMIVersion, version.BuildDate)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
If `--allow-network-plugin-kubenet` is set to true, then we can bypass the check as it's been explicitly set to allow by the user. 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/aad-pod-identity/issues/997

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
