### PR TITLE
fix: make metadata header required configurable in helm

### DIFF
--- a/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -82,18 +82,14 @@ spec:
           {{- if .Values.nmi.findIdentityRetryIntervalInSeconds }}
           - --find-identity-retry-interval={{ .Values.nmi.findIdentityRetryIntervalInSeconds }}
           {{- end }}
-          {{- if .Values.nmi.enableScaleFeatures }}
           - --enableScaleFeatures={{ .Values.nmi.enableScaleFeatures }}
-          {{- end }}
           {{- if .Values.nmi.prometheusPort }}
           - --prometheus-port={{ .Values.nmi.prometheusPort }}
           {{- end }}
           {{- if .Values.nmi.blockInstanceMetadata }}
           - --block-instance-metadata={{ .Values.nmi.blockInstanceMetadata }}
           {{- end }}
-          {{- if .Values.nmi.metadataHeaderRequired}}
           - --metadata-header-required={{ .Values.nmi.metadataHeaderRequired }}
-          {{- end }}
           {{- if .Values.nmi.loggingFormat }}
           - --log-format={{ .Values.nmi.loggingFormat }}
           {{- end}}

--- a/website/content/en/changelog/_index.md
+++ b/website/content/en/changelog/_index.md
@@ -44,6 +44,10 @@ menu:
 
 ## v1.8.4
 
+### Breaking Changes
+
+The metadata header required flag is enabled by default to prevent SSRF attacks. Check [Metadata Header Required](https://azure.github.io/aad-pod-identity/docs/configure/feature_flags/#metadata-header-required-flag) for more information. To disable the metadata header check, set `--metadata-header-required=false` in NMI [container args](https://github.com/Azure/aad-pod-identity/blob/v1.8.6/deploy/infra/deployment-rbac.yaml#L483).
+
 ### Bug Fixes
 - update the node name label as part of AzureAssignedIdentity update ([#1161](https://github.com/Azure/aad-pod-identity/issues/1161))
 

--- a/website/content/en/docs/_index.md
+++ b/website/content/en/docs/_index.md
@@ -16,6 +16,10 @@ Using Kubernetes primitives, administrators configure identities and bindings to
 
 ## Breaking Changes
 
+### v1.8.4
+
+The metadata header required flag is enabled by default to prevent SSRF attacks. Check [Metadata Header Required](./configure/feature_flags/#metadata-header-required-flag) for more information. To disable the metadata header check, set `--metadata-header-required=false` in NMI [container args](https://github.com/Azure/aad-pod-identity/blob/v1.8.6/deploy/infra/deployment-rbac.yaml#L483).
+
 ### v1.8.0
 
 - The API version of Pod Identity's CRDs (`AzureIdentity`, `AzureIdentityBinding`, `AzureAssignedIdentity`, `AzurePodIdentityException`) have been upgraded from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`. For Kubernetes clusters with < 1.16, `apiextensions.k8s.io/v1` CRDs would not work. You can either:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
ref #1239, #1238
fixes #1237 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
