### PR TITLE
fix: skip PATCH call if no identities to assign or un-assign

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -180,6 +180,12 @@ func (c *Client) GetUserMSIs(name string, isvmss bool) ([]string, error) {
 
 // UpdateUserMSI will batch process the removal and addition of ids
 func (c *Client) UpdateUserMSI(addUserAssignedMSIIDs, removeUserAssignedMSIIDs []string, name string, isvmss bool) error {
+	// if there are no identities to be assigned and un-assigned, then we should not
+	// invoke an additional GET or PATCH request.
+	if len(addUserAssignedMSIIDs) == 0 && len(removeUserAssignedMSIIDs) == 0 {
+		klog.Infof("No identities to assign or un-assign")
+		return nil
+	}
 	idH, updateFunc, err := c.getIdentityResource(name, isvmss)
 	if err != nil {
 		return fmt.Errorf("failed to get identity resource, error: %v", err)

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -184,6 +184,18 @@ func TestSimple(t *testing.T) {
 				cloudClient.PrintMSI(t)
 				t.Error("MSI mismatch")
 			}
+
+			// when no add or remove identities, then GET and PATCH should be skipped
+			err = cloudClient.UpdateUserMSI(nil, nil, node4.Name, true)
+			if err != nil {
+				t.Errorf("Couldn't update MSI: %v", err)
+			}
+
+			testMSI = []string{"ID4", "ID3"}
+			if !cloudClient.CompareMSI(node4.Name, true, testMSI) {
+				cloudClient.PrintMSI(t)
+				t.Error("MSI mismatch")
+			}
 		})
 	}
 }

--- a/test/e2e/framework/exec/kubectl.go
+++ b/test/e2e/framework/exec/kubectl.go
@@ -40,6 +40,7 @@ func KubectlExec(kubeconfigPath, podName, namespace string, args []string) (stri
 		"exec",
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
 		fmt.Sprintf("--namespace=%s", namespace),
+		fmt.Sprintf("--request-timeout=5s"),
 		podName,
 		"--",
 	}, args...)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Skip identity PATCH call when there are no identities to assign/un-assign as part of MIC sync cycle. This prevents accidental deletes of existing identities when the GET response for VM/VMSS contains out of date data.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
