### PR TITLE
Allow selecting bind address for NMI

### DIFF
--- a/cmd/nmi/main.go
+++ b/cmd/nmi/main.go
@@ -22,6 +22,7 @@ import (
 const (
 	defaultMetadataIP                         = "169.254.169.254"
 	defaultMetadataPort                       = "80"
+	defaultNmiHost                            = "127.0.0.1"
 	defaultNmiPort                            = "2579"
 	defaultIPTableUpdateTimeIntervalInSeconds = 60
 	defaultlistPodIDsRetryAttemptsForCreated  = 16
@@ -31,6 +32,7 @@ const (
 
 var (
 	versionInfo                        = pflag.Bool("version", false, "prints the version information")
+	nmiHost                            = pflag.String("nmi-listen-address", defaultNmiHost, "NMI listen address")
 	nmiPort                            = pflag.String("nmi-port", defaultNmiPort, "NMI application port")
 	metadataIP                         = pflag.String("metadata-ip", defaultMetadataIP, "instance metadata host ip")
 	metadataPort                       = pflag.String("metadata-port", defaultMetadataPort, "instance metadata host ip")
@@ -118,6 +120,7 @@ func main() {
 	s.KubeClient = client
 	s.MetadataIP = *metadataIP
 	s.MetadataPort = *metadataPort
+	s.NMIHost = *nmiHost
 	s.NMIPort = *nmiPort
 	s.NodeName = *nodename
 	s.IPTableUpdateTimeIntervalInSeconds = *ipTableUpdateTimeIntervalInSeconds


### PR DESCRIPTION
**Reason for Change**:

When using NMI on a cluster using cilium as CNI, the iptables DNAT rule that intercepts traffic towards IMDS has to be replaced by a CiliumLocalRedirectPolicy that works using eBPF.

In practice, it means that traffic is redirected to `add-pod-identity` pod's IP (which is the node IP) rather than 127.0.0.1.

This currently fails, because NMI only listens to localhost.

See https://github.com/cilium/cilium/issues/20103 for more details

This PR adds a new flag to allow specifying which address port 2579 should listen to.

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [x] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:

The default value of the new flag is 127.0.0.1 to make this change 100% compatible with previous releases.