### PR TITLE
fix: Remove incorrect fields from gatekeeper e2e test

### DIFF
--- a/test/e2e/gatekeeper_test.go
+++ b/test/e2e/gatekeeper_test.go
@@ -30,9 +30,6 @@ spec:
     spec:
       names:
         kind: azureidentityformat
-        listKind: azureidentityformatList
-        plural: azureidentityformat
-        singular: azureidentityformat
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/validation/gatekeeper/azureidentityformat_template.yaml
+++ b/validation/gatekeeper/azureidentityformat_template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: azureidentityformat
-        listKind: azureidentityformatList
-        plural: azureidentityformat
-        singular: azureidentityformat
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/website/content/en/docs/Configure/azure_identity_validation.md
+++ b/website/content/en/docs/Configure/azure_identity_validation.md
@@ -60,9 +60,6 @@ spec:
     spec:
       names:
         kind: azureidentityformat
-        listKind: azureidentityformatList
-        plural: azureidentityformat
-        singular: azureidentityformat
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Fix e2e test

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes: #1089
**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:

Looks like there was a change in gatekeeper deployment manifests that causes e2e tests to fail with the below message:

```
STEP: kubectl apply --kubeconfig=/agent/_work/1/s/_output/aad-pod-identity-e2e-70b6/kubeconfig/kubeconfig.westus2.json --namespace=gatekeeper-9wnsd -f /tmp/470855604
error: error validating "/tmp/470855604": error validating data: [ValidationError(ConstraintTemplate.spec.crd.spec.names): unknown field "listKind" in sh.gatekeeper.templates.v1beta1.ConstraintTemplate.spec.crd.spec.names, ValidationError(ConstraintTemplate.spec.crd.spec.names): unknown field "plural" in sh.gatekeeper.templates.v1beta1.ConstraintTemplate.spec.crd.spec.names, ValidationError(ConstraintTemplate.spec.crd.spec.names): unknown field "singular" in sh.gatekeeper.templates.v1beta1.ConstraintTemplate.spec.crd.spec.names]; if you choose to ignore these errors, turn validation off with --validate=false
```

This looks to be caused by Gatekeeper updating their CRDs recently in master that no longer allows additional invalid fields to be passed in the CRD spec since promoting to `apiextensions.k8s.io/v1`. The e2e tests looks to take the latest gatekeeper deployment manifests from master, hence the breaking change.
