### PR TITLE
fix: update nmi affinity sample in helm charts

### DIFF
--- a/charts/aad-pod-identity/values.yaml
+++ b/charts/aad-pod-identity/values.yaml
@@ -202,7 +202,7 @@ nmi:
   affinity: {}
     # nodeAffinity:
     #   preferredDuringSchedulingIgnoredDuringExecution:
-    #     - weight 1
+    #     - weight: 1
     #       preference:
     #         matchExpressions:
     #           - key: kubernetes.azure.com/mode

--- a/charts/aad-pod-identity/values.yaml
+++ b/charts/aad-pod-identity/values.yaml
@@ -202,7 +202,7 @@ nmi:
   affinity: {}
     # nodeAffinity:
     #   preferredDuringSchedulingIgnoredDuringExecution:
-    #     - weight: 1
+    #     - weight 1
     #       preference:
     #         matchExpressions:
     #           - key: kubernetes.azure.com/mode

--- a/manifest_staging/charts/aad-pod-identity/values.yaml
+++ b/manifest_staging/charts/aad-pod-identity/values.yaml
@@ -202,7 +202,7 @@ nmi:
   affinity: {}
     # nodeAffinity:
     #   preferredDuringSchedulingIgnoredDuringExecution:
-    #     - weight 1
+    #     - weight: 1
     #       preference:
     #         matchExpressions:
     #           - key: kubernetes.azure.com/mode


### PR DESCRIPTION
**Reason for Change**:
A colon was missing in the `nodeAffinity` sample comment ... for less experienced k8s user this is not an error easy to catch 😄

**Requirements**

- [X] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [X] no

**Notes for Reviewers**:

Just modifying comments, no biggie 😄 