### PR TITLE
chore: add redacted client ID in the error log & cleanup role assignments

### DIFF
--- a/.pipelines/templates/cleanup-role-assignments.yml
+++ b/.pipelines/templates/cleanup-role-assignments.yml
@@ -1,0 +1,11 @@
+parameters:
+  - name: keyvault_name
+    type: string
+    default: $(KEYVAULT_NAME)
+
+steps:
+  - bash: |
+      az role assignment delete --ids ${ROLE_ASSIGNMENT_IDS} > /dev/null
+      az keyvault delete-policy --name ${{ parameters.keyvault_name }} --object-id "${ASSIGNEE_OBJECT_ID}" > /dev/null
+    condition: always()
+    displayName: Cleanup role assignments

--- a/.pipelines/templates/e2e-test.yml
+++ b/.pipelines/templates/e2e-test.yml
@@ -62,8 +62,9 @@ jobs:
             SERVICE_PRINCIPAL_CLIENT_SECRET: $(SERVICE_PRINCIPAL_CLIENT_SECRET)
           displayName: "Run E2E tests"
 
+        - template: cleanup-role-assignments.yml
+
         - script: |
-            az role assignment delete --ids ${ROLE_ASSIGNMENT_IDS} || true
             if [[ "${CLUSTER_CONFIG}" == "aks" ]]; then
               az aks delete -g ${RESOURCE_GROUP} -n ${RESOURCE_GROUP} --yes --no-wait
             fi

--- a/.pipelines/templates/role-assignment.yml
+++ b/.pipelines/templates/role-assignment.yml
@@ -27,6 +27,8 @@ parameters:
 steps:
   - script: |
       ASSIGNEE_OBJECT_ID="$(az identity show -g ${{ parameters.node_resource_group }} -n ${{ parameters.resource_group }}-agentpool --query principalId -otsv)"
+      echo "##vso[task.setvariable variable=ASSIGNEE_OBJECT_ID]${ASSIGNEE_OBJECT_ID}"
+
       ROLE_ASSIGNMENT_IDS=""
 
       az role assignment create --assignee-object-id "${ASSIGNEE_OBJECT_ID}" --role "Virtual Machine Contributor" --scope "/subscriptions/${{ parameters.subscription_id }}/resourcegroups/${{ parameters.node_resource_group }}"

--- a/pkg/nmi/standard.go
+++ b/pkg/nmi/standard.go
@@ -146,8 +146,8 @@ func (sc *StandardClient) listPodIDsWithRetry(ctx context.Context, podns, podnam
 					}
 				}
 				if !foundMatch && attempt >= sc.ListPodIDsRetryAttemptsForCreated {
-					return nil, false, fmt.Errorf("getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s, error: %+v. Check MIC pod logs for identity assignment errors",
-						podns, podname, sc.ListPodIDsRetryAttemptsForCreated, sc.ListPodIDsRetryIntervalInSeconds, err)
+					return nil, false, fmt.Errorf("clientID in request: %s, getting assigned identities for pod %s/%s in CREATED state failed after %d attempts, retry duration [%d]s, error: %+v. Check MIC pod logs for identity assignment errors",
+						utils.RedactClientID(rqClientID), podns, podname, sc.ListPodIDsRetryAttemptsForCreated, sc.ListPodIDsRetryIntervalInSeconds, err)
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

- Fixes #1136 
- cleanup role assignments for ACR and keyvault

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
