### PR TITLE
fix: update the node name label as part of `AzureAssignedIdentity` update

### DIFF
--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -834,9 +834,13 @@ func (c *Client) getAzureAssignedIdentitiesToUpdate(add, del map[string]aadpodid
 	}
 	for assignedIDName, addAssignedID := range add {
 		if delAssignedID, exists := del[assignedIDName]; exists {
+			objMeta := delAssignedID.ObjectMeta
+			// the label should always be the latest as the pod could have moved to a different node
+			// with the same assigned identity
+			objMeta.SetLabels(addAssignedID.GetObjectMeta().GetLabels())
+			addAssignedID.ObjectMeta = objMeta
 			// assigned identity exists in add and del list
 			// update the assigned identity to the latest
-			addAssignedID.ObjectMeta = delAssignedID.ObjectMeta
 			beforeUpdate[assignedIDName] = delAssignedID
 			afterUpdate[assignedIDName] = addAssignedID
 			// since this is part of update, remove the assignedID from the add and del list


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
In case of stateful sets, the pod with the same name could move from one node to another still bound to the same `AzureIdentity`. Currently in such scenarios, the `nodename` label in metadata for `AzureAssignedIdentity` isn't updated to reflect the node change. This will cause token request to fail as NMI has filtered watch based on nodename.

We need to use the old object metadata because resourceVersion needs to be set as part of update. This PR uses the existing object metadata and updates just the labels to latest. 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
