### PR TITLE
fix: inject TypeMeta during type upgrade

### DIFF
--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -15,6 +15,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -346,12 +347,20 @@ func (c *Client) Upgrade(resource string, i runtime.Object) (map[string]runtime.
 			if err != nil {
 				return m, err
 			}
+			obj.TypeMeta = metav1.TypeMeta{
+				APIVersion: aadpodv1.SchemeGroupVersion.String(),
+				Kind:       reflect.ValueOf(i).Elem().Type().Name(),
+			}
 			m[getMapKey(o.GetNamespace(), o.GetName())] = &obj
 		case aadpodv1.AzureIDBindingResource:
 			var obj aadpodv1.AzureIdentityBinding
 			err = c.setObject(resource, o.GetNamespace(), o.GetName(), o, &obj)
 			if err != nil {
 				return m, err
+			}
+			obj.TypeMeta = metav1.TypeMeta{
+				APIVersion: aadpodv1.SchemeGroupVersion.String(),
+				Kind:       reflect.ValueOf(i).Elem().Type().Name(),
 			}
 			m[getMapKey(o.GetNamespace(), o.GetName())] = &obj
 		default:


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Fixes type upgrade:
```log
F0505 18:18:32.670266       1 mic.go:343] type upgrade failed with error: failed to upgrade type, error: failed to set object for resource azureassignedidentities, error: AzureAssignedIdentity.aadpodidentity.k8s.io "n0-default-azid0" is invalid: [spec.azureBindingRef.apiVersion: Required value: must not be empty, spec.azureBindingRef.kind: Required value: must not be empty, spec.azureIdentityRef.apiVersion: Required value: must not be empty, spec.azureIdentityRef.kind: Required value: must not be empty]
```

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
