### PR TITLE
fix: optionally allow disabling iptables rule cleanup 

### DIFF
--- a/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -70,6 +70,9 @@ spec:
           {{- if .Values.nmi.ipTableUpdateTimeIntervalInSeconds }}
           - --ipt-update-interval-sec={{ .Values.nmi.ipTableUpdateTimeIntervalInSeconds }}
           {{- end }}
+          {{- if .Values.nmi.dontFlushIptableOnExit  }}
+          - --dont-flush-iptables-on-exit={{ .Values.nmi.dontFlushIptablesOnExit }}
+          {{- end }}
           {{- if .Values.nmi.micNamespace }}
           - --MICNamespace={{ .Values.nmi.micNamespace }}
           {{- end }}

--- a/charts/aad-pod-identity/values.yaml
+++ b/charts/aad-pod-identity/values.yaml
@@ -212,6 +212,8 @@ nmi:
 
   # Override iptables update interval in seconds (default is 60)
   ipTableUpdateTimeIntervalInSeconds: ""
+  # Control whether iptables will be flushed on exit
+  dontFlushIptablesOnExit: "false"
 
   # Override mic namespace to short circuit MIC token requests (default is default namespace)
   micNamespace: ""

--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -51,6 +51,7 @@ var (
 	allowNetworkPluginKubenet          = pflag.Bool("allow-network-plugin-kubenet", false, "Allow running aad-pod-identity in cluster with kubenet")
 	kubeletConfig                      = pflag.String("kubelet-config", "/etc/default/kubelet", "Path to kubelet default config")
 	setRetryAfterHeader                = pflag.Bool("set-retry-after-header", false, "Set Retry-After header in NMI responses")
+	dontFlushIptableOnExit             = pflag.Bool("dont-flush-iptables-on-exit", false, "Do not flush iptables rules on exit")
 )
 
 func main() {
@@ -120,6 +121,7 @@ func main() {
 	s.NMIPort = *nmiPort
 	s.NodeName = *nodename
 	s.IPTableUpdateTimeIntervalInSeconds = *ipTableUpdateTimeIntervalInSeconds
+	s.DontFlushIptablesOnExit = *dontFlushIptableOnExit
 
 	nmiConfig := nmi.Config{
 		Mode:                               strings.ToLower(*operationMode),

--- a/website/content/en/docs/Configure/feature_flags.md
+++ b/website/content/en/docs/Configure/feature_flags.md
@@ -86,3 +86,14 @@ While enabling this feature, you must also disable the internal retries in NMI.
   - Set `--retry-attempts-for-created=1`, `--retry-attempts-for-assigned=1` and `--find-identity-retry-interval=1` flags in the NMI container to disable the internal retries in NMI.
 - If using [helm](../../getting-started/installation/#helm) to deploy aad-pod-identity, you can enable this feature by setting `nmi.setRetryAfterHeader=true` as part of helm install/upgrade.
   - Set `nmi.retryAttemptsForCreated=1`, `nmi.retryAttemptsForAssigned=1` and `nmi.findIdentityRetryIntervalInSeconds=1` flags in the helm install/upgrade command to disable the internal retries in NMI.
+
+## Do not Flush Iptables on Exit
+
+> Available from v1.8.7 release
+
+NMI currently flushes the iptables rule on exit. For some applications this causes requests to reach metadata endpoint directly instead of going through nmi pod. This flag disables flushing of iptable rules when the nmi pod terminates
+
+### How to enable this feature
+
+- If using the [yaml](../../getting-started/installation/#quick-install) to deploy aad-pod-identity, you can enable this feature by setting the `--dont-flush-iptables-on-exit=true` flag in the NMI container.
+- If using [helm](../../getting-started/installation/#helm) to deploy aad-pod-identity, you can enable this feature by setting `nmi.dontFlushIptablesOnExit=true` as part of helm install/upgrade.


### PR DESCRIPTION
**Reason for Change**:

We have observed some applications don`t work well if iptables rules are flushed by nmi pod on exit.

It causes those application to access imds endpoint directly , causing issues with fetching tokens.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:


**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
