### PR TITLE
ci: switch to `staging-pool`

### DIFF
--- a/.pipelines/nightly.yml
+++ b/.pipelines/nightly.yml
@@ -8,7 +8,7 @@ schedules:
       include:
         - master
 
-pool: Upstream Pool
+pool: staging-pool
 
 jobs:
   - template: templates/unit-test.yml

--- a/.pipelines/pr.yml
+++ b/.pipelines/pr.yml
@@ -8,7 +8,7 @@ pr:
     exclude:
       - docs/*
 
-pool: Upstream Pool
+pool: staging-pool
 
 jobs:
   - template: templates/unit-test.yml

--- a/test/e2e/framework/identityvalidator/identityvalidator_helpers.go
+++ b/test/e2e/framework/identityvalidator/identityvalidator_helpers.go
@@ -93,7 +93,7 @@ func Create(input CreateInput) *corev1.Pod {
 		pod.Spec.InitContainers = []corev1.Container{
 			{
 				Name:  "init-myservice",
-				Image: "microsoft/azure-cli:latest",
+				Image: "mcr.microsoft.com/azure-cli:latest",
 				Command: []string{
 					"sh",
 					"-c",


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

`Upstream Pool` has been renamed to `staging-pool`.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
