### PR TITLE
Automatically checksum the mic-secret secret to roll mic deployment

### DIFF
--- a/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/mic-deployment.yaml
@@ -23,10 +23,11 @@ spec:
       {{- if .Values.mic.podLabels }}
       {{- toYaml .Values.mic.podLabels | nindent 8 }}
       {{- end }}
-{{- if .Values.mic.podAnnotations }}
       annotations:
-{{ toYaml .Values.mic.podAnnotations | indent 8 }}
-{{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/mic-secret.yaml") . | sha256sum }}
+        {{- if .Values.mic.podAnnotations }}
+        {{ toYaml .Values.mic.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
**Reason for Change**:
Addresses bug found in issue https://github.com/Azure/aad-pod-identity/issues/1059

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
Fixes #1059 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
