### PR TITLE
ci: restrict permissions for gh workflows

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,6 +1,8 @@
 name: Codecov
 on: pull_request
 
+permissions: read-all
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- explicitly set permissions for each workflow
- changed the default workflow permissions to read only with this change.