### PR TITLE
security: fix CVE-2021-3995, CVE-2021-3996

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ FROM k8s.gcr.io/build-image/debian-iptables:bullseye-v1.1.0 AS nmi
 # upgrading libssl1.1 due to CVE-2021-3711 and CVE-2021-3712
 # upgrading libgssapi-krb5-2 and libk5crypto3 due to CVE-2021-37750
 # upgrading libgmp10 due to CVE-2021-43618
-RUN clean-install ca-certificates libssl1.1 libgssapi-krb5-2 libk5crypto3 libgmp10
+# upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
+RUN clean-install ca-certificates libssl1.1 libgssapi-krb5-2 libk5crypto3 libgmp10 bsdutils
 COPY --from=builder /go/src/github.com/Azure/aad-pod-identity/bin/aad-pod-identity/nmi /bin/
 RUN useradd -u 10001 nonroot
 USER nonroot


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
```bash
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| bsdutils | CVE-2021-3995    | MEDIUM   | 2.36.1-8          | 2.36.1-8+deb11u1 | util-linux: Unauthorized unmount     |
|          |                  |          |                   |                  | of FUSE filesystems belonging        |
|          |                  |          |                   |                  | to users with similar uid...         |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3995 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2021-3996    |          |                   |                  | util-linux: Unauthorized unmount     |
|          |                  |          |                   |                  | of filesystems in libmount           |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3996 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
```
<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
