### PR TITLE
test: use kubectl to get vmss name

### DIFF
--- a/.pipelines/templates/load-test.yml
+++ b/.pipelines/templates/load-test.yml
@@ -56,7 +56,7 @@ jobs:
             echo "##vso[task.setvariable variable=POD_IDENTITY_CLIENT_ID]${POD_IDENTITY_CLIENT_ID}"
 
             if [[ $OPERATION_MODE == "managed" ]]; then
-              VMSS_NAME=$(az vmss list -g ${NODE_RESOURCE_GROUP} --query "[].name" -o tsv)
+              VMSS_NAME="$(kubectl get node -ojson | jq -r '.items[0].metadata.name' | grep -o '.*[^0-9]')"
               echo "Assigning /subscriptions/$(LOAD_TEST_SUBSCRIPTION_ID)/resourcegroups/${NODE_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${POD_IDENTITY_ID_NAME} to ${VMSS_NAME}"
 
               # Assign user assigned identity to the VMSS

--- a/test/e2e/framework/azure/vm_manager.go
+++ b/test/e2e/framework/azure/vm_manager.go
@@ -98,6 +98,7 @@ func (m *vmManager) UnassignUserAssignedIdentity(vmName, identityToUnassign stri
 			vm.Identity.UserAssignedIdentities[identity] = nil
 			continue
 		}
+		vm.Identity.UserAssignedIdentities[identity] = &compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
 		hasOtherIdentitiesAssigned = true
 	}
 

--- a/test/e2e/framework/azure/vmss_manager.go
+++ b/test/e2e/framework/azure/vmss_manager.go
@@ -98,6 +98,7 @@ func (m *vmssManager) UnassignUserAssignedIdentity(vmssName, identityToUnassign 
 			vmss.Identity.UserAssignedIdentities[identity] = nil
 			continue
 		}
+		vmss.Identity.UserAssignedIdentities[identity] = &compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue{}
 		hasOtherIdentitiesAssigned = true
 	}
 


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Fixes test failures in https://dev.azure.com/AzureContainerUpstream/AAD%20Pod%20Identity/_build/results?buildId=19324&view=results.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
