### PR TITLE
chore: update debian-iptables to bullseye-v1.5.2

### DIFF
--- a/.pipelines/templates/deploy-aks-cluster.yml
+++ b/.pipelines/templates/deploy-aks-cluster.yml
@@ -30,6 +30,7 @@ steps:
           --name ${RESOURCE_GROUP} \
           --max-pods ${MAX_PODS} \
           --network-plugin azure \
+          --node-count 2 \
           --generate-ssh-keys > /dev/null
       fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN export GOOS=$TARGETOS && \
     export GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | tr -d 'v') && \
     make build
 
-FROM k8s.gcr.io/build-image/debian-iptables:bullseye-v1.5.1 AS nmi
+FROM k8s.gcr.io/build-image/debian-iptables:bullseye-v1.5.2 AS nmi
 RUN apt update && \
     apt upgrade -y && \
     clean-install ca-certificates


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md). -->

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Identity? Why is it needed? -->
- update debian-iptables to `bullseye-v1.5.2`

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/aad-pod-identity/tree/master/manifest_staging/charts/aad-pod-identity#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable). See [test standard](https://github.com/Azure/aad-pod-identity/blob/master/CONTRIBUTING.md#test-standard) for more details.
- [ ] ran `make precommit`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
