### PR TITLE
test: reuse helm values during helm upgrade

### DIFF
--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -60,6 +60,7 @@ func (c *Config) DeepCopy() *Config {
 	copy.ImmutableUserMSIs = c.ImmutableUserMSIs
 	copy.NMIMode = c.NMIMode
 	copy.BlockInstanceMetadata = c.BlockInstanceMetadata
+	copy.IsSoakTest = c.IsSoakTest
 	copy.ServicePrincipalClientID = c.ServicePrincipalClientID
 	copy.ServicePrincipalClientSecret = c.ServicePrincipalClientSecret
 	copy.MICSyncInterval = c.MICSyncInterval

--- a/test/e2e/framework/helm/helm_helpers.go
+++ b/test/e2e/framework/helm/helm_helpers.go
@@ -85,6 +85,7 @@ func Upgrade(input UpgradeInput) {
 		"upgrade",
 		chartName,
 		"manifest_staging/charts/aad-pod-identity",
+		"--reuse-values",
 		"--wait",
 		fmt.Sprintf("--namespace=%s", framework.NamespaceKubeSystem),
 		"--debug",

--- a/test/e2e/retry_after_header_test.go
+++ b/test/e2e/retry_after_header_test.go
@@ -28,13 +28,13 @@ var _ = Describe("When SetRetryAfter header is enabled", func() {
 		})
 		// upgrade pod identity to use the feature flag set-retry-after-header and
 		// disable the internal retries.
-		c := *config
+		c := config.DeepCopy()
 		c.RetryAttemptsForCreated = 1
 		c.RetryAttemptsForAssigned = 1
 		c.FindIdentityRetryIntervalInSeconds = 1
 		c.SetRetryAfterHeader = true
 
-		helm.Upgrade(helm.UpgradeInput{Config: &c})
+		helm.Upgrade(helm.UpgradeInput{Config: c})
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Fixes test failures in https://dev.azure.com/AzureContainerUpstream/AAD%20Pod%20Identity/_build/results?buildId=24228&view=results. We have to reuse helm values during helm upgrade so existing values won't be overwritten by the default values.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-idexntity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
