### PR TITLE
feat: Add AllowedNamespaceToInstanceMetadata flag to NMI

### DIFF
--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -45,6 +45,7 @@ var (
 	enableProfile                      = pflag.Bool("enableProfile", false, "Enable/Disable pprof profiling")
 	enableScaleFeatures                = pflag.Bool("enableScaleFeatures", true, "Enable/Disable features for scale clusters")
 	blockInstanceMetadata              = pflag.Bool("block-instance-metadata", false, "Block instance metadata endpoints")
+	allowedNamespaceToInstanceMetadata = pflag.String("allowed-namespace-to-instance-metadata", "kube-system", "Allowed namespace to instance metadata endpoints if `block-instance-metadata` flag is set")
 	metadataHeaderRequired             = pflag.Bool("metadata-header-required", true, "Metadata header required for querying Azure Instance Metadata service")
 	prometheusPort                     = pflag.String("prometheus-port", "9090", "Prometheus port for metrics")
 	operationMode                      = pflag.String("operation-mode", "standard", "NMI operation mode")
@@ -113,7 +114,7 @@ func main() {
 	*forceNamespaced = *forceNamespaced || "true" == os.Getenv("FORCENAMESPACED")
 	klog.Infof("running NMI in namespaced mode: %v", *forceNamespaced)
 
-	s := server.NewServer(*micNamespace, *blockInstanceMetadata, *metadataHeaderRequired, *setRetryAfterHeader)
+	s := server.NewServer(*micNamespace, *allowedNamespaceToInstanceMetadata, *blockInstanceMetadata, *metadataHeaderRequired, *setRetryAfterHeader)
 	s.KubeClient = client
 	s.MetadataIP = *metadataIP
 	s.MetadataPort = *metadataPort

--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -49,6 +49,7 @@ type Server struct {
 	NodeName                           string
 	IPTableUpdateTimeIntervalInSeconds int
 	MICNamespace                       string
+	AllowedNamespaceToInstanceMetadata string
 	Initialized                        bool
 	BlockInstanceMetadata              bool
 	MetadataHeaderRequired             bool
@@ -72,7 +73,7 @@ type MetadataResponse struct {
 }
 
 // NewServer will create a new Server with default values.
-func NewServer(micNamespace string, blockInstanceMetadata, metadataHeaderRequired, setRetryAfterHeader bool) *Server {
+func NewServer(micNamespace, allowedNamespaceToInstanceMetadata string, blockInstanceMetadata, metadataHeaderRequired, setRetryAfterHeader bool) *Server {
 	reporter, err := metrics.NewReporter()
 	if err != nil {
 		klog.Errorf("failed to create reporter for metrics, error: %+v", err)
@@ -82,11 +83,12 @@ func NewServer(micNamespace string, blockInstanceMetadata, metadataHeaderRequire
 		auth.InitReporter(reporter)
 	}
 	return &Server{
-		MICNamespace:           micNamespace,
-		BlockInstanceMetadata:  blockInstanceMetadata,
-		MetadataHeaderRequired: metadataHeaderRequired,
-		Reporter:               reporter,
-		SetRetryAfterHeader:    setRetryAfterHeader,
+		MICNamespace:                       micNamespace,
+		AllowedNamespaceToInstanceMetadata: allowedNamespaceToInstanceMetadata,
+		BlockInstanceMetadata:              blockInstanceMetadata,
+		MetadataHeaderRequired:             metadataHeaderRequired,
+		Reporter:                           reporter,
+		SetRetryAfterHeader:                setRetryAfterHeader,
 	}
 }
 
@@ -98,7 +100,7 @@ func (s *Server) Run() error {
 	rtr.PathPrefix(tokenPathPrefix).Handler(appHandler(s.msiHandler))
 	rtr.PathPrefix(hostTokenPathPrefix).Handler(appHandler(s.hostHandler))
 	if s.BlockInstanceMetadata {
-		rtr.PathPrefix(instancePathPrefix).HandlerFunc(forbiddenHandler)
+		rtr.PathPrefix(instancePathPrefix).HandlerFunc(s.instancePathHandler)
 	}
 	rtr.PathPrefix("/").HandlerFunc(s.defaultPathHandler)
 
@@ -512,6 +514,20 @@ func parseTokenRequest(r *http.Request) (request TokenRequest) {
 	return request
 }
 
+// instancePathHandler creates a new instance metadata request and returns the response body and code
+func (s *Server) instancePathHandler(w http.ResponseWriter, r *http.Request) {
+	if s.BlockInstanceMetadata {
+		if s.AllowedNamespaceToInstanceMetadata == "" {
+			http.Error(w, "Request blocked by AAD Pod Identity NMI", http.StatusForbidden)
+			return
+		}
+		if !s.hasAccessToInstanceMetadata(w, r) {
+			return
+		}
+	}
+	s.defaultPathHandler(w, r)
+}
+
 // defaultPathHandler creates a new request and returns the response body and code
 func (s *Server) defaultPathHandler(w http.ResponseWriter, r *http.Request) {
 	if s.MetadataHeaderRequired && parseMetadata(r) != "true" {
@@ -552,9 +568,31 @@ func (s *Server) defaultPathHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(body)
 }
 
-// forbiddenHandler responds to any request with HTTP 403 Forbidden
-func forbiddenHandler(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Request blocked by AAD Pod Identity NMI", http.StatusForbidden)
+// hasAccessToInstanceMetadata validates if the requester has access to instance metadata
+func (s *Server) hasAccessToInstanceMetadata(w http.ResponseWriter, r *http.Request) bool {
+	podIP := parseRemoteAddr(r.RemoteAddr)
+	if podIP == "" {
+		klog.Error("request remote address is empty")
+		http.Error(w, "request remote address is empty", http.StatusInternalServerError)
+		return false
+	}
+	podns, _, _, _, err := s.KubeClient.GetPodInfo(podIP)
+	if err != nil {
+		klog.Errorf("failed to get pod info from pod IP: %s, error: %+v", podIP, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return false
+	}
+
+	if podns == "" {
+		klog.Errorf("failed to get podns from pod IP: %s", podIP)
+		http.Error(w, "failed to get podns from pod IP", http.StatusInternalServerError)
+		return false
+	}
+	if podns != s.AllowedNamespaceToInstanceMetadata {
+		http.Error(w, "Request blocked by AAD Pod Identity NMI", http.StatusForbidden)
+		return false
+	}
+	return true
 }
 
 func copyHeader(dst, src http.Header) {

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ImmutableUserMSIs                  string        `envconfig:"IMMUTABLE_IDENTITY_CLIENT_ID"`
 	NMIMode                            string        `envconfig:"NMI_MODE" default:"standard"`
 	BlockInstanceMetadata              bool          `envconfig:"BLOCK_INSTANCE_METADATA" default:"true"`
+	AllowedNamespaceToInstanceMetadata string        `envconfig:"ALLOWED_NAMESPACE_TO_INSTANCE_METADATA" default:""`
 	IsSoakTest                         bool          `envconfig:"IS_SOAK_TEST" default:"false"`
 	IdentityReconcileInterval          time.Duration `envconfig:"IDENTITY_RECONCILE_INTERVAL" default:"2m"`
 	ServicePrincipalClientID           string        `envconfig:"SERVICE_PRINCIPAL_CLIENT_ID"`
@@ -62,6 +63,7 @@ func (c *Config) DeepCopy() *Config {
 	copy.ImmutableUserMSIs = c.ImmutableUserMSIs
 	copy.NMIMode = c.NMIMode
 	copy.BlockInstanceMetadata = c.BlockInstanceMetadata
+	copy.AllowedNamespaceToInstanceMetadata = c.AllowedNamespaceToInstanceMetadata
 	copy.IsSoakTest = c.IsSoakTest
 	copy.ServicePrincipalClientID = c.ServicePrincipalClientID
 	copy.ServicePrincipalClientSecret = c.ServicePrincipalClientSecret

--- a/test/e2e/instance_metadata_test.go
+++ b/test/e2e/instance_metadata_test.go
@@ -49,7 +49,11 @@ var _ = Describe("When sending a request to Instance Metadata Service", func() {
 				cmd = "curl -f 127.0.0.1:2579/metadata/instance -H Metadata:true"
 				stdout, err := exec.KubectlExec(kubeconfigPath, busyboxPod.Name, namespace, strings.Split(cmd, " "))
 				Expect(err).NotTo(BeNil())
-				Expect(strings.Contains(stdout, "403 Forbidden")).To(BeTrue())
+				if config.AllowedNamespaceToInstanceMetadata == namespace {
+					Expect(strings.Contains(stdout, "403 Forbidden")).To(BeFalse())
+				} else {
+					Expect(strings.Contains(stdout, "403 Forbidden")).To(BeTrue())
+				}
 			}
 		}
 	})

--- a/website/content/en/docs/Configure/feature_flags.md
+++ b/website/content/en/docs/Configure/feature_flags.md
@@ -53,6 +53,13 @@ Forbidden response. This flag is disabled by default to maximize compatibility.
 Users are encouraged to determine if this option is relevant and beneficial for
 their use cases.
 
+## Allowed Namespace To Instance Metadata flag
+
+> Available from 1.8.7 release
+
+The `allowed-namespace-to-instance-metadata` flag for NMI allows pods from specified namespace to access the instance metadata when
+`blockInstanceMetadata` flag is set. If empty, no pods will have access to instance metadata.
+
 ## ImmutableUserMSIs flag
 
 > Available from 1.5.4 release


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
Add new flag for NMI, `AllowedNamespaceToInstanceMetadata`, in order to allow pods from specific namespace to access the instance metadata when `blockInstanceMetadata` flag is set.

A use case will be to allow Azure CSI drivers to access instance metadata when running in overlay network.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
