### PR TITLE
test: fix helm upgrade for soak test

### DIFF
--- a/test/e2e/framework/helm/helm_helpers.go
+++ b/test/e2e/framework/helm/helm_helpers.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package helm
@@ -105,6 +106,8 @@ func generateValueArgs(config *framework.Config) []string {
 		fmt.Sprintf("--set=nmi.retryAttemptsForCreated=%d", config.RetryAttemptsForCreated),
 		fmt.Sprintf("--set=nmi.retryAttemptsForAssigned=%d", config.RetryAttemptsForAssigned),
 		fmt.Sprintf("--set=nmi.findIdentityRetryIntervalInSeconds=%d", config.FindIdentityRetryIntervalInSeconds),
+		// Setting this explicitly as the old charts don't have this value object and fail with --reuse-values
+		fmt.Sprintf("--set=mic.customCloud.enabled=false"),
 	}
 
 	// TODO (aramase) bump this to compare against v1.7.3 after next release


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
Helm upgrade commands in soak cluster are failing because of the new `mic.customCloud.enabled` value in helm chart. As this doesn't exist in the old chart, it fails with nil pointer exception with `--reuse-values`.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
