### PR TITLE
dockerfile: upgrade multiple packages due to CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,12 @@ RUN export GOOS=$TARGETOS && \
     export GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | tr -d 'v') && \
     make build
 
-FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.0 AS nmi
-# upgrading liblz4-1 due to CVE-2021-3520
-RUN clean-install ca-certificates liblz4-1
+FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.3 AS nmi
+# upgrading libgcrypt20 due to CVE-2021-33560
+# upgrading libgnutls30 due to CVE-2021-20231, CVE-2021-20232, CVE-2020-24659
+# upgrading libhogweed4 due to CVE-2021-20305, CVE-2021-3580
+# upgrading libnettle6 due to CVE-2021-20305, CVE-2021-3580
+RUN clean-install ca-certificates libgcrypt20 libgnutls30 libhogweed4 libnettle6
 COPY --from=builder /go/src/github.com/Azure/aad-pod-identity/bin/aad-pod-identity/nmi /bin/
 RUN useradd -u 10001 nonroot
 USER nonroot


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Fixes the following CVEs:

```
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
|   LIBRARY   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION  |                 TITLE                 |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libgcrypt20 | CVE-2021-33560   | HIGH     | 1.8.4-5           | 1.8.4-5+deb10u1 | libgcrypt: mishandles ElGamal         |
|             |                  |          |                   |                 | encryption because it lacks           |
|             |                  |          |                   |                 | exponent blinding to address a...     |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-33560 |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libgnutls30 | CVE-2021-20231   | CRITICAL | 3.6.7-4+deb10u6   | 3.6.7-4+deb10u7 | gnutls: Use after free in             |
|             |                  |          |                   |                 | client key_share extension            |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-20231 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2021-20232   |          |                   |                 | gnutls: Use after free                |
|             |                  |          |                   |                 | in client_send_params in              |
|             |                  |          |                   |                 | lib/ext/pre_shared_key.c              |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-20232 |
+             +------------------+----------+                   +                 +---------------------------------------+
|             | CVE-2020-24659   | HIGH     |                   |                 | gnutls: Heap buffer                   |
|             |                  |          |                   |                 | overflow in handshake with            |
|             |                  |          |                   |                 | no_renegotiation alert sent           |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2020-24659 |
+-------------+------------------+          +-------------------+-----------------+---------------------------------------+
| libhogweed4 | CVE-2021-20305   |          | 3.4.1-1           | 3.4.1-1+deb10u1 | nettle: Out of bounds memory          |
|             |                  |          |                   |                 | access in signature verification      |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-20305 |
+             +------------------+----------+                   +                 +---------------------------------------+
|             | CVE-2021-3580    | MEDIUM   |                   |                 | nettle: Remote crash                  |
|             |                  |          |                   |                 | in RSA decryption via                 |
|             |                  |          |                   |                 | manipulated ciphertext                |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-3580  |
+-------------+------------------+----------+                   +                 +---------------------------------------+
| libnettle6  | CVE-2021-20305   | HIGH     |                   |                 | nettle: Out of bounds memory          |
|             |                  |          |                   |                 | access in signature verification      |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-20305 |
+             +------------------+----------+                   +                 +---------------------------------------+
|             | CVE-2021-3580    | MEDIUM   |                   |                 | nettle: Remote crash                  |
|             |                  |          |                   |                 | in RSA decryption via                 |
|             |                  |          |                   |                 | manipulated ciphertext                |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-3580  |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+

```

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
