### PR TITLE
Update NMI server resource id query key

### DIFF
--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -549,6 +549,9 @@ func parseTokenRequest(r *http.Request) (request TokenRequest) {
 		// These are mutually exclusive values (client_id, msi_resource_id)
 		request.ClientID = vals.Get("client_id")
 		request.ResourceID = vals.Get("msi_res_id")
+		if len(request.ResourceID) == 0 {
+			request.ResourceID = vals.Get("mi_res_id")
+		}
 
 		request.Resource = vals.Get("resource")
 	}

--- a/pkg/nmi/server/server_test.go
+++ b/pkg/nmi/server/server_test.go
@@ -115,6 +115,20 @@ func TestParseTokenRequest(t *testing.T) {
 		}
 	})
 
+	t.Run("query present with latest resource id", func(t *testing.T) {
+		const resource = "https://vault.azure.net"
+		const resourceID = "/subscriptions/9f2be85c-f8ae-4569-9353-38e5e8b459ef/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test"
+
+		var r http.Request
+		r.URL, _ = url.Parse(fmt.Sprintf("%s?mi_res_id=%s&resource=%s", endpoint, resourceID, resource))
+
+		result := parseTokenRequest(&r)
+
+		if result.ResourceID != resourceID {
+			t.Errorf("invalid ResourceID - expected: %q, actual: %q", resourceID, result.ResourceID)
+		}
+	})
+
 	t.Run("bare endpoint", func(t *testing.T) {
 		var r http.Request
 		r.URL, _ = url.Parse(endpoint)


### PR DESCRIPTION
**Reason for Change**:
In the latest .Net ["Azure.Identity" SDK](https://www.nuget.org/packages/Azure.Identity) (v1.8.2), the get identity token request to IMDS with resource id is like this:

Caller method example:
`var token = new ManagedIdentityCredential("<resourceId>").GetToken(<token request context>)`
HTTP request: _/metadata/identity/oauth2/token?api-version=...&resource=...&**mi_res_id**=<resource_id>_

So nmi needs to read both "mi_res_id" and "msi_res_id"(backward compatible) values.

Does this change contain code from or inspired by another project?  -  no

from Microsoft COSMIC team.
