### PR TITLE
fix: delete conntrack entries after adding iptables rules on initialization

### DIFF
--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -51,6 +51,7 @@ var (
 	allowNetworkPluginKubenet          = pflag.Bool("allow-network-plugin-kubenet", false, "Allow running aad-pod-identity in cluster with kubenet")
 	kubeletConfig                      = pflag.String("kubelet-config", "/etc/default/kubelet", "Path to kubelet default config")
 	setRetryAfterHeader                = pflag.Bool("set-retry-after-header", false, "Set Retry-After header in NMI responses")
+	enableConntrackDeletion            = pflag.Bool("enable-conntrack-deletion", false, "Enable/Disable deletion of conntrack entries for pre-existing connections to metadata endpoint")
 )
 
 func main() {
@@ -120,6 +121,7 @@ func main() {
 	s.NMIPort = *nmiPort
 	s.NodeName = *nodename
 	s.IPTableUpdateTimeIntervalInSeconds = *ipTableUpdateTimeIntervalInSeconds
+	s.EnableConntrackDeletion = *enableConntrackDeletion
 
 	nmiConfig := nmi.Config{
 		Mode:                               strings.ToLower(*operationMode),

--- a/go.mod
+++ b/go.mod
@@ -13,15 +13,18 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
+	github.com/vishvananda/netlink v1.1.1-0.20220112194529-e5fd1f8193de
 	go.opencensus.io v0.23.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
 	k8s.io/component-base v0.23.0
 	k8s.io/klog/v2 v2.30.0
+	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 )
 
 require (
@@ -58,12 +61,12 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
-	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
@@ -72,7 +75,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
-	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,10 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/vishvananda/netlink v1.1.1-0.20220112194529-e5fd1f8193de h1:oKsSb37Gigkqp182VDDWVZ+WgyX5BKBKgTpsDheV45w=
+github.com/vishvananda/netlink v1.1.1-0.20220112194529-e5fd1f8193de/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -591,6 +595,7 @@ golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -602,6 +607,7 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
+++ b/manifest_staging/charts/aad-pod-identity/templates/nmi-daemonset.yaml
@@ -114,6 +114,9 @@ spec:
           {{- if .Values.nmi.setRetryAfterHeader }}
           - --set-retry-after-header={{ .Values.nmi.setRetryAfterHeader }}
           {{- end }}
+          {{- if .Values.nmi.enableConntrackDeletion  }}
+          - --enable-conntrack-deletion={{ .Values.nmi.enableConntrackDeletion }}
+          {{- end }}
         env:
           {{- if semverCompare "<= 1.6.1-0" .Values.nmi.tag }}
           - name: HOST_IP

--- a/manifest_staging/charts/aad-pod-identity/values.yaml
+++ b/manifest_staging/charts/aad-pod-identity/values.yaml
@@ -255,6 +255,9 @@ nmi:
   # Set retry-after header in the NMI responses when the identity is still being assigned.
   setRetryAfterHeader: false
 
+  # Enable/Disable deletion of conntrack entries for pre-existing connections to metadata endpoint
+  enableConntrackDeletion: false
+
 rbac:
   enabled: true
   # NMI requires permissions to get secrets when service principal (type: 1) is used in AzureIdentity.

--- a/pkg/nmi/conntrack/conntrack.go
+++ b/pkg/nmi/conntrack/conntrack.go
@@ -1,0 +1,53 @@
+package conntrack
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+	knet "k8s.io/utils/net"
+)
+
+const (
+	protoTCP = 6
+)
+
+// returns the netlink family for a given IP address
+func getNetlinkFamily(ip net.IP) netlink.InetFamily {
+	if knet.IsIPv4(ip) {
+		return unix.AF_INET
+	}
+	return unix.AF_INET6
+}
+
+// Deletes conntrack entries for TCP connections which have metadata endpoint as their destination
+func DeleteConntrackEntries(metadataIP, metadataPort string) error {
+	dstIP := net.ParseIP(metadataIP)
+	if dstIP == nil {
+		return fmt.Errorf("metadata ip %s is incorrect", metadataIP)
+	}
+	dstPort, err := knet.ParsePort(metadataPort, false)
+	if err != nil {
+		return fmt.Errorf("failed to parse metadata port: %s, error: %w", metadataPort, err)
+	}
+	connectionFilter := &netlink.ConntrackFilter{}
+	if err = connectionFilter.AddIP(netlink.ConntrackOrigDstIP, dstIP); err != nil {
+		return fmt.Errorf("failed to delete conntrack entries, error: %w", err)
+	}
+	if err = connectionFilter.AddProtocol(protoTCP); err != nil {
+		return fmt.Errorf("failed to delete conntrack entries, error: %w", err)
+	}
+	if err = connectionFilter.AddPort(netlink.ConntrackOrigDstPort, uint16(dstPort)); err != nil {
+		return fmt.Errorf("failed to delete conntrack entries, error: %w", err)
+	}
+	connectionfamily := getNetlinkFamily(dstIP)
+	klog.V(5).InfoS("net link family", connectionfamily, "ip", dstIP, "port", dstPort)
+	_, err = netlink.ConntrackDeleteFilter(netlink.ConntrackTable, connectionfamily, connectionFilter)
+	if err != nil {
+		return fmt.Errorf("failed to delete conntrack entries, error: %w", err)
+	}
+	klog.V(5).Info("deleted conntrack entries")
+	return nil
+}

--- a/website/content/en/docs/Configure/feature_flags.md
+++ b/website/content/en/docs/Configure/feature_flags.md
@@ -86,3 +86,16 @@ While enabling this feature, you must also disable the internal retries in NMI.
   - Set `--retry-attempts-for-created=1`, `--retry-attempts-for-assigned=1` and `--find-identity-retry-interval=1` flags in the NMI container to disable the internal retries in NMI.
 - If using [helm](../../getting-started/installation/#helm) to deploy aad-pod-identity, you can enable this feature by setting `nmi.setRetryAfterHeader=true` as part of helm install/upgrade.
   - Set `nmi.retryAttemptsForCreated=1`, `nmi.retryAttemptsForAssigned=1` and `nmi.findIdentityRetryIntervalInSeconds=1` flags in the helm install/upgrade command to disable the internal retries in NMI.
+
+## Enable deletion of conntrack entries
+
+> Available from v1.8.7 release
+
+NMI redirects Instance Metadata Service (IMDS) requests to itself by setting up iptables rules after it starts running on the node.
+However, these rules are not applicable to pre-existing connections. In such a scenario, the token request will be directly sent to IMDS instead of being intercepted by NMI. What this means is that the workload pod that runs before the NMI pod on the node can access identities that it doesn't have access to.
+The `enable-conntrack-deletion` flag enables deletion of entries for pre-existing connections to IMDS endpoint, this causes applications which had pre-existing connections to be intercepted by NMI.
+
+### How to enable this feature
+
+- If using the [yaml](../../getting-started/installation/#quick-install) to deploy aad-pod-identity, you can enable this feature by setting the `--enable-conntrack-deletion=true` flag in the NMI container.
+- If using [helm](../../getting-started/installation/#helm) to deploy aad-pod-identity, you can enable this feature by setting `nmi.enableConntrackDeletion=true` as part of helm install/upgrade.


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
We have observed that in certain conditions iptables nat rules that are added by nmi pod don`t have any efect on preexisting connections.  This causes traffic to flow directly to metadata endpoint instead of being intercepted by nmi pod.
Have added a utility function to delete conntrack entries which point to metadata endpoint( ip and port comination)

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
