### PR TITLE
ci: install qemu instead of docker/binfmt

### DIFF
--- a/.pipelines/pr.yml
+++ b/.pipelines/pr.yml
@@ -15,7 +15,6 @@ jobs:
   - template: templates/unit-test.yml
   - template: templates/e2e-test.yml
     parameters:
-      buildPlatforms: linux/amd64
       clusterConfigs:
         - "aks"
         # File names in test/e2e/cluster_configs without file extension

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ export DOCKER_BUILDKIT DOCKER_CLI_EXPERIMENTAL
 BUILD_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7
 # Output type of docker buildx build
 OUTPUT_TYPE ?= registry
+QEMU_VERSION ?= 5.2.0-2
+BUILDX_BUILDER_NAME ?= container-builder
 
 CONTROLLER_GEN := $(TOOLS_DIR)/controller-gen
 GOLANGCI_LINT := $(TOOLS_DIR)/golangci-lint
@@ -141,11 +143,11 @@ deepcopy-gen:
 
 .PHONY: docker-buildx-builder
 docker-buildx-builder:
-	docker run --rm --privileged docker/binfmt:820fdd95a9972a5308930a2bdfb8573dd4447ad3
-	if ! docker buildx ls | grep -q container-builder; then \
-		DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name container-builder --use; \
+	if ! docker buildx ls | grep -q $(BUILDX_BUILDER_NAME); then \
+		docker run --rm --privileged multiarch/qemu-user-static:$(QEMU_VERSION) --reset -p yes; \
+		DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name $(BUILDX_BUILDER_NAME) --use; \
+		docker buildx inspect $(BUILDX_BUILDER_NAME) --bootstrap; \
 	fi
-	docker buildx inspect container-builder --bootstrap
 
 .PHONY: image-nmi
 image-nmi:


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Install qemu instead of docker/binfmt

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes failure in https://dev.azure.com/AzureContainerUpstream/AAD%20Pod%20Identity/_build/results?buildId=28670&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
