### PR TITLE
dockerfile: upgrade debian-iptables to buster-v1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,8 @@ RUN export GOOS=$TARGETOS && \
     export GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | tr -d 'v') && \
     make build
 
-FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.5.0 AS nmi
-# upgrading libssl1.1 due to CVE-2021-23840 and CVE-2021-23841
-# upgrading libzstd1 due to CVE-2021-24032
-RUN clean-install ca-certificates libssl1.1 libzstd1
+FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.0 AS nmi
+RUN clean-install ca-certificates
 COPY --from=builder /go/src/github.com/Azure/aad-pod-identity/bin/aad-pod-identity/nmi /bin/
 RUN useradd -u 10001 nonroot
 USER nonroot


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Fixes CVEs in libssl1.1 and libzstd1

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:

```
$ docker run k8s.gcr.io/build-image/debian-iptables:buster-v1.6.0 iptables                                                                                                                        
iptables v1.8.5 (legacy): no command specified
```