### PR TITLE
feat: return http 503 when IMDS healthcheck fails 

### DIFF
--- a/pkg/auth/errors.go
+++ b/pkg/auth/errors.go
@@ -8,3 +8,8 @@ func IsTokenRefreshError(err error) bool {
 	_, ok := err.(adal.TokenRefreshError)
 	return ok
 }
+
+// IsHealthCheckError returns true if the error is not a token refresh error.
+func IsHealthCheckError(err error) bool {
+	return !IsTokenRefreshError(err)
+}

--- a/pkg/auth/errors.go
+++ b/pkg/auth/errors.go
@@ -1,0 +1,10 @@
+package auth
+
+import "github.com/Azure/go-autorest/autorest/adal"
+
+// IsTokenRefreshError returns true if the error is a TokenRefreshError.
+// This method can be used to distinguish health check errors from token refresh errors.
+func IsTokenRefreshError(err error) bool {
+	_, ok := err.(adal.TokenRefreshError)
+	return ok
+}

--- a/pkg/auth/errors_test.go
+++ b/pkg/auth/errors_test.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+)
+
+type testError struct {
+	adal.TokenRefreshError
+}
+
+func TestIsTokenRefreshError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "not a token refresh error",
+			err:  errors.New("some error"),
+		},
+		{
+			name: "token refresh error",
+			err:  testError{},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsTokenRefreshError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsTokenRefreshError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/auth/errors_test.go
+++ b/pkg/auth/errors_test.go
@@ -37,3 +37,31 @@ func TestIsTokenRefreshError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsHealthCheckError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "health check error",
+			err:  errors.New("some error"),
+			want: true,
+		},
+		{
+			name: "not health check error",
+			err:  testError{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsHealthCheckError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsHealthCheckError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -106,21 +106,16 @@ func (c *Client) Init() error {
 
 	var spt *adal.ServicePrincipalToken
 	if c.Config.UseManagedIdentityExtension {
-		// MSI endpoint is required for both types of MSI - system assigned and user assigned.
-		msiEndpoint, err := adal.GetMSIVMEndpoint()
-		if err != nil {
-			return fmt.Errorf("failed to get MSI endpoint, error: %+v", err)
-		}
 		// UserAssignedIdentityID is empty, so we are going to use system assigned MSI
 		if c.Config.UserAssignedIdentityID == "" {
 			klog.Infof("MIC using system assigned identity for authentication.")
-			spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, azureEnv.ResourceManagerEndpoint)
+			spt, err = adal.NewServicePrincipalTokenFromMSI("", azureEnv.ResourceManagerEndpoint)
 			if err != nil {
 				return fmt.Errorf("failed to get token from system-assigned identity, error: %+v", err)
 			}
 		} else { // User assigned identity usage.
 			klog.Infof("MIC using user assigned identity: %s for authentication.", utils.RedactClientID(c.Config.UserAssignedIdentityID))
-			spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, azureEnv.ResourceManagerEndpoint, c.Config.UserAssignedIdentityID)
+			spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID("", azureEnv.ResourceManagerEndpoint, c.Config.UserAssignedIdentityID)
 			if err != nil {
 				return fmt.Errorf("failed to get token from user-assigned identity, error: %+v", err)
 			}

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -245,7 +245,14 @@ func (s *Server) hostHandler(w http.ResponseWriter, r *http.Request) (ns string)
 	tokens, err := s.TokenClient.GetTokens(r.Context(), tokenRequest.ClientID, tokenRequest.Resource, *podID)
 	if err != nil {
 		klog.Errorf("failed to get service principal token for pod:%s/%s, error: %+v", podns, podname, err)
-		http.Error(w, err.Error(), http.StatusForbidden)
+		httpErrorCode := http.StatusForbidden
+		if !auth.IsTokenRefreshError(err) {
+			// the adal library performs a health check prior to making the token request
+			// if the health check fails, we want to return a 503 instead of 403
+			// for health check failures, the error is not a token refresh error
+			httpErrorCode = http.StatusServiceUnavailable
+		}
+		http.Error(w, err.Error(), httpErrorCode)
 		return
 	}
 	nmiResp := NMIResponse{
@@ -390,7 +397,14 @@ func (s *Server) msiHandler(w http.ResponseWriter, r *http.Request) (ns string) 
 	tokens, err := s.TokenClient.GetTokens(r.Context(), tokenRequest.ClientID, tokenRequest.Resource, *podID)
 	if err != nil {
 		klog.Errorf("failed to get service principal token for pod: %s/%s, error: %+v", podns, podname, err)
-		http.Error(w, err.Error(), http.StatusForbidden)
+		httpErrorCode := http.StatusForbidden
+		if !auth.IsTokenRefreshError(err) {
+			// the adal library performs a health check prior to making the token request
+			// if the health check fails, we want to return a 503 instead of 403
+			// for health check failures, the error is not a token refresh error
+			httpErrorCode = http.StatusServiceUnavailable
+		}
+		http.Error(w, err.Error(), httpErrorCode)
 		return
 	}
 

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -246,7 +246,7 @@ func (s *Server) hostHandler(w http.ResponseWriter, r *http.Request) (ns string)
 	if err != nil {
 		klog.Errorf("failed to get service principal token for pod:%s/%s, error: %+v", podns, podname, err)
 		httpErrorCode := http.StatusForbidden
-		if !auth.IsTokenRefreshError(err) {
+		if auth.IsHealthCheckError(err) {
 			// the adal library performs a health check prior to making the token request
 			// if the health check fails, we want to return a 503 instead of 403
 			// for health check failures, the error is not a token refresh error
@@ -398,7 +398,7 @@ func (s *Server) msiHandler(w http.ResponseWriter, r *http.Request) (ns string) 
 	if err != nil {
 		klog.Errorf("failed to get service principal token for pod: %s/%s, error: %+v", podns, podname, err)
 		httpErrorCode := http.StatusForbidden
-		if !auth.IsTokenRefreshError(err) {
+		if auth.IsHealthCheckError(err) {
 			// the adal library performs a health check prior to making the token request
 			// if the health check fails, we want to return a 503 instead of 403
 			// for health check failures, the error is not a token refresh error

--- a/test/image/identityvalidator/identityvalidator.go
+++ b/test/image/identityvalidator/identityvalidator.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
-	"github.com/Azure/go-autorest/autorest/adal"
 	"k8s.io/klog/v2"
 )
 
@@ -56,7 +55,6 @@ func main() {
 
 	klog.Infof("starting identity validator pod %s/%s with pod IP %s", podnamespace, podname, podip)
 
-	imdsTokenEndpoint, _ := adal.GetMSIVMEndpoint()
 	kvt := &keyvaultTester{
 		client:             keyvault.New(),
 		subscriptionID:     subscriptionID,
@@ -66,10 +64,6 @@ func main() {
 		secretName:         keyvaultSecretName,
 		secretVersion:      keyvaultSecretVersion,
 		secretValue:        keyvaultSecretValue,
-		imdsTokenEndpoint:  imdsTokenEndpoint,
-	}
-	spt := &servicePrincipalTester{
-		imdsTokenEndpoint: imdsTokenEndpoint,
 	}
 
 	var wg sync.WaitGroup
@@ -78,7 +72,7 @@ func main() {
 	for _, assert := range []assertFunction{
 		kvt.assertWithIdentityClientID,
 		kvt.assertWithIdentityResourceID,
-		spt.assertWithSystemAssignedIdentity,
+		assertWithSystemAssignedIdentity,
 	} {
 		wg.Add(1)
 		go func(assert assertFunction) {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- Parse the error from adal token request to distinguish token request error from IMDS health check failures.
  - If IMDS health check fails, return a 503
  - For token request failures, keep the same behavior and return 403
- Update the token request method in all the packages as the current ones we're using are deprecated.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
