### PR TITLE
chore: add redacted client ID in the error log (#1141)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN export GOOS=$TARGETOS && \
     make build
 
 FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.6 AS nmi
-RUN clean-install ca-certificates
+# upgrading libssl1.1 due to CVE-2021-33910 and CVE-2021-3712
+RUN clean-install ca-certificates libssl1.1
 COPY --from=builder /go/src/github.com/Azure/aad-pod-identity/bin/aad-pod-identity/nmi /bin/
 RUN useradd -u 10001 nonroot
 USER nonroot


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Fixes the following CVEs:

```bash
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
|  LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
| libssl1.1 | CVE-2021-3711    | HIGH     | 1.1.1d-0+deb10u6  | 1.1.1d-0+deb10u7 | openssl: SM2 Decryption              |
|           |                  |          |                   |                  | Buffer Overflow                      |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3711 |
+           +------------------+----------+                   +                  +--------------------------------------+
|           | CVE-2021-3712    | MEDIUM   |                   |                  | openssl: Read buffer overruns        |
|           |                  |          |                   |                  | processing ASN.1 strings             |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3712 |
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
```

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
