### PR TITLE
fix: mount kubelet config to `/var/lib/kubelet` for non-rbac deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,12 @@ RUN export GOOS=$TARGETOS && \
     export GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | tr -d 'v') && \
     make build
 
-FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.0 AS nmi
-# upgrading liblz4-1 due to CVE-2021-3520
-RUN clean-install ca-certificates liblz4-1
+FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.3 AS nmi
+# upgrading libgcrypt20 due to CVE-2021-33560
+# upgrading libgnutls30 due to CVE-2021-20231, CVE-2021-20232, CVE-2020-24659
+# upgrading libhogweed4 due to CVE-2021-20305, CVE-2021-3580
+# upgrading libnettle6 due to CVE-2021-20305, CVE-2021-3580
+RUN clean-install ca-certificates libgcrypt20 libgnutls30 libhogweed4 libnettle6
 COPY --from=builder /go/src/github.com/Azure/aad-pod-identity/bin/aad-pod-identity/nmi /bin/
 RUN useradd -u 10001 nonroot
 USER nonroot

--- a/manifest_staging/deploy/infra/deployment.yaml
+++ b/manifest_staging/deploy/infra/deployment.yaml
@@ -496,7 +496,7 @@ spec:
       - name: mic
         image: "mcr.microsoft.com/oss/azure/aad-pod-identity/mic:v1.8.0"
         args:
-          - "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
+          - "--kubeconfig=/var/lib/kubelet/kubeconfig"
           - "--cloudconfig=/etc/kubernetes/azure.json"
           - "--logtostderr"
         securityContext:
@@ -514,8 +514,8 @@ spec:
             cpu: 100m
             memory: 256Mi
         volumeMounts:
-          - name: kubeconfig
-            mountPath: /etc/kubernetes/kubeconfig
+          - name: kubelet-config
+            mountPath: /var/lib/kubelet
             readOnly: true
           - name: certificates
             mountPath: /etc/kubernetes/certs
@@ -530,7 +530,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       volumes:
-      - name: kubeconfig
+      - name: kubelet-config
         hostPath:
           path: /var/lib/kubelet
       - name: certificates

--- a/manifest_staging/deploy/infra/noazurejson/deployment.yaml
+++ b/manifest_staging/deploy/infra/noazurejson/deployment.yaml
@@ -508,7 +508,7 @@ spec:
       - name: mic
         image: "mcr.microsoft.com/oss/azure/aad-pod-identity/mic:v1.8.0"
         args:
-          - "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
+          - "--kubeconfig=/var/lib/kubelet/kubeconfig"
           - "--logtostderr"
         securityContext:
           runAsUser: 0
@@ -560,8 +560,8 @@ spec:
             cpu: 100m
             memory: 256Mi
         volumeMounts:
-          - name: kubeconfig
-            mountPath: /etc/kubernetes/kubeconfig
+          - name: kubelet-config
+            mountPath: /var/lib/kubelet
             readOnly: true
           - name: certificates
             mountPath: /etc/kubernetes/certs
@@ -573,7 +573,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       volumes:
-      - name: kubeconfig
+      - name: kubelet-config
         hostPath:
           path: /var/lib/kubelet
       - name: certificates


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

AKS is rolling out the TLS bootstrapping change. Before this change, AKS cluster agent node uses kubeconfig as follow:

```yaml
apiVersion: v1
kind: Config
clusters:
- name: localcluster
  cluster:
    certificate-authority: /etc/kubernetes/certs/ca.crt
    server: https://<api-server-address>:443
users:
- name: client
  user:
    client-certificate: /etc/kubernetes/certs/client.crt
    client-key: /etc/kubernetes/certs/client.key
contexts:
- context:
    cluster: localcluster
    user: client
  name: localclustercontext
current-context: localclustercontext
```

After enabling TLS bootstrapping, the agent node will get the kubeconfig as follow:

```yaml
apiVersion: v1
clusters:
- cluster:
    certificate-authority: /etc/kubernetes/certs/ca.crt
    server: https://<api-server-address>:443
  name: default-cluster
contexts:
- context:
    cluster: default-cluster
    namespace: default
    user: default-auth
  name: default-context
current-context: default-context
kind: Config
preferences: {}
users:
- name: default-auth
  user:
    client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem
    client-key: /var/lib/kubelet/pki/kubelet-client-current.pem
```

As we can see, in the new mode, kubelet's kubeconfig references the client certificates in `/var/lib/kubelet/pki` instead of `/etc/kubernetes/certs`. 

Since we are mounting the kubeconfig from host for those RBAC-disabled cluster, I think it's better to maintain the mount path structure for the kubeconfig (i.e. mounting `/var/lib/kubelet` from host to `/var/lib/kubelet` inside the pod) - with this, we can avoiding breaking MIC for certificates change.

I had verified this change in two AKS RBAC-disabled clusters, using with/out TLS bootstrapping setup.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
