### PR TITLE
Fix broken URLs in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,8 +8,8 @@ assignees: ''
 
 **Have you**
 
-- [ ] Read [Troubleshooting Guide](../../docs/readmes/README.troubleshooting.md)
-- [ ] Read [Known Issues](../../docs/readmes/README.known-issues.md)
+- [ ] Read [Troubleshooting Guide](https://azure.github.io/aad-pod-identity/docs/troubleshooting/)
+- [ ] Read [Known Issues](https://azure.github.io/aad-pod-identity/docs/known-issues/)
 - [ ] Searched on [GitHub issues](https://github.com/Azure/aad-pod-identity/issues)
 
 **Describe the bug**


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
The troubleshooting and known issues links in the bug report template have been broken since the docs moved to azure.github.io.

**Requirements**

- [X] squashed commits
- [X] included documentation
- [X] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [X] ran `make precommit`

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [X] no
