### PR TITLE
Fix type in homepage docs

### DIFF
--- a/website/content/en/docs/_index.md
+++ b/website/content/en/docs/_index.md
@@ -16,7 +16,7 @@ Using Kubernetes primitives, administrators configure identities and bindings to
 
 ### v1.8.0
 
-- The API version of Pod Identity's CRDs (`AzureIdentity`, `AzureIdentityBinding`, `AzureAssignedIdentity`, `AzurePodIdentityException`) have been upgraded from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`. For Kubernetes clsuters with < 1.16, `apiextensions.k8s.io/v1` CRDs would not work. You can either:
+- The API version of Pod Identity's CRDs (`AzureIdentity`, `AzureIdentityBinding`, `AzureAssignedIdentity`, `AzurePodIdentityException`) have been upgraded from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`. For Kubernetes clusters with < 1.16, `apiextensions.k8s.io/v1` CRDs would not work. You can either:
   1. Continue using AAD Pod Identity v1.7.5 or
   2. Upgrade your cluster to 1.16+, then upgrade AAD Pod Identity.
 


### PR DESCRIPTION
Fix typo "clutster" --> "cluster" on homepage of the docs

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
