### PR TITLE
chore: use ubuntu-latest gh runner

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   codecov:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- The `gh-pages` [publish workflow](https://github.com/Azure/aad-pod-identity/actions/runs/4997336268/jobs/8970870915) has been waiting for runner since yesterday and this could be because `ubuntu-18.04` is not supported anymore. Updating the workflows to use `ubuntu-latest` runner.