### PR TITLE
chore: remove armv7 from build platforms

### DIFF
--- a/.pipelines/templates/e2e-test.yml
+++ b/.pipelines/templates/e2e-test.yml
@@ -3,7 +3,7 @@ parameters:
     type: object
   - name: buildPlatforms
     type: string
-    default: linux/amd64,linux/arm64,linux/arm/v7
+    default: linux/amd64,linux/arm64
 
 jobs:
   - ${{ each clusterConfig in parameters.clusterConfigs }}:

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ TOOLS_DIR := $(abspath ./.tools)
 DOCKER_BUILDKIT = 1
 DOCKER_CLI_EXPERIMENTAL = enabled
 export DOCKER_BUILDKIT DOCKER_CLI_EXPERIMENTAL
-BUILD_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7
+BUILD_PLATFORMS ?= linux/amd64,linux/arm64
 # Output type of docker buildx build
 OUTPUT_TYPE ?= registry
 QEMU_VERSION ?= 5.2.0-2


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

Removing armv7 from build platforms and only build linux/amd64 and linux/arm64 going fowrad.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
